### PR TITLE
fix(cli): terminate process after crawl completes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,6 +276,16 @@ CLI シグナルハンドラ（SIGINT / SIGHUP 等）
 - `CrawlerOrchestrator` のコンストラクタで `archive` の `error` イベントを監視し、アーカイブエラー発生時にも `Crawler.abort()` を呼び出す
 - CLI の `killed()` ハンドラでは `abort()` 後に `garbageCollect()`（ゾンビ Chromium プロセスの終了）→ `process.exit()` を実行
 
+### CLI プロセス終了とリソース解放
+
+`commands/crawl.ts` の `startCrawl` / `resumeCrawl` では `try { write } finally { close + garbageCollect }` 構造で SQLite コネクションプール（Knex の `acquireTimeoutMillis: 600_000`）を `archive.close()` → `db.destroy()` で確実に解放する。これをサボると `.nitpicker` ファイルは生成されるがプロセスが終了しない（pool 内部の reaper timer が event loop を握る）。
+
+さらに `cli.ts` 末尾で `process.exit(process.exitCode ?? ExitCode.Success)` を明示的に呼ぶ。理由は外部依存の timer leak で、特に `@d-zero/beholder` の `dom-evaluation.js#getProp` が `Promise.race(_getProp, setTimeout(fallback, 10_000))` の負け側 timer を clear しないため、`getMeta` 1 回あたり最大 ~13 個の 10 秒 timer が積み上がり、自然終了を 10 秒以上ブロックする。
+
+自リポ内の同型パターンは `crawler/fetch-destination.ts` の HEAD タイムアウトのみ。ここは cancellable な `setTimeout`/`clearTimeout` に書き直し済み（`Promise.race` + `delay()` を使わないこと）。
+
+検証は `packages/test-server/src/__tests__/e2e/cli-process-exit.e2e.ts` が CLI を spawn して 60 秒以内に exit するかを継続的に保証する。
+
 ### 主要定数
 
 | 定数                 | 値  | 説明               |
@@ -706,6 +716,7 @@ packages/test-server/
 │       ├── exclude.e2e.ts
 │       ├── options.e2e.ts
 │       ├── archive-pipeline.e2e.ts
+│       ├── cli-process-exit.e2e.ts  # CLI を spawn してプロセス終了を保証
 │       ├── config-persistence.e2e.ts
 │       ├── error-status.e2e.ts
 │       ├── scope.e2e.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,8 @@ yarn lint                                          # lint + cspell
 - **公開 API はオブジェクトコンテキスト**: パラメータ3つ以上の関数は名前付きオブジェクトにまとめる
 - **Options は Partial**: オプショナル設定は `Partial<OptionsType>` パターンを使用する
 - **exports で公開 API を厳選**: package.json の `exports` フィールドにサブパスを明示的に定義し、公開 API を限定する。モノレポ内パッケージ間でも exports 経由でのみアクセスする
+- **`Promise.race` の負け側 timer は必ずキャンセル**: タイムアウト実装で `Promise.race([work, delay(N)])` を書く場合、勝者が決まった後も負け側の `setTimeout` は発火するまで event loop を握り続け、CLI プロセス終了をブロックする。`setTimeout`/`clearTimeout` を直接使い、`.finally()` で確実に clear すること（`delay()` は signal を取らないので race には使わない）。実例: `packages/@nitpicker/crawler/src/crawler/fetch-destination.ts`
+- **CLI 末尾は明示的に `process.exit`**: `packages/@nitpicker/cli/src/cli.ts` の末尾で `process.exit(process.exitCode ?? ExitCode.Success)` を呼ぶ。外部依存（特に `@d-zero/beholder` の `dom-evaluation.js#getProp`）に同じ「`Promise.race` + `setTimeout` の負け側 timer 残留」パターンがあり、自然終了をブロックするため。await 済み work 完了後の defensive measure であり、内部の cleanup は順番に await した上で呼ぶこと
 
 ## AI 操作プロトコル
 

--- a/packages/@nitpicker/cli/src/cli.ts
+++ b/packages/@nitpicker/cli/src/cli.ts
@@ -49,3 +49,9 @@ try {
 	formatCliError(error, true);
 	process.exit(ExitCode.Fatal);
 }
+
+// Defensive: force exit after work completes. External dependencies (notably
+// `@d-zero/beholder`'s DOM evaluation timeouts) leak unref'd-but-still-active
+// timers via `Promise.race(..., setTimeout(..., 10_000))`, which can keep the
+// event loop alive for up to 10 seconds after the CLI's work is done.
+process.exit(process.exitCode ?? ExitCode.Success);

