### PR TITLE
ci: add nightly/path-filtered E2E workflow and fix the red E2E specs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,11 +33,16 @@ jobs:
         with:
           node-version: 24
           cache: yarn
+      # Skip Puppeteer's postinstall browser download. Under Yarn 4 it finishes in
+      # ~1s creating an empty browser folder without the binary, which then makes the
+      # explicit install below think Chrome is present and refuse to re-download.
       - run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
       - run: yarn build
-      # Puppeteer's postinstall does not reliably download Chrome under Yarn 4
-      # (it finishes in ~1s without fetching the binary), so install the pinned
-      # browser explicitly into the cache that puppeteer-core resolves at runtime.
+      # Install the pinned browser explicitly into the cache that puppeteer-core
+      # resolves at runtime (~/.cache/puppeteer). With the postinstall skipped above,
+      # this performs a clean, complete download.
       - name: Install Chrome for Puppeteer
         run: yarn workspace @nitpicker/crawler exec puppeteer browsers install chrome
       # ubuntu-latest (24.04) restricts unprivileged user namespaces via AppArmor,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+name: E2E
+
+# Full E2E suite (~15 min locally, serial maxWorkers:1, Puppeteer-driven).
+# It is too heavy to block every PR, so it runs:
+#   - nightly via cron (catch regressions on the default branch)
+#   - on demand via workflow_dispatch
+#   - on PRs that touch the crawler / CLI / test-server (path filter)
+on:
+  schedule:
+    - cron: '0 18 * * *' # 03:00 JST, nightly
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/@nitpicker/crawler/**'
+      - 'packages/@nitpicker/cli/**'
+      - 'packages/test-server/**'
+      - 'vitest.e2e.config.ts'
+      - '.github/workflows/e2e.yml'
+
+# A new push to the same ref supersedes any in-flight run.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn build
+      # ubuntu-latest (24.04) restricts unprivileged user namespaces via AppArmor,
+      # which breaks Chromium's sandbox. Relax the restriction so the sandbox can
+      # still start — this keeps the sandbox enabled rather than passing --no-sandbox.
+      - name: Allow Chromium sandbox (unprivileged userns)
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+      - run: yarn vitest run --config vitest.e2e.config.ts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,12 +26,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      # Pin one cache dir shared by the explicit install below and the puppeteer
-      # runtime in the tests. Without this they can resolve different default dirs
-      # (@puppeteer/browsers CLI vs the puppeteer package), so the browser installs
-      # to one place and the crawl looks in another → "Could not find Chrome".
-      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.puppeteer-cache
     steps:
       - uses: actions/checkout@v6
       - run: corepack enable
@@ -39,20 +33,19 @@ jobs:
         with:
           node-version: 24
           cache: yarn
+      # Puppeteer's browser download is a silent no-op on this runner (it creates an
+      # empty cache folder without the binary), so skip it and drive the Chrome that
+      # ubuntu-latest ships pre-installed via PUPPETEER_EXECUTABLE_PATH instead.
       - run: yarn install --immutable
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
       - run: yarn build
-      # Install the pinned Chrome explicitly into PUPPETEER_CACHE_DIR and assert the
-      # binary exists, so a silent no-op download fails here instead of mid-test.
-      # Verbose + dual-dir listing to diagnose where the binary actually lands.
-      - name: Install Chrome for Puppeteer
+      - name: Use the runner's pre-installed Chrome
         run: |
-          set -x
-          rm -rf "$PUPPETEER_CACHE_DIR"
-          yarn workspace @nitpicker/crawler exec puppeteer browsers install chrome
-          ls -la "$PUPPETEER_CACHE_DIR" || true
-          ls -la "$HOME/.cache/puppeteer" || true
-          find "$PUPPETEER_CACHE_DIR" "$HOME/.cache/puppeteer" -maxdepth 4 -type f -name chrome 2>/dev/null || true
-          test -n "$(find "$PUPPETEER_CACHE_DIR" -type f -name chrome)"
+          CHROME="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium-browser || command -v chromium)"
+          test -n "$CHROME"
+          "$CHROME" --version
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME" >> "$GITHUB_ENV"
       # ubuntu-latest (24.04) restricts unprivileged user namespaces via AppArmor,
       # which breaks Chromium's sandbox. Relax the restriction so the sandbox can
       # still start — this keeps the sandbox enabled rather than passing --no-sandbox.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,15 +41,17 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn build
-      # Puppeteer's Yarn 4 postinstall leaves an empty browser folder without the
-      # binary, which blocks a re-install. Wipe the cache, install the pinned Chrome
-      # explicitly into PUPPETEER_CACHE_DIR, then assert the binary actually exists
-      # so a silent no-op download fails the job here instead of mid-test.
+      # Install the pinned Chrome explicitly into PUPPETEER_CACHE_DIR and assert the
+      # binary exists, so a silent no-op download fails here instead of mid-test.
+      # Verbose + dual-dir listing to diagnose where the binary actually lands.
       - name: Install Chrome for Puppeteer
         run: |
+          set -x
           rm -rf "$PUPPETEER_CACHE_DIR"
           yarn workspace @nitpicker/crawler exec puppeteer browsers install chrome
-          find "$PUPPETEER_CACHE_DIR" -maxdepth 4 -type f -name chrome
+          ls -la "$PUPPETEER_CACHE_DIR" || true
+          ls -la "$HOME/.cache/puppeteer" || true
+          find "$PUPPETEER_CACHE_DIR" "$HOME/.cache/puppeteer" -maxdepth 4 -type f -name chrome 2>/dev/null || true
           test -n "$(find "$PUPPETEER_CACHE_DIR" -type f -name chrome)"
       # ubuntu-latest (24.04) restricts unprivileged user namespaces via AppArmor,
       # which breaks Chromium's sandbox. Relax the restriction so the sandbox can

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,11 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn build
+      # Puppeteer's postinstall does not reliably download Chrome under Yarn 4
+      # (it finishes in ~1s without fetching the binary), so install the pinned
+      # browser explicitly into the cache that puppeteer-core resolves at runtime.
+      - name: Install Chrome for Puppeteer
+        run: yarn workspace @nitpicker/crawler exec puppeteer browsers install chrome
       # ubuntu-latest (24.04) restricts unprivileged user namespaces via AppArmor,
       # which breaks Chromium's sandbox. Relax the restriction so the sandbox can
       # still start — this keeps the sandbox enabled rather than passing --no-sandbox.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,12 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Pin one cache dir shared by the explicit install below and the puppeteer
+      # runtime in the tests. Without this they can resolve different default dirs
+      # (@puppeteer/browsers CLI vs the puppeteer package), so the browser installs
+      # to one place and the crawl looks in another → "Could not find Chrome".
+      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.puppeteer-cache
     steps:
       - uses: actions/checkout@v6
       - run: corepack enable
@@ -33,18 +39,18 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-      # Skip Puppeteer's postinstall browser download. Under Yarn 4 it finishes in
-      # ~1s creating an empty browser folder without the binary, which then makes the
-      # explicit install below think Chrome is present and refuse to re-download.
       - run: yarn install --immutable
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: 'true'
       - run: yarn build
-      # Install the pinned browser explicitly into the cache that puppeteer-core
-      # resolves at runtime (~/.cache/puppeteer). With the postinstall skipped above,
-      # this performs a clean, complete download.
+      # Puppeteer's Yarn 4 postinstall leaves an empty browser folder without the
+      # binary, which blocks a re-install. Wipe the cache, install the pinned Chrome
+      # explicitly into PUPPETEER_CACHE_DIR, then assert the binary actually exists
+      # so a silent no-op download fails the job here instead of mid-test.
       - name: Install Chrome for Puppeteer
-        run: yarn workspace @nitpicker/crawler exec puppeteer browsers install chrome
+        run: |
+          rm -rf "$PUPPETEER_CACHE_DIR"
+          yarn workspace @nitpicker/crawler exec puppeteer browsers install chrome
+          find "$PUPPETEER_CACHE_DIR" -maxdepth 4 -type f -name chrome
+          test -n "$(find "$PUPPETEER_CACHE_DIR" -type f -name chrome)"
       # ubuntu-latest (24.04) restricts unprivileged user namespaces via AppArmor,
       # which breaks Chromium's sandbox. Relax the restriction so the sandbox can
       # still start — this keeps the sandbox enabled rather than passing --no-sandbox.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Nitpicker
 
+[![CI](https://github.com/d-zero-dev/nitpicker/actions/workflows/ci.yml/badge.svg)](https://github.com/d-zero-dev/nitpicker/actions/workflows/ci.yml)
+[![E2E](https://github.com/d-zero-dev/nitpicker/actions/workflows/e2e.yml/badge.svg)](https://github.com/d-zero-dev/nitpicker/actions/workflows/e2e.yml)
+
 Web サイト全体のデータを取得するツール。クロール、リンクのメタデータ取得、ネットワークリソースの記録、各ページのレンダリング後 HTML スナップショット生成が可能。
 
 ## 概要

--- a/cspell.json
+++ b/cspell.json
@@ -77,6 +77,10 @@
 		"strnatcmp",
 		"isdigit",
 		"isspace",
-		"tolower"
+		"tolower",
+
+		// CI / GitHub Actions (Chromium sandbox on ubuntu runners)
+		"apparmor",
+		"userns"
 	]
 }

--- a/packages/test-server/src/__tests__/e2e/exclude.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/exclude.e2e.ts
@@ -51,6 +51,12 @@ describe('Exclude patterns', () => {
 			expect(pageB).toBeDefined();
 			expect(pageB!.isTarget).toBe(false);
 			expect(pageB!.isSkipped).toBe(true);
+			// スキップ理由にマッチしたキーワードが記録される（他の skip 要因と区別できる）。
+			expect(pageB!.skipReason).toContain('FORBIDDEN_KEYWORD');
+
+			// フルスクレイプ済みページ（internal-page）には現れない（negative pin）。
+			const fullPages = await result.accessor.getPages('internal-page');
+			expect(fullPages.some((p) => p.url.pathname === '/exclude/page-b')).toBe(false);
 		});
 
 		it('キーワードマッチしないページは正常にスクレイプされる', async () => {

--- a/packages/test-server/src/__tests__/e2e/exclude.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/exclude.e2e.ts
@@ -44,10 +44,13 @@ describe('Exclude patterns', () => {
 		});
 
 		it('キーワードマッチしたページがスキップされる', async () => {
-			const pages = await result.accessor.getPages('internal-page');
+			// キーワードマッチしたページはフルスクレイプされず、contentType を持たない
+			// スキップ済みスタブとして記録される（→ internal-no-page カテゴリ）。
+			const pages = await result.accessor.getPages('internal-no-page');
 			const pageB = pages.find((p) => p.url.pathname === '/exclude/page-b');
 			expect(pageB).toBeDefined();
 			expect(pageB!.isTarget).toBe(false);
+			expect(pageB!.isSkipped).toBe(true);
 		});
 
 		it('キーワードマッチしないページは正常にスクレイプされる', async () => {

--- a/packages/test-server/src/__tests__/e2e/options.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/options.e2e.ts
@@ -22,12 +22,13 @@ describe('Crawler options', () => {
 			const pages = await result.accessor.getPages('external-no-page');
 			const externalPage = pages.find((p) => p.url.hostname === '127.0.0.1');
 			expect(externalPage).toBeDefined();
-			// fetchExternal: false の場合、外部ページはフルスクレイプされない
-			expect(
-				externalPage!.status === null ||
-					externalPage!.status === 0 ||
-					externalPage!.title === '',
-			).toBe(true);
+			// 未フェッチスタブ: status は null（未フェッチの契約）、title は空文字。
+			expect(externalPage!.status).toBeNull();
+			expect(externalPage!.title).toBe('');
+
+			// フルスクレイプ済み外部ページ（external-page）には現れない（negative pin）。
+			const fetched = await result.accessor.getPages('external-page');
+			expect(fetched.some((p) => p.url.hostname === '127.0.0.1')).toBe(false);
 		});
 
 		it('内部ページは通常通りスクレイプされる', async () => {

--- a/packages/test-server/src/__tests__/e2e/options.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/options.e2e.ts
@@ -17,7 +17,9 @@ describe('Crawler options', () => {
 		});
 
 		it('外部リンクがフェッチされずにDBに記録される', async () => {
-			const pages = await result.accessor.getPages('external-page');
+			// fetchExternal: false の外部リンクはフェッチされないため contentType を持たず、
+			// external-no-page カテゴリにスタブとして記録される。
+			const pages = await result.accessor.getPages('external-no-page');
 			const externalPage = pages.find((p) => p.url.hostname === '127.0.0.1');
 			expect(externalPage).toBeDefined();
 			// fetchExternal: false の場合、外部ページはフルスクレイプされない

--- a/packages/test-server/src/__tests__/e2e/output-path.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/output-path.e2e.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { Archive, CrawlerOrchestrator } from '@nitpicker/crawler';
+import { CrawlerOrchestrator } from '@nitpicker/crawler';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 describe('Output path (filePath option)', () => {
@@ -51,8 +51,9 @@ describe('Output path (filePath option)', () => {
 	});
 
 	it('config.name にファイル名が反映される', async () => {
-		const accessor = await Archive.connect(orchestrator.archive.tmpDir);
-		const config = await accessor.getConfig();
+		// write() は tmpDir をリネーム後に削除して .nitpicker に集約するため、
+		// tmpDir への再接続は空 DB になる。既存の開いた接続から config を読む。
+		const config = await orchestrator.archive.getConfig();
 		expect(config.name).toBe('custom-output');
 	});
 
@@ -107,8 +108,8 @@ describe('Output path without extension', () => {
 	});
 
 	it('config.name に拡張子なしのファイル名が反映される', async () => {
-		const accessor = await Archive.connect(orchestrator.archive.tmpDir);
-		const config = await accessor.getConfig();
+		// write() で tmpDir は消費されるため、既存の開いた接続から config を読む。
+		const config = await orchestrator.archive.getConfig();
 		expect(config.name).toBe('my-report');
 	});
 });

--- a/packages/test-server/src/__tests__/e2e/output-path.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/output-path.e2e.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { CrawlerOrchestrator } from '@nitpicker/crawler';
+import { Archive, CrawlerOrchestrator } from '@nitpicker/crawler';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 describe('Output path (filePath option)', () => {
@@ -50,11 +50,21 @@ describe('Output path (filePath option)', () => {
 		expect(stat.size).toBeGreaterThan(0);
 	});
 
-	it('config.name にファイル名が反映される', async () => {
-		// write() は tmpDir をリネーム後に削除して .nitpicker に集約するため、
-		// tmpDir への再接続は空 DB になる。既存の開いた接続から config を読む。
-		const config = await orchestrator.archive.getConfig();
-		expect(config.name).toBe('custom-output');
+	it('書き出した .nitpicker を開き直して config と pages を読み戻せる', async () => {
+		// 永続化の往復検証: 生成された .nitpicker を Archive.open で展開し直し、
+		// config.name とページ数を確認する（in-memory ではなくファイルの中身を検証）。
+		const openCwd = path.join(os.tmpdir(), `nitpicker-e2e-open-${crypto.randomUUID()}`);
+		await fs.mkdir(openCwd, { recursive: true });
+		const opened = await Archive.open({ filePath: outputPath, cwd: openCwd });
+		try {
+			const config = await opened.getConfig();
+			expect(config.name).toBe('custom-output');
+			const pages = await opened.getPages('page');
+			expect(pages.length).toBeGreaterThan(0);
+		} finally {
+			await opened.close();
+			await fs.rm(openCwd, { recursive: true, force: true }).catch(() => {});
+		}
 	});
 
 	it('自動生成のファイルが作成されていない', async () => {
@@ -108,8 +118,19 @@ describe('Output path without extension', () => {
 	});
 
 	it('config.name に拡張子なしのファイル名が反映される', async () => {
-		// write() で tmpDir は消費されるため、既存の開いた接続から config を読む。
-		const config = await orchestrator.archive.getConfig();
-		expect(config.name).toBe('my-report');
+		// 拡張子なし指定でも my-report.nitpicker が生成される。開き直して config を検証する。
+		const openCwd = path.join(os.tmpdir(), `nitpicker-e2e-open-${crypto.randomUUID()}`);
+		await fs.mkdir(openCwd, { recursive: true });
+		const opened = await Archive.open({
+			filePath: path.join(cwd, 'my-report.nitpicker'),
+			cwd: openCwd,
+		});
+		try {
+			const config = await opened.getConfig();
+			expect(config.name).toBe('my-report');
+		} finally {
+			await opened.close();
+			await fs.rm(openCwd, { recursive: true, force: true }).catch(() => {});
+		}
 	});
 });

--- a/packages/test-server/src/__tests__/e2e/single-page.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/single-page.e2e.ts
@@ -27,7 +27,9 @@ describe('Single page scraping', () => {
 	});
 
 	it('非再帰モードで子ページはisTarget=falseで記録される', async () => {
-		const pages = await result.accessor.getPages('page');
+		// 子ページは title-only モードで text/html ページとして記録されるが isTarget=false。
+		// 'page' フィルタは isTarget=1 のみを返すため internal-page で引く。
+		const pages = await result.accessor.getPages('internal-page');
 		const aboutPages = pages.filter((p) => p.url.pathname === '/about');
 		expect(aboutPages.length).toBeGreaterThan(0);
 		// titleOnlyモードでスクレイプされた場合、isTarget=falseであること


### PR DESCRIPTION
## 概要

E2E テストを CI で実行できるようにする（#24）。前提として赤かった E2E スイートを緑化し、フル E2E を回す専用ワークフローを追加する。

## 背景・計測

ローカルでフル E2E を計測したところ **約15分**（19 spec / 73 tests、`maxWorkers:1` 直列、CPU 22% ＝ ほぼ I/O 待ち）。「重い」部類のため、全 PR をブロックする運用は不適。テストピラミッドの定石どおり **nightly + path-filter** とする。

## 変更点

### 1. 赤かった E2E spec の修正（製品コードは無変更）

着手時点で 5 tests / 4 files が失敗していた。原因はすべて **テスト側の誤り**：

- **カテゴリ取り違え**: skip / 未フェッチ外部ページは `contentType=null` のスタブ → `*-no-page` カテゴリに属する。title-only の子ページは `text/html` + `isTarget=false` で `internal-page`。`'page'` フィルタは `isTarget=1` のみ返すため、`isTarget=false` を期待する spec とは自己矛盾だった。
- **output-path**: `write()` は tmpDir をリネーム後に削除して `.nitpicker` に集約するため、消費済み tmpDir への `Archive.connect` は空 DB になり `No config`。→ `Archive.open` で書き出したファイルを開き直す往復検証に変更。

QA レビューを反映し、skipReason のキーワード検証・negative pin・未フェッチスタブの契約（status=null）・永続化往復を追加して強化。

### 2. E2E ワークフロー追加（`.github/workflows/e2e.yml`）

- nightly cron（`0 18 * * *` ＝ 03:00 JST）+ `workflow_dispatch` + crawler/CLI/test-server を変更した PR（path filter）
- ubuntu 24.04 の AppArmor userns 制限を緩和して Chromium サンドボックスを起動（`--no-sandbox` を本番コードに足さない）
- concurrency キャンセル、`timeout-minutes: 30`

### 3. README に CI / E2E ステータスバッジ（監視目的）

## テスト

- ローカル: フル E2E **73/73 passed**、`yarn build` / `yarn test`（135 files）/ `yarn lint:check` すべて緑。
- 本 PR は path filter に合致するため、**この PR 上で E2E ワークフローが実走**する。AppArmor knob と puppeteer の Chromium セットアップが実 runner で機能するかは、その run の結果で検証する（マージ受け入れ条件）。

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)