### PR TITLE
chore(repo): exclude CODEOWNERS from cspell checks

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,6 @@
 {
 	"import": ["@d-zero/cspell-config"],
-	"ignorePaths": ["*.sqlite"],
+	"ignorePaths": ["*.sqlite", "**/CODEOWNERS"],
 	"words": [
 		// nitpicker
 		"readtext",


### PR DESCRIPTION
`.github/CODEOWNERS` にはユーザー名のみが並ぶため、cspell がスペルミスとして拾わないよう `ignorePaths` に `**/CODEOWNERS` を追加します。