--- a/packages/@nitpicker/cli/src/commands/analyze.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/analyze.spec.ts
@@ -374,4 +374,27 @@ describe('analyze command', () => {
 		expect(mockNitpicker.archive.close).toHaveBeenCalled();
 		expect(exitSpy).not.toHaveBeenCalled();
 	});
+
+	it('write() が失敗しても archive.close() が呼ばれる', async () => {
+		Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true });
+		const mockNitpicker = createMockNitpicker();
+		mockNitpicker.write.mockRejectedValueOnce(new Error('write failed'));
+		vi.mocked(Nitpicker.open).mockResolvedValue(mockNitpicker as never);
+		vi.mocked(selectPluginsFn).mockResolvedValue();
+
+		await expect(
+			analyze(['test.nitpicker'], {
+				all: true,
+				plugin: undefined,
+				verbose: undefined,
+				searchKeywords: undefined,
+				searchScope: undefined,
+				mainContentSelector: undefined,
+				axeLang: undefined,
+				silent: undefined,
+			}),
+		).rejects.toThrow(ExitError);
+
+		expect(mockNitpicker.archive.close).toHaveBeenCalledOnce();
+	});
 });

--- a/packages/@nitpicker/cli/src/commands/analyze.ts
+++ b/packages/@nitpicker/cli/src/commands/analyze.ts
@@ -113,80 +113,83 @@ export async function analyze(args: string[], flags: AnalyzeFlags) {
 		}
 		const nitpicker = await Nitpicker.open(absFilePath);
 
-		const pluginOverrides = buildPluginOverrides(flags);
-		if (Object.keys(pluginOverrides).length > 0) {
-			nitpicker.setPluginOverrides(pluginOverrides);
-		}
+		try {
+			const pluginOverrides = buildPluginOverrides(flags);
+			if (Object.keys(pluginOverrides).length > 0) {
+				nitpicker.setPluginOverrides(pluginOverrides);
+			}
 
-		const config = await nitpicker.getConfig();
-		const plugins = config.analyze || [];
+			const config = await nitpicker.getConfig();
+			const plugins = config.analyze || [];
 
-		if (plugins.length === 0) {
-			throw new Error(
-				'No analyze plugins found. Install @nitpicker/analyze-* packages or configure them in .nitpickerrc.',
-			);
-		}
-
-		const pluginFlags = flags.plugin ?? [];
-
-		const filter = await selectPlugins({
-			all: flags.all ?? false,
-			pluginFlags,
-			plugins,
-			isTTY: !!isTTY,
-			async promptPlugins() {
-				const labels = await readPluginLabels(plugins);
-				const choices = plugins.map((plugin) => ({
-					name: plugin.name,
-					message: labels.get(plugin.name) || plugin.name,
-				}));
-				const res = await prompt<{ filter: string[] }>([
-					{
-						message: 'What do you analyze?',
-						name: 'filter',
-						type: 'multiselect',
-						choices,
-					},
-				]);
-				return res.filter;
-			},
-		});
-
-		// Warn about unknown plugin names specified via --plugin
-		if (pluginFlags.length > 0 && filter) {
-			const matched = new Set(filter);
-			const unknownPlugins = pluginFlags.filter((name) => !matched.has(name));
-			if (unknownPlugins.length > 0) {
-				const availableNames = plugins.map((p) => p.name).join(', ');
-				// eslint-disable-next-line no-console
-				console.error(
-					`Unknown plugin(s): ${unknownPlugins.join(', ')}\nAvailable plugins: ${availableNames}`,
+			if (plugins.length === 0) {
+				throw new Error(
+					'No analyze plugins found. Install @nitpicker/analyze-* packages or configure them in .nitpickerrc.',
 				);
 			}
-			if (filter.length === 0) {
-				throw new Error('No valid plugins to run.');
+
+			const pluginFlags = flags.plugin ?? [];
+
+			const filter = await selectPlugins({
+				all: flags.all ?? false,
+				pluginFlags,
+				plugins,
+				isTTY: !!isTTY,
+				async promptPlugins() {
+					const labels = await readPluginLabels(plugins);
+					const choices = plugins.map((plugin) => ({
+						name: plugin.name,
+						message: labels.get(plugin.name) || plugin.name,
+					}));
+					const res = await prompt<{ filter: string[] }>([
+						{
+							message: 'What do you analyze?',
+							name: 'filter',
+							type: 'multiselect',
+							choices,
+						},
+					]);
+					return res.filter;
+				},
+			});
+
+			// Warn about unknown plugin names specified via --plugin
+			if (pluginFlags.length > 0 && filter) {
+				const matched = new Set(filter);
+				const unknownPlugins = pluginFlags.filter((name) => !matched.has(name));
+				if (unknownPlugins.length > 0) {
+					const availableNames = plugins.map((p) => p.name).join(', ');
+					// eslint-disable-next-line no-console
+					console.error(
+						`Unknown plugin(s): ${unknownPlugins.join(', ')}\nAvailable plugins: ${availableNames}`,
+					);
+				}
+				if (filter.length === 0) {
+					throw new Error('No valid plugins to run.');
+				}
 			}
-		}
 
-		const siteUrl = (await nitpicker.archive.getUrl()) || '<Unknown URL>';
+			const siteUrl = (await nitpicker.archive.getUrl()) || '<Unknown URL>';
 
-		if (!silent) {
-			log(
-				nitpicker,
-				[`🥢 ${siteUrl} (${filePath})`, `  📤 Read file: ${absFilePath}`],
-				verbose,
-			);
-		}
+			if (!silent) {
+				log(
+					nitpicker,
+					[`🥢 ${siteUrl} (${filePath})`, `  📤 Read file: ${absFilePath}`],
+					verbose,
+				);
+			}
 
-		const lanes = silent ? undefined : new Lanes({ verbose, indent: '  ' });
-		try {
-			await nitpicker.analyze(filter, { lanes, verbose });
+			const lanes = silent ? undefined : new Lanes({ verbose, indent: '  ' });
+			try {
+				await nitpicker.analyze(filter, { lanes, verbose });
+			} finally {
+				lanes?.close();
+			}
+
+			await nitpicker.write();
 		} finally {
-			lanes?.close();
+			await nitpicker.archive.close();
 		}
-
-		await nitpicker.write();
-		await nitpicker.archive.close();
 	} catch (error) {
 		formatCliError(error, verbose);
 		process.exit(1);

--- a/packages/@nitpicker/cli/src/commands/crawl.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/crawl.spec.ts
@@ -87,7 +87,7 @@ function setupFakeOrchestrator() {
 	const fakeOrchestrator = {
 		write: vi.fn().mockResolvedValue(),
 		garbageCollect: vi.fn(),
-		archive: { filePath: '/tmp/test.nitpicker' },
+		archive: { filePath: '/tmp/test.nitpicker', close: vi.fn().mockResolvedValue() },
 	} as unknown as OrchestratorType;
 
 	mockCrawling.mockImplementation((_urls, _opts, cb) => {
@@ -208,6 +208,49 @@ describe('startCrawl', () => {
 			CrawlAggregateError,
 		);
 	});
+
+	it('完了後に archive.close() を呼ぶ', async () => {
+		const fake = setupFakeOrchestrator();
+		const { startCrawl } = await import('./crawl.js');
+		await startCrawl(['https://example.com'], createFlags());
+
+		expect(fake.archive.close).toHaveBeenCalledOnce();
+	});
+
+	it('write → close → garbageCollect の順で呼び出される', async () => {
+		const fake = setupFakeOrchestrator();
+		const { startCrawl } = await import('./crawl.js');
+		await startCrawl(['https://example.com'], createFlags());
+
+		const writeMock = fake.write as unknown as ReturnType<typeof vi.fn>;
+		const closeMock = fake.archive.close as unknown as ReturnType<typeof vi.fn>;
+		const gcMock = fake.garbageCollect as unknown as ReturnType<typeof vi.fn>;
+
+		const writeOrder = writeMock.mock.invocationCallOrder[0];
+		const closeOrder = closeMock.mock.invocationCallOrder[0];
+		const gcOrder = gcMock.mock.invocationCallOrder[0];
+
+		expect(writeOrder).toBeDefined();
+		expect(closeOrder).toBeDefined();
+		expect(gcOrder).toBeDefined();
+		expect(writeOrder!).toBeLessThan(closeOrder!);
+		expect(closeOrder!).toBeLessThan(gcOrder!);
+	});
+
+	it('write() が失敗しても archive.close() と garbageCollect() が呼ばれる', async () => {
+		const fake = setupFakeOrchestrator();
+		(fake.write as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error('write failed'),
+		);
+		const { startCrawl } = await import('./crawl.js');
+
+		await expect(startCrawl(['https://example.com'], createFlags())).rejects.toThrow(
+			'write failed',
+		);
+
+		expect(fake.archive.close).toHaveBeenCalledOnce();
+		expect(fake.garbageCollect).toHaveBeenCalledOnce();
+	});
 });
 
 describe('crawl', () => {
@@ -303,6 +346,29 @@ describe('crawl', () => {
 		).rejects.toThrow(
 			'--output flag is not supported with --resume. The archive path is determined by the stub file.',
 		);
+	});
+
+	it('--resume 経由でも完了後に archive.close() を呼ぶ', async () => {
+		const fake = setupFakeOrchestrator();
+		const { crawl } = await import('./crawl.js');
+		await crawl([], createFlags({ resume: '/absolute/stub' }));
+
+		expect(fake.archive.close).toHaveBeenCalledOnce();
+	});
+
+	it('--resume 経由で write() が失敗しても archive.close() が呼ばれる', async () => {
+		const fake = setupFakeOrchestrator();
+		(fake.write as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			new Error('write failed'),
+		);
+		const { crawl } = await import('./crawl.js');
+
+		await expect(crawl([], createFlags({ resume: '/absolute/stub' }))).rejects.toThrow(
+			'write failed',
+		);
+
+		expect(fake.archive.close).toHaveBeenCalledOnce();
+		expect(fake.garbageCollect).toHaveBeenCalledOnce();
 	});
 
 	it('--verbose フラグで verbosely() を呼び出す', async () => {

--- a/packages/@nitpicker/cli/src/commands/crawl.ts
+++ b/packages/@nitpicker/cli/src/commands/crawl.ts
@@ -216,11 +216,14 @@ export async function startCrawl(siteUrl: string[], flags: CrawlFlags): Promise<
 		},
 	);
 
-	await orchestrator.write();
+	try {
+		await orchestrator.write();
+	} finally {
+		await orchestrator.archive.close();
+		orchestrator.garbageCollect();
+	}
 
 	const archivePath = orchestrator.archive.filePath;
-
-	orchestrator.garbageCollect();
 
 	if (errStack.length > 0) {
 		const error = new CrawlAggregateError(errStack);
@@ -263,9 +266,12 @@ async function resumeCrawl(stubFilePath: string, flags: CrawlFlags) {
 		},
 	);
 
-	await orchestrator.write();
-
-	orchestrator.garbageCollect();
+	try {
+		await orchestrator.write();
+	} finally {
+		await orchestrator.archive.close();
+		orchestrator.garbageCollect();
+	}
 
 	if (errStack.length > 0) {
 		const error = new CrawlAggregateError(errStack);

--- a/packages/@nitpicker/crawler/src/crawler/fetch-destination.ts
+++ b/packages/@nitpicker/crawler/src/crawler/fetch-destination.ts
@@ -62,15 +62,20 @@ export async function fetchDestination(
 
 	const effectiveMethod = titleBytesLimit == null ? method : 'GET';
 
+	// Race the fetch against a 10-second timeout. The losing timer is cleared
+	// explicitly so it never keeps the event loop alive after the race settles
+	// (a plain `delay()` in `Promise.race` would leak the timer until it fires).
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 	const result = await Promise.race([
 		_fetchHead(url, isExternal, effectiveMethod, titleBytesLimit, userAgent).catch(
 			(error: unknown) => (error instanceof Error ? error : new Error(String(error))),
 		),
-		(async () => {
-			await delay(10 * 1000);
-			return new NetTimeoutError(url.href);
-		})(),
-	]);
+		new Promise<NetTimeoutError>((resolve) => {
+			timeoutHandle = setTimeout(() => resolve(new NetTimeoutError(url.href)), 10 * 1000);
+		}),
+	]).finally(() => {
+		if (timeoutHandle) clearTimeout(timeoutHandle);
+	});
 
 	destinationCache.set(cacheKey, result);
 	if (result instanceof Error) {

--- a/packages/test-server/src/__tests__/e2e/cli-process-exit.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/cli-process-exit.e2e.ts
@@ -1,0 +1,78 @@
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/** Absolute path to the built CLI entry point. */
+const CLI_BIN = path.resolve(
+	import.meta.dirname,
+	'../../../../@nitpicker/cli/bin/nitpicker.js',
+);
+
+describe('CLI process termination', () => {
+	it('crawl 完了後に CLI プロセスが自然終了する', async () => {
+		const cwd = path.join(os.tmpdir(), `nitpicker-e2e-cli-exit-${crypto.randomUUID()}`);
+		await fs.mkdir(cwd, { recursive: true });
+
+		try {
+			const child = spawn(
+				process.execPath,
+				[
+					CLI_BIN,
+					'crawl',
+					'http://localhost:8010/',
+					'--silent',
+					'--no-image',
+					'--no-fetch-external',
+					'--no-recursive',
+				],
+				{ cwd, stdio: ['ignore', 'pipe', 'pipe'] },
+			);
+
+			let stdoutBuf = '';
+			let stderrBuf = '';
+			child.stdout?.on('data', (chunk: Buffer) => {
+				stdoutBuf += chunk.toString();
+			});
+			child.stderr?.on('data', (chunk: Buffer) => {
+				stderrBuf += chunk.toString();
+			});
+
+			const PROCESS_EXIT_TIMEOUT = 60_000;
+			const exitCode = await new Promise<number | null>((resolve, reject) => {
+				const timer = setTimeout(() => {
+					child.kill('SIGKILL');
+					reject(
+						new Error(
+							`CLI did not exit within ${PROCESS_EXIT_TIMEOUT}ms — archive DB pool likely leaked\n--- stdout ---\n${stdoutBuf}\n--- stderr ---\n${stderrBuf}`,
+						),
+					);
+				}, PROCESS_EXIT_TIMEOUT);
+
+				child.once('exit', (code) => {
+					clearTimeout(timer);
+					resolve(code);
+				});
+				child.once('error', (error) => {
+					clearTimeout(timer);
+					reject(error);
+				});
+			});
+
+			if (exitCode !== 0) {
+				// eslint-disable-next-line no-console
+				console.error('--- stdout ---\n', stdoutBuf, '\n--- stderr ---\n', stderrBuf);
+			}
+			expect(exitCode).toBe(0);
+
+			const entries = await fs.readdir(cwd);
+			const archives = entries.filter((name) => name.endsWith('.nitpicker'));
+			expect(archives.length).toBe(1);
+		} finally {
+			await fs.rm(cwd, { recursive: true, force: true }).catch(() => {});
+		}
+	}, 90_000);
+});


### PR DESCRIPTION
## Summary

Fixes the long-standing issue where `nitpicker crawl` (and `analyze`) would finish writing the `.nitpicker` archive but the CLI process would not terminate — sometimes for many seconds, sometimes indefinitely. Three independent root causes:

1. **Knex SQLite connection pool leak** — `commands/crawl.ts` and `commands/analyze.ts` never called `archive.close()` after `write()`, so the pool's internal reaper timer kept the event loop alive.
2. **Cancellable timeout in HEAD fetch** — `fetch-destination.ts` raced the fetch against `delay(10s)`, and the loser timer was never cleared. Each HEAD request leaked one 10-second timer.
3. **External timer leak in `@d-zero/beholder`** — `dom-evaluation.js#getProp` has the same `Promise.race + setTimeout` anti-pattern but is out of this repo's reach. `cli.ts` now calls `process.exit` at the end as a defensive measure.

## Changes

- `crawler/fetch-destination.ts`: replace `Promise.race + delay()` with a cancellable `setTimeout`/`clearTimeout` cleared in `.finally()`
- `cli/commands/crawl.ts`, `cli/commands/analyze.ts`: wrap `write()` in `try/finally` so `archive.close()` and `garbageCollect()` always run
- `cli/cli.ts`: explicit `process.exit(process.exitCode ?? Success)` at end of script
- `cli/commands/{crawl,analyze}.spec.ts`: 6 new unit tests for close() invocation, ordering, and write-failure paths
- `test-server/__tests__/e2e/cli-process-exit.e2e.ts`: regression E2E that spawns the CLI and asserts exit within 60s
- `ARCHITECTURE.md`, `CLAUDE.md`: document the lifecycle contract and the `Promise.race` timer rule

## Test plan

- [x] `yarn lint` — clean
- [x] `yarn build` — 13 packages succeed
- [x] `yarn test` — 954/954 unit tests pass (+6 new)
- [x] `yarn vitest run --config vitest.e2e.config.ts packages/test-server/src/__tests__/e2e/cli-process-exit.e2e.ts` — passes (~14s, previously hung 60s+)
- [x] `archive-pipeline.e2e.ts` — still passes (3/3)

## Follow-ups (out of scope)

- `@d-zero/beholder@2.1.2` `dom-evaluation.js#getProp` has the same `Promise.race(_getProp, setTimeout(fallback, 10_000))` anti-pattern. Once that is patched upstream, the defensive `process.exit` in `cli.ts` could be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)