### PR TITLE
feat(crawler): stream snapshot HTML and reuse captured sub-resources

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,7 +111,7 @@ scrapeStart → openPage → loadDOMContent → getHTML → waitNetworkIdle
 - **`Crawler`**: リンク管理・スクレイプスケジューリング
 - **`LinkList`**: URL キュー管理（pending → progress → done）
 - **`Archive`**: アーカイブの作成・再開・書き出し
-- **`ArchiveAccessor`**: 読み取り専用アクセサ（`getPages`, `getPagesWithRefs` など）
+- **`ArchiveAccessor`**: 読み取り専用アクセサ（`getPages`, `getPagesWithRefs` など）。HTML スナップショットの読み取り（`getHtmlOfPage`）は `snapshot-html.zip` を物理展開せず、central directory を 1 度だけ読んでキャッシュし、エントリ単位でストリーミング取得する（zip はランダムアクセス可能なため O(該当エントリ) で済む。全展開方式は単一ページ取得で zip 全体の inflate + 書き戻し I/O を払い、ディスクにも展開ディレクトリが残るため採用しない）
 - **`Page`**: ページデータラッパー
 
 **内部モジュール構造:**
@@ -252,10 +252,47 @@ URL を deal() で受け取り:
 1. robots.txt チェック → 拒否なら skip イベント emit + return
 2. shouldSkipUrl（excludes / excludeUrls）→ マッチなら skip
 3. fetchExternal チェック → 外部 URL で無効なら externalPage emit + return
-4. HEAD プリフライト → 到達不能なら error
-5. metadataOnly / 非 HTML → ブラウザなしで結果返却
-6. HTML → Puppeteer 起動（User-Agent 設定済み）→ スクレイプ
+4. キャプチャ済みリソースの再利用チェック → ヒットすればフェッチなしで結果返却
+5. HEAD プリフライト → 到達不能なら error
+6. metadataOnly / 非 HTML → ブラウザなしで結果返却
+7. HTML → Puppeteer 起動（User-Agent 設定済み）→ スクレイプ
 ```
+
+### キャプチャ済みリソースの再利用（resource-to-page-data.ts）
+
+ページレンダリング中にサブリソース（`<img src>` 等）として既にキャプチャ済みの URL が
+直リンク（`<a href>`）としてキューに積まれた場合、HEAD プリフライトを省略して
+resources テーブルの記録（status / contentType / contentLength / responseHeaders）から
+PageData を合成する。
+
+```
+#scrapePage(url)
+  ├── #resources Set（メモリ）で一次フィルタ — ミス時のコストはゼロ
+  ├── ヒット時のみ lookupResource()（orchestrator がコンストラクタで注入するコールバック）
+  │     ├── まず SQLite を直接点引き（hit ならブロックなしで即返却）
+  │     └── miss の場合のみ WriteQueue.enqueue 経由で再読
+  │         （未 flush の resource insert の後ろに直列化され hit/miss が決定的になる。
+  │          直列化待ちは miss パスに限定されるため dealer レーンをブロックしない）
+  ├── status 2xx かつ contentType 非 HTML → PageData 合成して即返却
+  └── それ以外（行なし / 非 2xx / HTML / null / lookup 失敗）→ HEAD プリフライトにフォールバック
+```
+
+- **2xx 限定の理由**: Puppeteer はリダイレクトの各ホップごとに response イベントを発火する
+  ため、リダイレクトする URL は必ず 3xx 行として記録される。非 2xx をフォールバックさせる
+  ことで、リダイレクト元 URL は従来どおり HEAD（follow-redirects）が完全な `redirectPaths`
+  を取得し、再利用時の `redirectPaths: []` は常に正確な値になる
+- **非 HTML 限定の理由**: HTML はアンカー抽出のため Puppeteer レンダリングが必須。
+  MIME タイプ比較は `isHtmlContentType()`（大文字小文字非依存）で行う —
+  Puppeteer 由来の値はサーバーの大文字小文字をそのまま保持するため
+- **lookup 失敗は HEAD にフォールバック**: `getResourceByUrl` は意図的に `@ErrorEmitter` を
+  付けない（DB `error` イベント → orchestrator の abort listener はクロール全体を中断するため）。
+  crawler 側フックも try/catch で握り、読み取り失敗は「最適化なし」と同じ挙動に縮退する
+- **注入はコンストラクタ DI**: `CrawlerOptions.lookupResource` として `new Crawler()` 時に
+  渡す（セッターの呼び順依存を排除）。`null` なら最適化は無効
+- 検証: `packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts`（画像エンドポイントへの
+  リクエスト回数・メソッドを test-server 側で記録して検証）と
+  `crawler.spec.ts` の `resource reuse via the lookupResource option`（ネットワーク不使用・
+  lookup 失敗時フォールバックのユニットテスト）
 
 ### dealer 統合
 

--- a/packages/@nitpicker/analyze-main-contents/src/main-contents-plugin.spec.ts
+++ b/packages/@nitpicker/analyze-main-contents/src/main-contents-plugin.spec.ts
@@ -49,11 +49,15 @@ describe('analyze-main-contents plugin', () => {
 			total: 1,
 		});
 
+		// `page` ラッパーは必須: これが無いと worker が結果を破棄し、
+		// main の無いページがレポートから消えてしまう（リグレッション防止）
 		expect(result).toEqual({
-			wordCount: { value: 0 },
-			headings: { value: 0 },
-			images: { value: 0 },
-			table: { value: 0 },
+			page: {
+				wordCount: { value: 0 },
+				headings: { value: 0 },
+				images: { value: 0 },
+				table: { value: 0 },
+			},
 		});
 	});
 

--- a/packages/@nitpicker/analyze-main-contents/src/main-contents-plugin.ts
+++ b/packages/@nitpicker/analyze-main-contents/src/main-contents-plugin.ts
@@ -93,18 +93,23 @@ export default definePlugin((options: Options) => {
 			const $main = document.querySelector(selectors.join(','));
 
 			if (!$main) {
+				// Main content not found: still report the page with zero counts.
+				// The `page` wrapper is required — without it the worker discards
+				// the result and the page silently disappears from the report.
 				return {
-					wordCount: {
-						value: result.wordCount,
-					},
-					headings: {
-						value: result.headings.length,
-					},
-					images: {
-						value: result.images.length,
-					},
-					table: {
-						value: result.tables.length,
+					page: {
+						wordCount: {
+							value: result.wordCount,
+						},
+						headings: {
+							value: result.headings.length,
+						},
+						images: {
+							value: result.images.length,
+						},
+						table: {
+							value: result.tables.length,
+						},
 					},
 				};
 			}

--- a/packages/@nitpicker/crawler/src/archive/archive-accessor.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive-accessor.spec.ts
@@ -1,0 +1,220 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { extractZip, zip } from '@d-zero/fs/zip';
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import Archive from './archive.js';
+import { exists } from './filesystem/exists.js';
+import { mkdir } from './filesystem/mkdir.js';
+import { outputText } from './filesystem/output-text.js';
+import { remove } from './filesystem/remove.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__mock__');
+
+vi.mock('@d-zero/fs/zip', async (importOriginal) => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const original = await importOriginal<typeof import('@d-zero/fs/zip')>();
+	return {
+		...original,
+		extractZip: vi.fn(original.extractZip),
+	};
+});
+
+/**
+ * Builds minimal page data for `Archive.setPage` in tests.
+ * @param pathname - The URL pathname of the page.
+ * @param html - The HTML snapshot content of the page.
+ * @returns Page data accepted by `Archive.setPage`.
+ */
+function makePageData(pathname: string, html: string) {
+	return {
+		url: parseUrl(`http://localhost${pathname}`)!,
+		redirectPaths: [] as string[],
+		isExternal: false,
+		status: 200,
+		statusText: 'OK',
+		contentLength: html.length,
+		contentType: 'text/html',
+		responseHeaders: {},
+		meta: { title: 'Test Page' },
+		anchorList: [] as never[],
+		imageList: [] as never[],
+		html,
+		isSkipped: false,
+		isTarget: true,
+	};
+}
+
+describe('getHtmlOfPage: クロール中（スナップショットが生ディレクトリの状態）', () => {
+	const tmpDirPattern = path.resolve(
+		workingDir,
+		Archive.TMP_DIR_PREFIX + 'accessor-raw-test',
+	);
+	const archiveFilePath = path.resolve(workingDir, 'accessor-raw-test.nitpicker');
+	let archive: Archive;
+	let pageId: number;
+	const html = '<html><body>raw dir page</body></html>';
+
+	beforeAll(async () => {
+		archive = await Archive.create({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		pageId = await archive.setPage(makePageData('/raw-page', html));
+	});
+
+	afterAll(async () => {
+		await archive.close().catch(() => {});
+		await remove(tmpDirPattern).catch(() => {});
+		await remove(archiveFilePath).catch(() => {});
+	});
+
+	it('生ディレクトリから直接読み取る', async () => {
+		const result = await archive.getHtmlOfPage(
+			`${Archive.SNAPSHOT_HTML_DIR}/${pageId}.html`,
+		);
+		expect(result).toBe(html);
+	});
+
+	it('filePathがnullの場合はnullを返す', async () => {
+		const result = await archive.getHtmlOfPage(null);
+		expect(result).toBeNull();
+	});
+});
+
+describe('getHtmlOfPage: zip化後（write() 相当の状態）', () => {
+	const tmpDirPattern = path.resolve(
+		workingDir,
+		Archive.TMP_DIR_PREFIX + 'accessor-zip-test',
+	);
+	const archiveFilePath = path.resolve(workingDir, 'accessor-zip-test.nitpicker');
+	let archive: Archive;
+	let snapshotDir: string;
+	let pageId1: number;
+	let pageId2: number;
+	const html1 = '<html><body>zipped page 1</body></html>';
+	const html2 = '<html><body>zipped page 2</body></html>';
+
+	beforeAll(async () => {
+		archive = await Archive.create({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		pageId1 = await archive.setPage(makePageData('/zip-page-1', html1));
+		pageId2 = await archive.setPage(makePageData('/zip-page-2', html2));
+
+		// write() と同じ状態を作る: snapshot-html/ を zip 化して削除
+		snapshotDir = path.resolve(archive.tmpDir, Archive.SNAPSHOT_HTML_DIR);
+		// 空のスナップショットファイル（0バイト）も zip に含める
+		await outputText(path.resolve(snapshotDir, '999.html'), '');
+		await zip(`${snapshotDir}.zip`, snapshotDir);
+		await remove(snapshotDir);
+		vi.mocked(extractZip).mockClear();
+	});
+
+	afterAll(async () => {
+		await archive.close().catch(() => {});
+		await remove(tmpDirPattern).catch(() => {});
+		await remove(archiveFilePath).catch(() => {});
+	});
+
+	it('zipからストリーミング取得し、ディスクへ物理展開しない', async () => {
+		const result = await archive.getHtmlOfPage(
+			`${Archive.SNAPSHOT_HTML_DIR}/${pageId1}.html`,
+		);
+		expect(result).toBe(html1);
+		// 物理展開の副作用（snapshot-html/ ディレクトリの再生成）がないこと
+		expect(exists(snapshotDir)).toBe(false);
+	});
+
+	it('複数回の取得でもcentral directoryの読み込みは1回だけ', async () => {
+		const result = await archive.getHtmlOfPage(
+			`${Archive.SNAPSHOT_HTML_DIR}/${pageId2}.html`,
+		);
+		expect(result).toBe(html2);
+		expect(vi.mocked(extractZip)).toHaveBeenCalledTimes(1);
+	});
+
+	it('空のスナップショットは空文字列を返す（見つからない場合のnullと区別される）', async () => {
+		const result = await archive.getHtmlOfPage(`${Archive.SNAPSHOT_HTML_DIR}/999.html`);
+		expect(result).toBe('');
+	});
+
+	it('zipに存在しないエントリはnullを返す', async () => {
+		const result = await archive.getHtmlOfPage(`${Archive.SNAPSHOT_HTML_DIR}/99999.html`);
+		expect(result).toBeNull();
+	});
+
+	it('zipも生ディレクトリも存在しない場合はnullを返す', async () => {
+		const result = await archive.getHtmlOfPage('no-such-dir/1.html');
+		expect(result).toBeNull();
+	});
+
+	it('生ディレクトリに無いファイルはzipへフォールバックする', async () => {
+		// append 中の状態を模倣: 生ディレクトリは存在するが対象ファイルは旧 zip 側にある
+		// mkdir は与えたパスの親ディレクトリを作るため、ダミーの子パスを渡す
+		mkdir(path.resolve(snapshotDir, 'placeholder'));
+		try {
+			const result = await archive.getHtmlOfPage(
+				`${Archive.SNAPSHOT_HTML_DIR}/${pageId1}.html`,
+			);
+			expect(result).toBe(html1);
+		} finally {
+			await remove(snapshotDir);
+		}
+	});
+});
+
+describe('getHtmlOfPage: 破損zipのキャッシュ追い出し', () => {
+	const tmpDirPattern = path.resolve(
+		workingDir,
+		Archive.TMP_DIR_PREFIX + 'accessor-evict-test',
+	);
+	const archiveFilePath = path.resolve(workingDir, 'accessor-evict-test.nitpicker');
+	let archive: Archive;
+	let snapshotDir: string;
+	let pageId: number;
+	const html = '<html><body>evict test page</body></html>';
+
+	beforeAll(async () => {
+		archive = await Archive.create({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		pageId = await archive.setPage(makePageData('/evict-page', html));
+		snapshotDir = path.resolve(archive.tmpDir, Archive.SNAPSHOT_HTML_DIR);
+		await zip(`${snapshotDir}.zip`, snapshotDir);
+		await remove(snapshotDir);
+	});
+
+	afterAll(async () => {
+		await archive.close().catch(() => {});
+		await remove(tmpDirPattern).catch(() => {});
+		await remove(archiveFilePath).catch(() => {});
+	});
+
+	it('破損zipで失敗したキャッシュは追い出され、zipが直れば再読込できる', async () => {
+		const zipPath = `${snapshotDir}.zip`;
+		const backupPath = `${snapshotDir}.zip.bak`;
+		// 正常な zip を退避して破損 zip に差し替える（キャッシュは未充填の状態）
+		await fs.rename(zipPath, backupPath);
+		await outputText(zipPath, 'this is not a zip file');
+		try {
+			await expect(
+				archive.getHtmlOfPage(`${Archive.SNAPSHOT_HTML_DIR}/${pageId}.html`),
+			).rejects.toThrow();
+		} finally {
+			// 正常な zip に復元
+			await fs.rename(backupPath, zipPath);
+		}
+		// 失敗した Promise がキャッシュに残っていなければ、復元後の読み取りは成功する
+		const result = await archive.getHtmlOfPage(
+			`${Archive.SNAPSHOT_HTML_DIR}/${pageId}.html`,
+		);
+		expect(result).toBe(html);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/archive-accessor.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive-accessor.ts
@@ -11,7 +11,7 @@ import type { ParseURLOptions } from '@d-zero/shared/parse-url';
 
 import path from 'node:path';
 
-import { extractZip, unzip } from '@d-zero/fs/zip';
+import { extractZip } from '@d-zero/fs/zip';
 import { TypedAwaitEventEmitter as EventEmitter } from '@d-zero/shared/typed-await-event-emitter';
 
 import { log } from './debug.js';
@@ -25,6 +25,12 @@ import Resource from './resource.js';
 import { safePath } from './safe-path.js';
 
 /**
+ * A single file entry within a snapshot zip's central directory,
+ * inferred from the return type of `extractZip`.
+ */
+type ZipEntry = Awaited<ReturnType<typeof extractZip>>['files'][number];
+
+/**
  * Provides read-only access to an archive's database and stored data files.
  *
  * This class is the base for the `Archive` class and is also returned
@@ -36,6 +42,12 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 	#db: Database;
 	/** Namespace prefix for custom data storage (e.g. `"analysis/plugin-name"`). `null` disables `setData`. */
 	#namespace: string | null = null;
+	/**
+	 * Cached central-directory lookups of snapshot zip files, keyed by zip file path.
+	 * Each value maps an entry file name (e.g. `"123.html"`) to its zip entry,
+	 * enabling O(1) random access without physically extracting the zip.
+	 */
+	#snapshotZipFiles = new Map<string, Promise<Map<string, ZipEntry>>>();
 	/** Absolute path to the temporary working directory containing the database and files. */
 	#tmpDir: string;
 
@@ -104,24 +116,27 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 	}
 	/**
 	 * Reads the HTML content of a page snapshot from the archive.
-	 * Supports reading from both unzipped directories and zipped snapshot archives.
+	 *
+	 * Reads from the raw snapshot directory when the file exists there
+	 * (e.g. during an active crawl before `write()`), and otherwise streams
+	 * the single entry out of the zipped snapshot archive via its central
+	 * directory — the zip is never physically extracted to disk.
+	 * The parsed central directory is cached per zip file, so repeated calls
+	 * cost only one entry inflation each.
+	 * An empty snapshot file yields an empty string, while a missing snapshot
+	 * yields null — both code paths preserve that distinction.
 	 * @param filePath - The relative file path to the HTML snapshot, or null.
-	 * @param openZipped - Whether to attempt unzipping the snapshot archive. Defaults to `true`.
 	 * @returns The HTML content as a string, or null if the snapshot is not found or filePath is null.
 	 */
-	async getHtmlOfPage(filePath: string | null, openZipped = true) {
+	async getHtmlOfPage(filePath: string | null) {
 		if (!filePath) {
 			return null;
 		}
 		const snapshotDir = safePath(this.#tmpDir, path.dirname(filePath));
 		const name = path.basename(filePath);
 
-		if (openZipped) {
-			await unzip(`${snapshotDir}.zip`, snapshotDir);
-		}
-
 		if (exists(snapshotDir)) {
-			log('Load %s directly because snapshot dir is unzipped', name);
+			log('Load %s directly because snapshot dir exists', name);
 			const html = await readText(path.resolve(snapshotDir, name)).catch(
 				(error) => error,
 			);
@@ -129,21 +144,27 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 				log('Loaded: %s ...', html.split('\n')[0]);
 				return html;
 			}
-			log('Failed Loading: %O', html);
+			log('Not found %s in snapshot dir, falls back to zipped snapshots', name);
+		}
+
+		const opening = this.#openSnapshotZip(`${snapshotDir}.zip`);
+		if (!opening) {
+			log('Failed: Not found zipped snapshots %s.zip', snapshotDir);
 			return null;
 		}
 		log('Extracts %s from zipped snapshots', name);
-		const zipDir = await extractZip(`${snapshotDir}.zip`);
-		const file = zipDir.files.find((f) => f.type === 'File' && f.path === name);
+		const files = await opening;
+		const file = files.get(name);
 		if (!file) {
 			log('Failed: Not found %s from zipped snapshots', name);
 			return null;
 		}
 		const buffer = await file.buffer();
-		const html = buffer.toString('utf8') || null;
+		const html = buffer.toString('utf8');
 		log('Succeeded: Extracts %s from zipped snapshots', name);
 		return html;
 	}
+
 	/**
 	 * Returns the underlying Knex query builder instance for direct SQL access.
 	 * Enables advanced queries (GROUP BY, HAVING, JOINs) at the database layer
@@ -153,7 +174,6 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 	getKnex() {
 		return this.#db.getKnex();
 	}
-
 	/**
 	 * Retrieves all pages from the archive, optionally filtered by type.
 	 * Eagerly loads redirect relationships (`redirectFrom`) but does NOT load
@@ -181,7 +201,6 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 
 		return pages.map((page) => new Page(this, page, redirectMap.get(page.id) || []));
 	}
-
 	/**
 	 * Retrieves pages with their related data (redirects, anchors, referrers) in batches.
 	 * Processes pages in chunks of `limit` size, calling the callback for each batch.
@@ -214,7 +233,6 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 			times++;
 		}
 	}
-
 	/**
 	 * Retrieves pages that link to the specified page (incoming links).
 	 * @param pageId - The database ID of the target page.
@@ -224,7 +242,6 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 		const refs = await this.#db.getReferrersOfPage(pageId);
 		return refs;
 	}
-
 	/**
 	 * Retrieves page URLs that reference the specified resource.
 	 * @param pageId - The database ID of the resource.
@@ -234,7 +251,6 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 		const refs = await this.#db.getReferrersOfResource(pageId);
 		return refs;
 	}
-
 	/**
 	 * Retrieves all sub-resources (CSS, JS, images, etc.) stored in the archive.
 	 * @returns An array of {@link Resource} instances.
@@ -243,7 +259,6 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 		const resources = await this.#db.getResources();
 		return resources.map((r) => new Resource(this, r));
 	}
-
 	/**
 	 * Retrieves a flat list of all resource URLs stored in the archive.
 	 * @returns An array of resource URL strings.
@@ -251,7 +266,15 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 	async getResourceUrlList() {
 		return this.#db.getResourceUrlList();
 	}
-
+	/**
+	 * Clears the cached snapshot zip central directories.
+	 * Called when the underlying zip file is about to be rewritten or the
+	 * working directory is moved (e.g. by `Archive.write()`), so later reads
+	 * do not hit a dangling cache entry.
+	 */
+	invalidateSnapshotZipCache() {
+		this.#snapshotZipFiles.clear();
+	}
 	/**
 	 * Stores custom data in the archive under the configured namespace.
 	 * Requires a namespace to be set on this accessor; throws if namespace is null.
@@ -273,14 +296,12 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 		}
 		return path.relative(this.#tmpDir, filePath);
 	}
-
 	/**
 	 * Returns the total number of internal pages in the archive.
 	 */
 	async #getPageCount() {
 		return this.#db.getPageCount();
 	}
-
 	/**
 	 * Loads a batch of pages with their related data (redirects, anchors, referrers).
 	 * When `withRefs` is false, loads only pages without relationships for better performance.
@@ -345,5 +366,35 @@ export class ArchiveAccessor extends EventEmitter<DatabaseEvent> {
 		}
 		log('Create Page Data: Done');
 		return pPages;
+	}
+
+	/**
+	 * Opens a snapshot zip's central directory once and caches a name-to-entry
+	 * lookup map keyed by the zip file path. Subsequent calls for the same zip
+	 * reuse the cached map — skipping even the existence check — so each page
+	 * read costs only a single entry inflation instead of re-parsing the
+	 * central directory.
+	 * Failed opens are evicted from the cache so transient errors do not stick.
+	 * @param zipFilePath - The absolute path to the snapshot zip file.
+	 * @returns A promise of a map of entry file names to their zip entries,
+	 *   or null when the zip file does not exist.
+	 */
+	#openSnapshotZip(zipFilePath: string) {
+		const cached = this.#snapshotZipFiles.get(zipFilePath);
+		if (cached) {
+			return cached;
+		}
+		if (!exists(zipFilePath)) {
+			return null;
+		}
+		const opening = extractZip(zipFilePath).then(
+			(dir) =>
+				new Map(dir.files.filter((f) => f.type === 'File').map((f) => [f.path, f])),
+		);
+		opening.catch(() => {
+			this.#snapshotZipFiles.delete(zipFilePath);
+		});
+		this.#snapshotZipFiles.set(zipFilePath, opening);
+		return opening;
 	}
 }

--- a/packages/@nitpicker/crawler/src/archive/archive.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.spec.ts
@@ -20,6 +20,31 @@ vi.mock('./filesystem/output-text.js', async (importOriginal) => {
 	};
 });
 
+/**
+ * Builds minimal page data for `Archive.setPage` in tests.
+ * @param pathname - The URL pathname of the page.
+ * @param html - The HTML snapshot content of the page.
+ * @returns Page data accepted by `Archive.setPage`.
+ */
+function makePageData(pathname: string, html: string) {
+	return {
+		url: parseUrl(`http://localhost${pathname}`)!,
+		redirectPaths: [] as string[],
+		isExternal: false,
+		status: 200,
+		statusText: 'OK',
+		contentLength: html.length,
+		contentType: 'text/html',
+		responseHeaders: {},
+		meta: { title: 'Test Page' },
+		anchorList: [] as never[],
+		imageList: [] as never[],
+		html,
+		isSkipped: false,
+		isTarget: true,
+	};
+}
+
 describe('setPage', () => {
 	const tmpDirPattern = path.resolve(
 		workingDir,
@@ -122,6 +147,96 @@ describe('setPage', () => {
 			clearSpy.mockRestore();
 			mockedOutputText.mockRestore();
 			await archive.close();
+		}
+	});
+});
+
+describe('write: スナップショットzipキャッシュの無効化', () => {
+	const tmpDirPattern = path.resolve(
+		workingDir,
+		Archive.TMP_DIR_PREFIX + 'cache-invalidate-test',
+	);
+	const archiveFilePath = path.resolve(workingDir, 'cache-invalidate-test.nitpicker');
+
+	afterAll(async () => {
+		await remove(tmpDirPattern).catch(() => {});
+		await remove(archiveFilePath).catch(() => {});
+	});
+
+	it('write() 後の getHtmlOfPage は dangling キャッシュ参照で throw せず null を返す', async () => {
+		const html = '<html><body>cached page</body></html>';
+		const archive = await Archive.create({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		const pageId = await archive.setPage(makePageData('/cached', html));
+
+		// zip 経由の読み取りで central directory キャッシュを充填する
+		const snapshotDir = path.resolve(archive.tmpDir, Archive.SNAPSHOT_HTML_DIR);
+		const { zip } = await import('@d-zero/fs/zip');
+		await zip(`${snapshotDir}.zip`, snapshotDir);
+		await remove(snapshotDir);
+		const filePath = `${Archive.SNAPSHOT_HTML_DIR}/${pageId}.html`;
+		await expect(archive.getHtmlOfPage(filePath)).resolves.toBe(html);
+
+		// write() で tmpDir がリネーム・削除され、キャッシュ先の zip パスは消滅する
+		await archive.write();
+
+		// キャッシュが無効化されていれば ENOENT を投げず null になる
+		await expect(archive.getHtmlOfPage(filePath)).resolves.toBeNull();
+
+		await archive.close();
+	});
+});
+
+describe('write: append 時のスナップショットマージ', () => {
+	const tmpDirPattern = path.resolve(
+		workingDir,
+		Archive.TMP_DIR_PREFIX + 'append-merge-test',
+	);
+	const archiveFilePath = path.resolve(workingDir, 'append-merge-test.nitpicker');
+
+	afterAll(async () => {
+		await remove(tmpDirPattern).catch(() => {});
+		await remove(archiveFilePath).catch(() => {});
+	});
+
+	it('既存zipと追記スナップショットがマージされ、両方のHTMLが読める', async () => {
+		const html1 = '<html><body>original page</body></html>';
+		const html2 = '<html><body>appended page</body></html>';
+
+		// 1回目: 通常の crawl → write 相当
+		const first = await Archive.create({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		const pageId1 = await first.setPage(makePageData('/original', html1));
+		await first.write();
+		await first.close();
+
+		// 2回目: append 相当（既存アーカイブを開き、新規ページを追加して write）
+		const second = await Archive.open({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		const pageId2 = await second.setPage(makePageData('/appended', html2));
+		await second.write();
+		await second.close();
+
+		// 再オープンして両方のスナップショットが残っていることを検証
+		const reopened = await Archive.open({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		try {
+			await expect(
+				reopened.getHtmlOfPage(`${Archive.SNAPSHOT_HTML_DIR}/${pageId1}.html`),
+			).resolves.toBe(html1);
+			await expect(
+				reopened.getHtmlOfPage(`${Archive.SNAPSHOT_HTML_DIR}/${pageId2}.html`),
+			).resolves.toBe(html2);
+		} finally {
+			await reopened.close();
 		}
 	});
 });

--- a/packages/@nitpicker/crawler/src/archive/archive.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.ts
@@ -119,6 +119,14 @@ export default class Archive extends ArchiveAccessor {
 		return this.#db.getCrawlingState();
 	}
 	/**
+	 * Retrieves a single recorded sub-resource by its URL.
+	 * @param urls - URL candidates to match against the stored resource URL.
+	 * @returns The raw resource row, or `null` if none match.
+	 */
+	async getResourceByUrl(urls: readonly string[]) {
+		return this.#db.getResourceByUrl(urls);
+	}
+	/**
 	 * Retrieves the base URL of the crawl session from the archive database.
 	 * @returns The base URL string.
 	 */

--- a/packages/@nitpicker/crawler/src/archive/archive.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.ts
@@ -12,6 +12,7 @@ import { Database } from './database.js';
 import { dbLog, log, saveLog } from './debug.js';
 import { appendText } from './filesystem/append-text.js';
 import { exists } from './filesystem/exists.js';
+import { extractMissingZipEntries } from './filesystem/extract-missing-zip-entries.js';
 import { isDir } from './filesystem/is-dir.js';
 import { outputText } from './filesystem/output-text.js';
 import { remove } from './filesystem/remove.js';
@@ -250,12 +251,22 @@ export default class Archive extends ArchiveAccessor {
 	 */
 	async write() {
 		saveLog('Starts: %s', this.#filePath);
+		// The cached snapshot zip central directories become dangling once the
+		// zip is rewritten or tmpDir is renamed below.
+		this.invalidateSnapshotZipCache();
 		const snapshotZip = `${this.#snapshotDir}.zip`;
 		if (exists(this.#snapshotDir)) {
-			if (!exists(snapshotZip)) {
-				saveLog('Zips snapshot dir: %s', this.#snapshotDir);
-				await zip(snapshotZip, this.#snapshotDir);
+			if (exists(snapshotZip)) {
+				// Append flow: the dir holds only the snapshots written during this
+				// session while the zip holds the pre-existing ones. Merge the zip's
+				// entries into the dir (existing files win) and re-zip, so appended
+				// snapshots are not lost.
+				saveLog('Merges zipped snapshots into snapshot dir: %s', this.#snapshotDir);
+				await extractMissingZipEntries(snapshotZip, this.#snapshotDir);
+				await remove(snapshotZip);
 			}
+			saveLog('Zips snapshot dir: %s', this.#snapshotDir);
+			await zip(snapshotZip, this.#snapshotDir);
 			saveLog('Remove snapshot dir: %s', this.#snapshotDir);
 			await remove(this.#snapshotDir);
 		}

--- a/packages/@nitpicker/crawler/src/archive/database.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.spec.ts
@@ -950,3 +950,51 @@ describe('getJSON (getConfig 経由)', () => {
 		await db2.destroy();
 	});
 });
+
+describe('getResourceByUrl', () => {
+	const resourceDbPath = path.resolve(workingDir, 'get-resource-by-url-test.sqlite');
+
+	afterAll(async () => {
+		await remove(resourceDbPath);
+	});
+
+	it('挿入したリソースをURLで取得できる・未登録URLは null', async () => {
+		const db = await Database.connect({
+			workingDir,
+			filename: resourceDbPath,
+		});
+
+		await db.insertResource({
+			url: parseUrl('https://example.com/image.jpg')!,
+			isExternal: false,
+			isError: false,
+			status: 200,
+			statusText: 'OK',
+			contentType: 'image/jpeg',
+			contentLength: 1234,
+			compress: false,
+			cdn: false,
+			headers: { 'content-type': 'image/jpeg' },
+		});
+
+		const hit = await db.getResourceByUrl(['https://example.com/image.jpg']);
+		expect(hit).not.toBeNull();
+		expect(hit?.status).toBe(200);
+		expect(hit?.statusText).toBe('OK');
+		expect(hit?.contentType).toBe('image/jpeg');
+		expect(hit?.contentLength).toBe(1234);
+		expect(hit?.responseHeaders).toBe(JSON.stringify({ 'content-type': 'image/jpeg' }));
+
+		// 複数候補のうちいずれかが一致すればヒットする
+		const hitByCandidates = await db.getResourceByUrl([
+			'https://example.com/no-such.jpg',
+			'https://example.com/image.jpg',
+		]);
+		expect(hitByCandidates?.url).toBe('https://example.com/image.jpg');
+
+		const miss = await db.getResourceByUrl(['https://example.com/no-such.jpg']);
+		expect(miss).toBeNull();
+
+		await db.destroy();
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -530,6 +530,30 @@ export class Database extends EventEmitter<DatabaseEvent> {
 	}
 
 	/**
+	 * Retrieves a single sub-resource from the `resources` table by its URL.
+	 *
+	 * Accepts multiple URL candidates because the stored key is the resource's
+	 * `href` while callers may only know the hash-stripped form; the first match
+	 * wins.
+	 *
+	 * Deliberately NOT decorated with `@ErrorEmitter`: the only caller (the
+	 * crawler's resource-reuse hook) has a full fallback (the HEAD pre-flight),
+	 * so a read failure here must not surface as a database `error` event —
+	 * the orchestrator aborts the whole crawl on that event, which is the
+	 * correct reaction to write failures but not to a recoverable read.
+	 * @param urls - URL candidates to match against the `url` column.
+	 * @returns The raw {@link DB_Resource} row, or `null` if none match.
+	 */
+	@retry(retrySetting)
+	async getResourceByUrl(urls: readonly string[]): Promise<DB_Resource | null> {
+		const res = await this.#instance
+			.select('*')
+			.from<DB_Resource>('resources')
+			.whereIn('url', [...urls])
+			.first();
+		return res ?? null;
+	}
+	/**
 	 * Retrieves all sub-resources from the `resources` table.
 	 * @returns An array of raw {@link DB_Resource} rows.
 	 */

--- a/packages/@nitpicker/crawler/src/archive/filesystem/extract-missing-zip-entries.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/filesystem/extract-missing-zip-entries.spec.ts
@@ -1,0 +1,54 @@
+import path from 'node:path';
+
+import { zip } from '@d-zero/fs/zip';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { extractMissingZipEntries } from './extract-missing-zip-entries.js';
+import { outputText } from './output-text.js';
+import { readText } from './read-text.js';
+import { remove } from './remove.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workDir = path.resolve(__dirname, '__mock__', 'extract-missing-zip-entries');
+
+describe('extractMissingZipEntries', () => {
+	afterAll(async () => {
+		await remove(workDir).catch(() => {});
+	});
+
+	it('既存ファイルを上書きせず、zipの不足エントリのみ展開する', async () => {
+		const srcDir = path.resolve(workDir, 'src');
+		await outputText(path.resolve(srcDir, 'a.html'), 'old-a');
+		await outputText(path.resolve(srcDir, 'b.html'), 'old-b');
+		const zipPath = path.resolve(workDir, 'snapshot.zip');
+		await zip(zipPath, srcDir);
+		await remove(srcDir);
+
+		// append 後の状態を模倣: b は新しい内容で再生成、c は新規ファイル
+		await outputText(path.resolve(srcDir, 'b.html'), 'new-b');
+		await outputText(path.resolve(srcDir, 'c.html'), 'new-c');
+
+		await extractMissingZipEntries(zipPath, srcDir);
+
+		// zip にのみ存在した a は復元される
+		await expect(readText(path.resolve(srcDir, 'a.html'))).resolves.toBe('old-a');
+		// ディレクトリ側の新しい b は zip の古い内容で上書きされない
+		await expect(readText(path.resolve(srcDir, 'b.html'))).resolves.toBe('new-b');
+		// ディレクトリ側にのみ存在する c はそのまま残る
+		await expect(readText(path.resolve(srcDir, 'c.html'))).resolves.toBe('new-c');
+	});
+
+	it('展開先ディレクトリが存在しない場合は作成して全エントリを展開する', async () => {
+		const srcDir = path.resolve(workDir, 'src2');
+		await outputText(path.resolve(srcDir, 'x.html'), 'x');
+		const zipPath = path.resolve(workDir, 'snapshot2.zip');
+		await zip(zipPath, srcDir);
+		await remove(srcDir);
+
+		const destDir = path.resolve(workDir, 'dest2');
+		await extractMissingZipEntries(zipPath, destDir);
+
+		await expect(readText(path.resolve(destDir, 'x.html'))).resolves.toBe('x');
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/filesystem/extract-missing-zip-entries.ts
+++ b/packages/@nitpicker/crawler/src/archive/filesystem/extract-missing-zip-entries.ts
@@ -1,0 +1,33 @@
+import { promises as fs } from 'node:fs';
+
+import { extractZip } from '@d-zero/fs/zip';
+
+import { safePath } from '../safe-path.js';
+
+import { exists } from './exists.js';
+import { mkdir } from './mkdir.js';
+
+/**
+ * Extracts the entries of a zip file into a directory, skipping any entry
+ * whose destination file already exists — existing files always win.
+ *
+ * Used by `Archive.write()` in the append flow to merge previously zipped
+ * snapshots with snapshots newly written during the session, without letting
+ * stale zip entries overwrite fresh files.
+ * @param zipFilePath - The absolute path to the source zip file.
+ * @param destDir - The absolute path of the directory to extract into.
+ */
+export async function extractMissingZipEntries(zipFilePath: string, destDir: string) {
+	const dir = await extractZip(zipFilePath);
+	for (const file of dir.files) {
+		if (file.type !== 'File') {
+			continue;
+		}
+		const dest = safePath(destDir, file.path);
+		if (exists(dest)) {
+			continue;
+		}
+		mkdir(dest);
+		await fs.writeFile(dest, await file.buffer());
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/page.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/page.spec.ts
@@ -166,6 +166,20 @@ describe('Page', () => {
 			);
 			expect(page.responseHeaders).toEqual({});
 		});
+
+		it('多値ヘッダー（set-cookie 等）の string[] 値はそのまま保持される', () => {
+			// 型が Record<string, string | string[] | undefined> であることの実体保証:
+			// 配列値が文字列化されたり欠落したりしない
+			const page = new Page(
+				createMockArchive() as never,
+				createRawPage({
+					responseHeaders: '{"set-cookie":["a=1; Path=/","b=2; Path=/"]}',
+				}),
+			);
+			expect(page.responseHeaders).toEqual({
+				'set-cookie': ['a=1; Path=/', 'b=2; Path=/'],
+			});
+		});
 	});
 
 	describe('isPage / isInternalPage', () => {

--- a/packages/@nitpicker/crawler/src/archive/page.ts
+++ b/packages/@nitpicker/crawler/src/archive/page.ts
@@ -11,6 +11,7 @@ import type {
 
 import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
 
+import { isHtmlContentType } from '../crawler/is-html-content-type.js';
 import { parseResponseHeaders } from '../utils/object/parse-response-headers.js';
 
 /**
@@ -176,13 +177,11 @@ export default class Page {
 
 	/**
 	 * The parsed HTTP response headers as a key-value record.
-	 * Returns an empty object if headers cannot be parsed.
+	 * Header values may be arrays for multi-value headers (e.g. `set-cookie`).
+	 * Returns an empty object if headers are absent or cannot be parsed.
 	 */
-	get responseHeaders(): Record<string, string> {
-		return (parseResponseHeaders(this.#raw.responseHeaders) ?? {}) as Record<
-			string,
-			string
-		>;
+	get responseHeaders(): Record<string, string | string[] | undefined> {
+		return parseResponseHeaders(this.#raw.responseHeaders) ?? {};
 	}
 
 	/**
@@ -322,8 +321,7 @@ export default class Page {
 	 * @returns `true` if the content type is `text/html`, `false` otherwise.
 	 */
 	isPage() {
-		const type = this.contentType || '';
-		return type.toLowerCase().trim() === 'text/html';
+		return isHtmlContentType(this.contentType);
 	}
 
 	/**

--- a/packages/@nitpicker/crawler/src/archive/page.ts
+++ b/packages/@nitpicker/crawler/src/archive/page.ts
@@ -11,6 +11,8 @@ import type {
 
 import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
 
+import { parseResponseHeaders } from '../utils/object/parse-response-headers.js';
+
 /**
  * Represents a crawled page stored in the archive.
  *
@@ -177,11 +179,10 @@ export default class Page {
 	 * Returns an empty object if headers cannot be parsed.
 	 */
 	get responseHeaders(): Record<string, string> {
-		try {
-			return JSON.parse(this.#raw.responseHeaders);
-		} catch {
-			return {};
-		}
+		return (parseResponseHeaders(this.#raw.responseHeaders) ?? {}) as Record<
+			string,
+			string
+		>;
 	}
 
 	/**

--- a/packages/@nitpicker/crawler/src/crawler-orchestrator.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler-orchestrator.spec.ts
@@ -1,11 +1,91 @@
 import type Archive from './archive/archive.js';
+import type { CrawlerError } from './utils/types/types.js';
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { CrawlerOrchestrator } from './crawler-orchestrator.js';
 
+vi.mock('./crawler/crawler.js', () => {
+	/**
+	 * A minimal Crawler stand-in: records event handlers and, on `start()`,
+	 * emits a single `error` event followed by `crawlEnd`. This lets tests
+	 * drive the orchestrator's event-to-archive wiring without a browser.
+	 */
+	class FakeCrawler {
+		/** Registered event handlers keyed by event name. */
+		handlers = new Map<string, (payload: never) => void>();
+
+		/** No-op abort to satisfy the orchestrator's interface. */
+		abort() {}
+
+		/**
+		 * Returns an empty undead-PID list.
+		 * @returns An empty array.
+		 */
+		getUndeadPid() {
+			return [];
+		}
+
+		/**
+		 * Records an event handler.
+		 * @param event - The event name.
+		 * @param handler - The handler function.
+		 */
+		on(event: string, handler: (payload: never) => void) {
+			this.handlers.set(event, handler);
+		}
+
+		/** Emits `error` and then `crawlEnd`, simulating a crawl with one error. */
+		start() {
+			const error: CrawlerError = {
+				pid: process.pid,
+				isMainProcess: true,
+				url: 'https://example.com/',
+				isExternal: false,
+				error: new Error('scrape-failure'),
+			};
+			this.handlers.get('error')?.(error as never);
+			this.handlers.get('crawlEnd')?.(undefined as never);
+		}
+	}
+	return { default: FakeCrawler };
+});
+
 afterEach(() => {
 	vi.restoreAllMocks();
+});
+
+describe('CrawlerOrchestrator.crawling: error イベントの書き込み失敗', () => {
+	it('archive.addError が reject すると crawling() 全体が reject する（unhandledRejection にならない）', async () => {
+		const fakeArchive = {
+			on: vi.fn(),
+			setConfig: vi.fn(() => Promise.resolve()),
+			getConfig: vi.fn(() => Promise.resolve({ analyze: [] })),
+			addError: vi.fn(() => Promise.reject(new Error('db-write-failure'))),
+			setUrlOrder: vi.fn(() => Promise.resolve()),
+			getResourceByUrl: vi.fn(() => Promise.resolve(null)),
+			filePath: '/tmp/orchestrator-adderror-test.nitpicker',
+		} as unknown as Archive;
+
+		const archiveModule = await import('./archive/archive.js');
+		vi.spyOn(archiveModule.default, 'create').mockResolvedValueOnce(fakeArchive);
+
+		await expect(
+			CrawlerOrchestrator.crawling(
+				['https://example.com/'],
+				{
+					cwd: '/tmp',
+					filePath: '/tmp/orchestrator-adderror-test.nitpicker',
+				},
+				(orchestrator) => {
+					// 'error' イベント自体は通知される（リスナー未登録での throw を防ぐ）
+					orchestrator.on('error', () => {});
+				},
+			),
+		).rejects.toThrow('db-write-failure');
+
+		expect(fakeArchive.addError).toHaveBeenCalledOnce();
+	});
 });
 
 describe('CrawlerOrchestrator.append', () => {

--- a/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
+++ b/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
@@ -216,7 +216,9 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 		return new Promise<void>((resolve, reject) => {
 			this.#crawler.on('error', (error) => {
 				crawlerLog('On error: %O', error);
-				void writeQueue.enqueue(() => this.#archive.addError(error));
+				writeQueue
+					.enqueue(() => this.#archive.addError(error))
+					.catch((writeError) => reject(writeError));
 				void this.emit('error', error);
 			});
 

--- a/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
+++ b/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
@@ -17,6 +17,7 @@ import Crawler from './crawler/crawler.js';
 import { crawlerLog, log } from './debug.js';
 import { normalizeToArray } from './normalize-to-array.js';
 import { resolveOutputPath } from './resolve-output-path.js';
+import { resourceRowToLookupResult } from './resource-row-to-lookup-result.js';
 import { cleanObject } from './utils/object/clean-object.js';
 import { WriteQueue } from './write-queue.js';
 
@@ -114,6 +115,8 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 	readonly #crawler: Crawler;
 	/** Whether the crawl was started from a pre-defined URL list (non-recursive mode). */
 	readonly #fromList: boolean;
+	/** Serializes archive writes from crawler event handlers (FIFO). */
+	readonly #writeQueue = new WriteQueue();
 
 	/**
 	 * The underlying archive instance used for storing crawl results.
@@ -160,6 +163,23 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 			verbose: options?.verbose ?? false,
 			userAgent: options?.userAgent || defaultUserAgent,
 			ignoreRobots: options?.ignoreRobots ?? false,
+			// Let the crawler reuse sub-resource data captured during page
+			// rendering instead of issuing a redundant HEAD pre-flight.
+			lookupResource: async (urls) => {
+				// Fast path: read directly — the row is usually flushed long
+				// before the queued URL is dequeued, and a direct read does not
+				// block behind pending writes.
+				const direct = await this.#archive.getResourceByUrl(urls);
+				if (direct) {
+					return resourceRowToLookupResult(direct);
+				}
+				// A miss may be an insert still queued — re-read serialized
+				// behind the write queue so hit/miss is deterministic.
+				const row = await this.#writeQueue.enqueue(() =>
+					this.#archive.getResourceByUrl(urls),
+				);
+				return row ? resourceRowToLookupResult(row) : null;
+			},
 		});
 	}
 
@@ -191,7 +211,7 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 			throw new Error('URL is empty');
 		}
 
-		const writeQueue = new WriteQueue();
+		const writeQueue = this.#writeQueue;
 
 		return new Promise<void>((resolve, reject) => {
 			this.#crawler.on('error', (error) => {

--- a/packages/@nitpicker/crawler/src/crawler/crawler.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.spec.ts
@@ -33,6 +33,27 @@ vi.mock('./robots-checker.js', () => {
 });
 
 /**
+ * Configure the mocked deal() to synchronously drive every queued URL
+ * through the crawler's worker callback, mirroring the dealer contract.
+ */
+async function driveDeal() {
+	const { deal } = await import('@d-zero/dealer');
+	vi.mocked(deal).mockImplementation(async (items, factory) => {
+		for (const [index, item] of (items as unknown[]).entries()) {
+			const noop = () => {};
+			const noopAsync = async () => {};
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- deal factory signature is complex; cast is intentional in test
+			const workFn = (factory as Function)(item, noop, index, noop, noopAsync) as
+				| (() => Promise<void>)
+				| undefined;
+			if (workFn) {
+				await workFn();
+			}
+		}
+	});
+}
+
+/**
  * Default crawler options for testing.
  */
 const defaultOptions = {
@@ -257,25 +278,12 @@ describe('Crawler', () => {
 
 	describe('worker-level error handling', () => {
 		it('ワーカー内の例外が error イベントとして emit され処理が継続する', async () => {
-			const { deal } = await import('@d-zero/dealer');
 			const { default: Crawler } = await import('./crawler.js');
 
 			const workerError = new Error('unexpected crash');
 
 			// Simulate deal: call setup function, then invoke the returned work function
-			vi.mocked(deal).mockImplementation(async (items, factory) => {
-				for (const [index, item] of (items as unknown[]).entries()) {
-					const noop = () => {};
-					const noopAsync = async () => {};
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- deal factory signature is complex; cast is intentional in test
-					const workFn = (factory as Function)(item, noop, index, noop, noopAsync) as
-						| (() => Promise<void>)
-						| undefined;
-					if (workFn) {
-						await workFn();
-					}
-				}
-			});
+			await driveDeal();
 
 			// Mock fetchDestination to throw — triggers the worker catch block
 			const fetchDestMod = await import('./fetch-destination.js');
@@ -302,6 +310,97 @@ describe('Crawler', () => {
 			expect(errors).toHaveLength(1);
 			expect(errors[0]!.error.message).toBe('unexpected crash');
 			expect(errors[0]!.url).toBe('https://example.com');
+		});
+	});
+
+	describe('resource reuse via the lookupResource option', () => {
+		it('キャプチャ済みリソースが再利用され、ネットワークフェッチが一切発生しない', async () => {
+			await driveDeal();
+			const { default: Crawler } = await import('./crawler.js');
+
+			// Any network access fails the test: reuse must satisfy the URL alone
+			const fetchDestMod = await import('./fetch-destination.js');
+			const fetchSpy = vi
+				.spyOn(fetchDestMod, 'fetchDestination')
+				.mockRejectedValue(new Error('network must not be touched'));
+
+			const crawler = new Crawler({
+				...defaultOptions,
+				lookupResource: () =>
+					Promise.resolve({
+						status: 200,
+						statusText: 'OK',
+						contentType: 'image/png',
+						contentLength: 1234,
+						responseHeaders: { 'content-type': 'image/png' },
+					}),
+			});
+			// Seed the known-resources set the same way a resumed session does
+			crawler.resume([], [], ['https://example.com/img.png']);
+
+			const pages: CrawlerEventTypes['page'][] = [];
+			crawler.on('page', (p) => {
+				pages.push(p);
+			});
+
+			crawler.start([parseUrl('https://example.com/img.png')!]);
+
+			await vi.waitFor(() => {
+				expect(pages).toHaveLength(1);
+			});
+			expect(pages[0]!.result.status).toBe(200);
+			expect(pages[0]!.result.statusText).toBe('OK');
+			expect(pages[0]!.result.contentType).toBe('image/png');
+			expect(pages[0]!.result.contentLength).toBe(1234);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it('lookup が失敗してもクロールは止まらず HEAD プリフライトにフォールバックする', async () => {
+			await driveDeal();
+			const { default: Crawler } = await import('./crawler.js');
+
+			const url = parseUrl('https://example.com/img.png')!;
+			const fetchDestMod = await import('./fetch-destination.js');
+			const fetchSpy = vi.spyOn(fetchDestMod, 'fetchDestination').mockResolvedValue({
+				url,
+				redirectPaths: [],
+				isTarget: true,
+				isExternal: false,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'image/png',
+				contentLength: 1234,
+				responseHeaders: {},
+				meta: { title: '' },
+				anchorList: [],
+				imageList: [],
+				html: '',
+				isSkipped: false,
+			});
+
+			const crawler = new Crawler({
+				...defaultOptions,
+				lookupResource: () => Promise.reject(new Error('db read failed')),
+			});
+			crawler.resume([], [], ['https://example.com/img.png']);
+
+			const pages: CrawlerEventTypes['page'][] = [];
+			const errors: CrawlerEventTypes['error'][] = [];
+			crawler.on('page', (p) => {
+				pages.push(p);
+			});
+			crawler.on('error', (e) => {
+				errors.push(e);
+			});
+
+			crawler.start([url]);
+
+			await vi.waitFor(() => {
+				expect(pages).toHaveLength(1);
+			});
+			expect(errors).toHaveLength(0);
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			expect(pages[0]!.result.status).toBe(200);
 		});
 	});
 

--- a/packages/@nitpicker/crawler/src/crawler/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.ts
@@ -1,4 +1,4 @@
-import type { CrawlerEventTypes, CrawlerOptions } from './types.js';
+import type { CrawlerEventTypes, CrawlerOptions, ResourceLookupResult } from './types.js';
 import type {
 	ChangePhaseEvent,
 	PageData,
@@ -30,9 +30,11 @@ import { handleResourceResponse } from './handle-resource-response.js';
 import { handleScrapeEnd } from './handle-scrape-end.js';
 import { handleScrapeError } from './handle-scrape-error.js';
 import { injectScopeAuth } from './inject-scope-auth.js';
+import { isHtmlContentType } from './is-html-content-type.js';
 import LinkList from './link-list.js';
 import { linkToPageData } from './link-to-page-data.js';
 import { protocolAgnosticKey } from './protocol-agnostic-key.js';
+import { resourceToPageData } from './resource-to-page-data.js';
 import { RobotsChecker } from './robots-checker.js';
 import { shouldDiscardPredicted } from './should-discard-predicted.js';
 import { shouldSkipUrl } from './should-skip-url.js';
@@ -104,6 +106,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 			verbose: options?.verbose ?? false,
 			userAgent: options?.userAgent || `Nitpicker/${pkg.version}`,
 			ignoreRobots: options?.ignoreRobots ?? false,
+			lookupResource: options?.lookupResource ?? null,
 		};
 
 		this.#robotsChecker = new RobotsChecker(
@@ -697,6 +700,43 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 			return this.#launchBrowserAndScrape(url, update, isExternal, metadataOnly);
 		}
 
+		// Reuse captured resource data — when this URL was already observed as a
+		// sub-resource during page rendering, its response data is recorded and
+		// the HEAD pre-flight is redundant. Only 2xx non-HTML rows are eligible
+		// (see resourceToPageData); anything else falls through to the pre-flight.
+		// Both URL variants are checked because scope-auth injection adds
+		// credentials to queued URLs while browser-captured resource URLs have none.
+		// The result is deliberately NOT written to destinationCache: a queued URL
+		// is processed at most once (the dealer dedupes by protocol-agnostic key),
+		// so a URL that takes this path never reaches fetchDestination again.
+		const lookupResource = this.#options.lookupResource;
+		if (
+			lookupResource &&
+			(this.#resources.has(url.withoutHash) ||
+				this.#resources.has(url.withoutHashAndAuth))
+		) {
+			update('Checking captured resource%dots%');
+			let resource: ResourceLookupResult | null = null;
+			try {
+				resource = await lookupResource([url.withoutHash, url.withoutHashAndAuth]);
+			} catch (error) {
+				// A lookup failure must never be worse than not having the
+				// optimization — fall back to the HEAD pre-flight below.
+				crawlerLog('Resource lookup failed for %s, falling back: %O', url.href, error);
+			}
+			const pageData = resource
+				? resourceToPageData({ url, isExternal, resource })
+				: null;
+			if (pageData) {
+				crawlerLog('Reused captured resource for %s', url.href);
+				return {
+					type: 'success',
+					pageData: metadataOnly ? { ...pageData, isTarget: false } : pageData,
+					resources: [],
+				};
+			}
+		}
+
 		// Pre-flight: lightweight HEAD request to check server availability
 		update('HEAD request%dots%');
 		let headCheckResult: PageData;
@@ -721,7 +761,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 		if (metadataOnly) {
 			if (
 				headCheckResult.contentType === null ||
-				headCheckResult.contentType === 'text/html'
+				isHtmlContentType(headCheckResult.contentType)
 			) {
 				update('Fetching title%dots%');
 				try {
@@ -751,7 +791,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 		// Non-HTML content — skip browser
 		if (
 			headCheckResult.contentType !== null &&
-			headCheckResult.contentType !== 'text/html'
+			!isHtmlContentType(headCheckResult.contentType)
 		) {
 			return {
 				type: 'success',

--- a/packages/@nitpicker/crawler/src/crawler/format-crawl-progress.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/format-crawl-progress.spec.ts
@@ -23,7 +23,7 @@ describe('formatCrawlProgress', () => {
 			externalDone: 0,
 			limit: 10,
 		});
-		expect(result).toContain('50 done / 100 found');
+		expect(result).toContain('50 done / 100 found URLs');
 		expect(result).toContain('50 remaining');
 	});
 
@@ -36,7 +36,7 @@ describe('formatCrawlProgress', () => {
 			externalDone: 10,
 			limit: 5,
 		});
-		expect(result).toContain('50 done / 100 found');
+		expect(result).toContain('50 done / 100 found URLs');
 		expect(result).toContain('+10/20 ext');
 		expect(result).toContain('60 remaining');
 	});
@@ -50,7 +50,7 @@ describe('formatCrawlProgress', () => {
 			externalDone: 0,
 			limit: 10,
 		});
-		expect(result).toContain('130 done / 150 found');
+		expect(result).toContain('130 done / 150 found URLs');
 		expect(result).toContain('20 remaining');
 	});
 
@@ -75,7 +75,7 @@ describe('formatCrawlProgress', () => {
 			externalDone: 0,
 			limit: 10,
 		});
-		expect(result).toContain('0 done / 0 found');
+		expect(result).toContain('0 done / 0 found URLs');
 		expect(result).toContain('0 remaining');
 	});
 
@@ -128,7 +128,7 @@ describe('formatCrawlProgress', () => {
 			limit: 10,
 		});
 		expect(result).toBe(
-			'Crawling: 50 done / 100 found (+0/0 ext) (50%) [50 remaining] [10 parallel]',
+			'Crawling: 50 done / 100 found URLs (+0/0 ext) (50%) [50 remaining] [10 parallel]',
 		);
 	});
 
@@ -143,8 +143,24 @@ describe('formatCrawlProgress', () => {
 		});
 		// allDone=60, allTotal=100, internalDone=55, internalTotal=90
 		// internalRemaining=35, externalRemaining=5, totalRemaining=40
-		expect(result).toContain('55 done / 90 found');
+		expect(result).toContain('55 done / 90 found URLs');
 		expect(result).toContain('+5/10 ext');
 		expect(result).toContain('40 remaining');
+	});
+
+	it('formats counts with thousands separators', () => {
+		const result = formatCrawlProgress({
+			done: 12_345,
+			total: 1_234_567,
+			resumeOffset: 0,
+			externalTotal: 2345,
+			externalDone: 1234,
+			limit: 10,
+		});
+		// internalDone=12345-1234=11111, internalTotal=1234567-2345=1232222
+		// totalRemaining=1234567-12345=1222222
+		expect(result).toContain('11,111 done / 1,232,222 found URLs');
+		expect(result).toContain('+1,234/2,345 ext');
+		expect(result).toContain('1,222,222 remaining');
 	});
 });

--- a/packages/@nitpicker/crawler/src/crawler/format-crawl-progress.ts
+++ b/packages/@nitpicker/crawler/src/crawler/format-crawl-progress.ts
@@ -1,6 +1,11 @@
 import c from 'ansi-colors';
 
 /**
+ * Number formatter for thousands-separated count display (e.g. `1,234,567`).
+ */
+const countFormat = new Intl.NumberFormat('en-US');
+
+/**
  * Parameters for formatting crawl progress display.
  */
 interface FormatCrawlProgressParams {
@@ -21,8 +26,10 @@ interface FormatCrawlProgressParams {
 /**
  * Formats the crawl progress header for the deal() progress display.
  *
- * Shows "done / found (remaining)" format instead of "done/total"
- * to make it clearer that the total is expected to grow during crawling.
+ * Shows "done / found URLs (remaining)" format instead of "done/total"
+ * to make it clearer that the total is expected to grow during crawling
+ * and that the counts are processed URLs, not resulting pages.
+ * Counts are formatted with thousands separators (e.g. `1,234,567`).
  * @param params - The crawl progress parameters.
  * @param params.done - Number of URLs completed by the deal queue.
  * @param params.total - Total number of URLs in the deal queue (including completed).
@@ -50,9 +57,13 @@ export function formatCrawlProgress({
 	const pct = allTotal > 0 ? Math.round((allDone / allTotal) * 100) : 0;
 
 	return (
-		c.bold(`Crawling: ${internalDone} done / ${internalTotal} found`) +
-		c.dim(` (+${externalDone}/${externalTotal} ext)`) +
-		c.bold(` (${pct}%) [${totalRemaining} remaining]`) +
+		c.bold(
+			`Crawling: ${countFormat.format(internalDone)} done / ${countFormat.format(internalTotal)} found URLs`,
+		) +
+		c.dim(
+			` (+${countFormat.format(externalDone)}/${countFormat.format(externalTotal)} ext)`,
+		) +
+		c.bold(` (${pct}%) [${countFormat.format(totalRemaining)} remaining]`) +
 		c.dim(` [${limit} parallel]`)
 	);
 }

--- a/packages/@nitpicker/crawler/src/crawler/is-html-content-type.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/is-html-content-type.spec.ts
@@ -10,6 +10,13 @@ describe('isHtmlContentType', () => {
 		},
 	);
 
+	it.each(['text/html ', ' text/html', '\ttext/html\t'])(
+		'returns true for %j with surrounding whitespace',
+		(contentType) => {
+			expect(isHtmlContentType(contentType)).toBe(true);
+		},
+	);
+
 	it.each(['image/png', 'application/json', 'text/plain', 'text/htm', ''])(
 		'returns false for non-HTML media type %s',
 		(contentType) => {

--- a/packages/@nitpicker/crawler/src/crawler/is-html-content-type.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/is-html-content-type.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+
+import { isHtmlContentType } from './is-html-content-type.js';
+
+describe('isHtmlContentType', () => {
+	it.each(['text/html', 'text/HTML', 'TEXT/HTML', 'Text/Html'])(
+		'returns true for %s regardless of letter case',
+		(contentType) => {
+			expect(isHtmlContentType(contentType)).toBe(true);
+		},
+	);
+
+	it.each(['image/png', 'application/json', 'text/plain', 'text/htm', ''])(
+		'returns false for non-HTML media type %s',
+		(contentType) => {
+			expect(isHtmlContentType(contentType)).toBe(false);
+		},
+	);
+
+	it('returns false for null', () => {
+		expect(isHtmlContentType(null)).toBe(false);
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/is-html-content-type.ts
+++ b/packages/@nitpicker/crawler/src/crawler/is-html-content-type.ts
@@ -1,0 +1,13 @@
+/**
+ * Determine whether a Content-Type media type is HTML.
+ *
+ * MIME types are case-insensitive (RFC 2045), and values captured from
+ * Puppeteer responses preserve the server's original casing, so the
+ * comparison must normalize case — `text/HTML` is HTML.
+ * @param contentType - The media type portion of a Content-Type header
+ *   (parameters already stripped), or `null` when unknown.
+ * @returns `true` when the media type is `text/html` in any letter case.
+ */
+export function isHtmlContentType(contentType: string | null): boolean {
+	return contentType !== null && contentType.toLowerCase() === 'text/html';
+}

--- a/packages/@nitpicker/crawler/src/crawler/is-html-content-type.ts
+++ b/packages/@nitpicker/crawler/src/crawler/is-html-content-type.ts
@@ -3,11 +3,17 @@
  *
  * MIME types are case-insensitive (RFC 2045), and values captured from
  * Puppeteer responses preserve the server's original casing, so the
- * comparison must normalize case — `text/HTML` is HTML.
+ * comparison must normalize case — `text/HTML` is HTML. Surrounding
+ * whitespace (e.g. `text/html ` left over after parameter stripping)
+ * is also tolerated.
+ *
+ * This is the single source of truth for HTML detection — `Page.isPage()`
+ * and the link list delegate here so the classification never diverges
+ * between code paths.
  * @param contentType - The media type portion of a Content-Type header
  *   (parameters already stripped), or `null` when unknown.
  * @returns `true` when the media type is `text/html` in any letter case.
  */
 export function isHtmlContentType(contentType: string | null): boolean {
-	return contentType !== null && contentType.toLowerCase() === 'text/html';
+	return contentType !== null && contentType.trim().toLowerCase() === 'text/html';
 }

--- a/packages/@nitpicker/crawler/src/crawler/link-list.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/link-list.spec.ts
@@ -226,6 +226,27 @@ describe('LinkList', () => {
 			expect(list.completePages).toBe(1);
 		});
 
+		it('大文字を含む text/HTML も completePages にカウントされる', () => {
+			// HTML 判定は isHtmlContentType に統一されているため、
+			// サーバーの Content-Type が大文字でもページとして数えられる
+			const list = new LinkList();
+			const url = createUrl('https://example.com/blog/post');
+			const scope = createScope([['example.com', ['https://example.com/']]]);
+			list.add(url);
+			list.done(
+				url,
+				scope,
+				{
+					page: createPageData({
+						status: 200,
+						contentType: 'text/HTML',
+					}),
+				},
+				defaultOptions,
+			);
+			expect(list.completePages).toBe(1);
+		});
+
 		it('does not count error pages as completePages', () => {
 			const list = new LinkList();
 			const url = createUrl('https://example.com/page');

--- a/packages/@nitpicker/crawler/src/crawler/link-list.ts
+++ b/packages/@nitpicker/crawler/src/crawler/link-list.ts
@@ -5,6 +5,7 @@ import { isError } from '@d-zero/beholder';
 import { isLowerLayer } from '@d-zero/shared/is-lower-layer';
 import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
 
+import { isHtmlContentType } from './is-html-content-type.js';
 import { protocolAgnosticKey } from './protocol-agnostic-key.js';
 
 /**
@@ -267,7 +268,7 @@ function isPage(link: Link) {
 		return false;
 	}
 
-	if (link.dest.contentType === 'text/html') {
+	if (isHtmlContentType(link.dest.contentType)) {
 		return true;
 	}
 

--- a/packages/@nitpicker/crawler/src/crawler/resource-to-page-data.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/resource-to-page-data.spec.ts
@@ -1,0 +1,133 @@
+import type { ResourceLookupResult } from './types.js';
+
+import { parseUrl } from '@d-zero/shared/parse-url';
+import { describe, it, expect } from 'vitest';
+
+import { resourceToPageData } from './resource-to-page-data.js';
+
+const url = parseUrl('https://example.com/image.jpg');
+
+/**
+ * Build a ResourceLookupResult with sensible defaults for tests.
+ * @param overrides - Fields to override.
+ * @returns A complete ResourceLookupResult.
+ */
+function createResource(
+	overrides: Partial<ResourceLookupResult> = {},
+): ResourceLookupResult {
+	return {
+		status: 200,
+		statusText: 'OK',
+		contentType: 'image/jpeg',
+		contentLength: 1234,
+		responseHeaders: { 'content-type': 'image/jpeg' },
+		...overrides,
+	};
+}
+
+describe('resourceToPageData', () => {
+	it('synthesizes PageData from a 2xx non-HTML resource', () => {
+		const result = resourceToPageData({
+			url,
+			isExternal: false,
+			resource: createResource(),
+		});
+		expect(result).not.toBeNull();
+		expect(result?.url).toBe(url);
+		expect(result?.isTarget).toBe(true);
+		expect(result?.isExternal).toBe(false);
+		expect(result?.status).toBe(200);
+		expect(result?.statusText).toBe('OK');
+		expect(result?.contentType).toBe('image/jpeg');
+		expect(result?.contentLength).toBe(1234);
+		expect(result?.responseHeaders).toEqual({ 'content-type': 'image/jpeg' });
+		expect(result?.redirectPaths).toEqual([]);
+		expect(result?.meta).toEqual({ title: '' });
+		expect(result?.anchorList).toEqual([]);
+		expect(result?.imageList).toEqual([]);
+		expect(result?.html).toBe('');
+		expect(result?.isSkipped).toBe(false);
+	});
+
+	it('reflects the external flag', () => {
+		const result = resourceToPageData({
+			url,
+			isExternal: true,
+			resource: createResource(),
+		});
+		expect(result?.isExternal).toBe(true);
+		expect(result?.isTarget).toBe(false);
+	});
+
+	it('returns null when status is null', () => {
+		const result = resourceToPageData({
+			url,
+			isExternal: false,
+			resource: createResource({ status: null }),
+		});
+		expect(result).toBeNull();
+	});
+
+	it.each([301, 304, 404, 500, 199])('returns null for non-2xx status %d', (status) => {
+		const result = resourceToPageData({
+			url,
+			isExternal: false,
+			resource: createResource({ status }),
+		});
+		expect(result).toBeNull();
+	});
+
+	it.each([200, 204, 206, 299])('accepts 2xx status %d', (status) => {
+		const result = resourceToPageData({
+			url,
+			isExternal: false,
+			resource: createResource({ status }),
+		});
+		expect(result?.status).toBe(status);
+	});
+
+	it('returns null when contentType is null', () => {
+		const result = resourceToPageData({
+			url,
+			isExternal: false,
+			resource: createResource({ contentType: null }),
+		});
+		expect(result).toBeNull();
+	});
+
+	it('returns null when contentType is text/html', () => {
+		const result = resourceToPageData({
+			url,
+			isExternal: false,
+			resource: createResource({ contentType: 'text/html' }),
+		});
+		expect(result).toBeNull();
+	});
+
+	it.each(['text/HTML', 'TEXT/HTML', 'Text/Html'])(
+		'returns null for HTML contentType in any letter case (%s)',
+		(contentType) => {
+			const result = resourceToPageData({
+				url,
+				isExternal: false,
+				resource: createResource({ contentType }),
+			});
+			expect(result).toBeNull();
+		},
+	);
+
+	it('normalizes null statusText and contentLength', () => {
+		const result = resourceToPageData({
+			url,
+			isExternal: false,
+			resource: createResource({
+				statusText: null,
+				contentLength: null,
+				responseHeaders: null,
+			}),
+		});
+		expect(result?.statusText).toBe('');
+		expect(result?.contentLength).toBeNull();
+		expect(result?.responseHeaders).toBeNull();
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/resource-to-page-data.ts
+++ b/packages/@nitpicker/crawler/src/crawler/resource-to-page-data.ts
@@ -1,0 +1,62 @@
+import type { ResourceLookupResult } from './types.js';
+import type { PageData } from '../utils/types/types.js';
+import type { ExURL } from '@d-zero/shared/parse-url';
+
+import { isHtmlContentType } from './is-html-content-type.js';
+
+/**
+ * Parameters for {@link resourceToPageData}.
+ */
+interface ResourceToPageDataParams {
+	/** The queued URL being processed. */
+	readonly url: ExURL;
+	/** Whether the URL is external to the crawl scope. */
+	readonly isExternal: boolean;
+	/** The recorded sub-resource data captured during page rendering. */
+	readonly resource: ResourceLookupResult;
+}
+
+/**
+ * Synthesize {@link PageData} from a recorded sub-resource row, or return
+ * `null` when the resource is not eligible for reuse.
+ *
+ * Eligible: the status is 2xx AND the content type is known and not
+ * `text/html`. Non-2xx rows (redirect hops, errors, 304s) and HTML rows must
+ * fall back to the normal HEAD pre-flight / browser scrape, which also
+ * guarantees that `redirectPaths: []` here is accurate — a URL that
+ * redirects is recorded with its 3xx status and never reaches this path.
+ * @param params - The queued URL, its external flag, and the recorded resource data.
+ * @returns The synthesized page data, or `null` when the caller must fall back.
+ */
+export function resourceToPageData(params: ResourceToPageDataParams): PageData | null {
+	const { url, isExternal, resource } = params;
+
+	if (
+		resource.status == null ||
+		resource.status < 200 ||
+		resource.status >= 300 ||
+		resource.contentType == null ||
+		isHtmlContentType(resource.contentType)
+	) {
+		return null;
+	}
+
+	return {
+		url,
+		redirectPaths: [],
+		isTarget: !isExternal,
+		isExternal,
+		status: resource.status,
+		statusText: resource.statusText ?? '',
+		contentType: resource.contentType,
+		contentLength: resource.contentLength,
+		responseHeaders: resource.responseHeaders,
+		meta: {
+			title: '',
+		},
+		anchorList: [],
+		imageList: [],
+		html: '',
+		isSkipped: false,
+	};
+}

--- a/packages/@nitpicker/crawler/src/crawler/types.ts
+++ b/packages/@nitpicker/crawler/src/crawler/types.ts
@@ -60,6 +60,47 @@ export interface CrawlerOptions extends Required<
 
 	/** Whether to ignore robots.txt restrictions. */
 	ignoreRobots: boolean;
+
+	/**
+	 * Lookup for previously captured sub-resources, or `null` to disable the
+	 * resource-reuse optimization. See {@link ResourceLookup}.
+	 */
+	lookupResource: ResourceLookup | null;
+}
+
+/**
+ * Looks up a previously captured sub-resource by URL.
+ *
+ * Injected by the orchestrator so that the crawler can reuse network data
+ * recorded during page rendering instead of issuing a redundant HEAD
+ * pre-flight request. Implementations must serialize the read against any
+ * pending resource writes (e.g., via the orchestrator's WriteQueue).
+ * @param urls - URL candidates to match (e.g., with and without auth credentials).
+ * @returns The recorded resource data, or `null` when no row matches.
+ */
+export type ResourceLookup = (
+	urls: readonly string[],
+) => Promise<ResourceLookupResult | null>;
+
+/**
+ * Minimal sub-resource data needed to synthesize {@link PageData}
+ * without performing a network fetch.
+ */
+export interface ResourceLookupResult {
+	/** HTTP status code of the recorded response, or `null` if unknown. */
+	status: number | null;
+
+	/** HTTP status text of the recorded response, or `null` if unknown. */
+	statusText: string | null;
+
+	/** The Content-Type header value (media type only), or `null` if unknown. */
+	contentType: string | null;
+
+	/** The Content-Length header value in bytes, or `null` if unknown. */
+	contentLength: number | null;
+
+	/** Raw HTTP response headers, or `null` if unavailable. */
+	responseHeaders: Record<string, string | string[] | undefined> | null;
 }
 
 /**

--- a/packages/@nitpicker/crawler/src/resource-row-to-lookup-result.spec.ts
+++ b/packages/@nitpicker/crawler/src/resource-row-to-lookup-result.spec.ts
@@ -1,0 +1,79 @@
+import type { DB_Resource } from './archive/types.js';
+
+import { describe, it, expect } from 'vitest';
+
+import { resourceRowToLookupResult } from './resource-row-to-lookup-result.js';
+
+/**
+ * Build a DB_Resource row with sensible defaults for tests.
+ * @param overrides - Fields to override.
+ * @returns A complete DB_Resource row.
+ */
+function createRow(overrides: Partial<DB_Resource> = {}): DB_Resource {
+	return {
+		id: 1,
+		url: 'https://example.com/image.jpg',
+		isExternal: 0,
+		status: 200,
+		statusText: 'OK',
+		contentType: 'image/jpeg',
+		contentLength: 1234,
+		compress: 0,
+		cdn: 0,
+		responseHeaders: JSON.stringify({ 'content-type': 'image/jpeg' }),
+		...overrides,
+	};
+}
+
+describe('resourceRowToLookupResult', () => {
+	it('converts a full row', () => {
+		const result = resourceRowToLookupResult(createRow());
+		expect(result).toEqual({
+			status: 200,
+			statusText: 'OK',
+			contentType: 'image/jpeg',
+			contentLength: 1234,
+			responseHeaders: { 'content-type': 'image/jpeg' },
+		});
+	});
+
+	it('parses null responseHeaders', () => {
+		const result = resourceRowToLookupResult(createRow({ responseHeaders: null }));
+		expect(result.responseHeaders).toBeNull();
+	});
+
+	it('parses the JSON string "null" as null', () => {
+		const result = resourceRowToLookupResult(createRow({ responseHeaders: 'null' }));
+		expect(result.responseHeaders).toBeNull();
+	});
+
+	it('falls back to null on malformed JSON', () => {
+		const result = resourceRowToLookupResult(createRow({ responseHeaders: '{not json' }));
+		expect(result.responseHeaders).toBeNull();
+	});
+
+	it.each([
+		['array', '["value"]'],
+		['string', '"text"'],
+		['number', '123'],
+		['boolean', 'true'],
+	])('valid JSON that is not a plain object (%s) becomes null', (_label, json) => {
+		const result = resourceRowToLookupResult(createRow({ responseHeaders: json }));
+		expect(result.responseHeaders).toBeNull();
+	});
+
+	it('passes through null metadata fields', () => {
+		const result = resourceRowToLookupResult(
+			createRow({
+				status: null,
+				statusText: null,
+				contentType: null,
+				contentLength: null,
+			}),
+		);
+		expect(result.status).toBeNull();
+		expect(result.statusText).toBeNull();
+		expect(result.contentType).toBeNull();
+		expect(result.contentLength).toBeNull();
+	});
+});

--- a/packages/@nitpicker/crawler/src/resource-row-to-lookup-result.ts
+++ b/packages/@nitpicker/crawler/src/resource-row-to-lookup-result.ts
@@ -1,0 +1,24 @@
+import type { DB_Resource } from './archive/types.js';
+import type { ResourceLookupResult } from './crawler/types.js';
+
+import { parseResponseHeaders } from './utils/object/parse-response-headers.js';
+
+/**
+ * Convert a raw `resources` table row into the minimal lookup result the
+ * crawler needs to reuse captured sub-resource data.
+ *
+ * Header parsing degrades to `null` on malformed JSON instead of throwing
+ * because a missing header set only loses fidelity — the reuse path stays
+ * valid.
+ * @param row - The raw database row.
+ * @returns The lookup result consumed by the crawler's resource-reuse hook.
+ */
+export function resourceRowToLookupResult(row: DB_Resource): ResourceLookupResult {
+	return {
+		status: row.status,
+		statusText: row.statusText,
+		contentType: row.contentType,
+		contentLength: row.contentLength,
+		responseHeaders: parseResponseHeaders(row.responseHeaders),
+	};
+}

--- a/packages/@nitpicker/crawler/src/utils/object/parse-response-headers.spec.ts
+++ b/packages/@nitpicker/crawler/src/utils/object/parse-response-headers.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseResponseHeaders } from './parse-response-headers.js';
+
+describe('parseResponseHeaders', () => {
+	it('parses a JSON object into a header record', () => {
+		expect(parseResponseHeaders('{"content-type":"image/png"}')).toEqual({
+			'content-type': 'image/png',
+		});
+	});
+
+	it('parses an empty JSON object as a valid empty record', () => {
+		expect(parseResponseHeaders('{}')).toEqual({});
+	});
+
+	it('returns null for a null column value', () => {
+		expect(parseResponseHeaders(null)).toBeNull();
+	});
+
+	it('returns null for the JSON string "null"', () => {
+		expect(parseResponseHeaders('null')).toBeNull();
+	});
+
+	it('returns null for malformed JSON', () => {
+		expect(parseResponseHeaders('{not json')).toBeNull();
+	});
+
+	it.each([
+		['array', '["value"]'],
+		['string', '"text"'],
+		['number', '123'],
+		['boolean', 'true'],
+	])('returns null for valid JSON that is not a plain object (%s)', (_label, json) => {
+		expect(parseResponseHeaders(json)).toBeNull();
+	});
+});

--- a/packages/@nitpicker/crawler/src/utils/object/parse-response-headers.ts
+++ b/packages/@nitpicker/crawler/src/utils/object/parse-response-headers.ts
@@ -1,0 +1,27 @@
+/**
+ * Parse a JSON-serialized HTTP response headers column from the archive
+ * database.
+ *
+ * The columns hold JSON produced by `JSON.stringify` at insert time; absent,
+ * malformed, or non-object JSON (the string `"null"`, arrays, primitives)
+ * degrades to `null` instead of throwing because a missing header set only
+ * loses fidelity — callers decide their own fallback (`?? {}` etc.).
+ * @param json - The raw column value.
+ * @returns The parsed header record, or `null` when absent or malformed.
+ */
+export function parseResponseHeaders(
+	json: string | null,
+): Record<string, string | string[] | undefined> | null {
+	if (json == null) {
+		return null;
+	}
+	try {
+		const parsed: unknown = JSON.parse(json);
+		if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			return null;
+		}
+		return parsed as Record<string, string | string[] | undefined>;
+	} catch {
+		return null;
+	}
+}

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -11,7 +11,10 @@
 		"hono": "4.12.2"
 	},
 	"devDependencies": {
+		"@nitpicker/analyze-main-contents": "0.9.0",
+		"@nitpicker/core": "0.9.0",
 		"@nitpicker/crawler": "0.9.0",
+		"@nitpicker/types": "0.9.0",
 		"await-event-emitter": "2.0.2",
 		"knex": "3.1.0",
 		"vitest": "4.0.18"

--- a/packages/test-server/src/__tests__/e2e/analyze-pipeline.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/analyze-pipeline.e2e.ts
@@ -1,0 +1,70 @@
+import type { Report } from '@nitpicker/types';
+
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Nitpicker } from '@nitpicker/core';
+import { Archive, CrawlerOrchestrator } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * crawl → write → analyze のクロスパッケージ統合テスト。
+ *
+ * crawler が書いた .nitpicker アーカイブ（zip 化された HTML スナップショット）を
+ * core の Nitpicker が開き、analyze プラグインの WorkerPool が
+ * `page.getHtml()`（zip ストリーミング読み取り）経由で全ページの HTML を
+ * 取得できることをエンドツーエンドで検証する。
+ */
+describe('Analyze pipeline (crawl → write → analyze)', () => {
+	let cwd: string;
+	let filePath: string;
+	let nitpicker: Nitpicker;
+
+	beforeAll(async () => {
+		cwd = path.join(os.tmpdir(), `nitpicker-analyze-e2e-${crypto.randomUUID()}`);
+		await fs.mkdir(cwd, { recursive: true });
+
+		// 1) クロールして .nitpicker を書き出す（スナップショットは zip 化される）
+		const orchestrator = await CrawlerOrchestrator.crawling(
+			['http://localhost:8010/meta/'],
+			{
+				cwd,
+				interval: 0,
+				parallels: 1,
+				image: false,
+			},
+		);
+		filePath = orchestrator.archive.filePath;
+		await orchestrator.write();
+		await orchestrator.archive.close();
+		orchestrator.garbageCollect();
+
+		// 2) core 側で開き直して analyze を実行（軽量な main-contents のみ）
+		const archive = await Archive.open({ filePath, cwd, openPluginData: true });
+		nitpicker = new Nitpicker(archive);
+		await nitpicker.analyze(['@nitpicker/analyze-main-contents']);
+	}, 240_000);
+
+	afterAll(async () => {
+		await nitpicker?.archive.close();
+		await fs.rm(cwd, { recursive: true, force: true });
+	});
+
+	it('analyze 結果のレポートがアーカイブに保存される', async () => {
+		const report = await nitpicker.archive.getData<Report>('analysis/report');
+		expect(report).toBeDefined();
+		expect(report.pageData).toBeDefined();
+		expect(Array.isArray(report.violations)).toBe(true);
+	});
+
+	it('クロールした internal ページが zip スナップショット経由で分析される', async () => {
+		const report = await nitpicker.archive.getData<Report>('analysis/report');
+		const analyzedUrls = Object.keys(report.pageData!.data);
+		// /meta/ 配下の internal ページの HTML が WorkerPool に渡り、
+		// per-URL のデータが生成されている（HTML が読めなければ 0 件になる）
+		expect(analyzedUrls.length).toBeGreaterThan(0);
+		expect(analyzedUrls).toContain('http://localhost:8010/meta/full');
+	});
+});

--- a/packages/test-server/src/__tests__/e2e/append.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/append.e2e.ts
@@ -92,6 +92,18 @@ describe('Append crawl', () => {
 		]);
 	});
 
+	it('appended pages keep their HTML snapshots after write() (zip merge)', async () => {
+		const internalPages = await accessor.getPages('internal-page');
+		// 追記クロールで取得されたページのスナップショットが write() で失われていない
+		const docsPage = internalPages.find((p) => p.url.pathname === '/scope/docs/');
+		expect(docsPage).toBeDefined();
+		await expect(docsPage!.getHtml()).resolves.toBeTruthy();
+		// 既存（1回目クロール）のスナップショットも維持されている
+		const blogPage = internalPages.find((p) => p.url.pathname === '/scope/blog/');
+		expect(blogPage).toBeDefined();
+		await expect(blogPage!.getHtml()).resolves.toBeTruthy();
+	});
+
 	it('removes the .bak backup file once the append succeeds', async () => {
 		const exists = await fs
 			.stat(filePath + '.bak')

--- a/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { type CrawlResult, cleanup, crawl } from './helpers.js';
+
+describe('Resource reuse', () => {
+	let result: CrawlResult;
+	let requests: { method: string; path: string }[];
+
+	beforeAll(async () => {
+		// 共有サーバーの観測ログを先行テストの蓄積からリセットする
+		// （リセットに失敗すると完全一致アサーションが壊れるため必ず成功を確認）
+		const reset = await fetch('http://localhost:8010/resource-reuse/__stats', {
+			method: 'DELETE',
+		});
+		if (!reset.ok) {
+			throw new Error(`__stats reset failed: ${reset.status}`);
+		}
+		result = await crawl(['http://localhost:8010/resource-reuse/']);
+		const res = await fetch('http://localhost:8010/resource-reuse/__stats');
+		requests = await res.json();
+	}, 120_000);
+
+	afterAll(async () => {
+		await cleanup(result);
+	});
+
+	it('サブリソースとして取得済みの直リンク画像には HEAD が飛ばない（レンダリング時の1回のみ）', () => {
+		const counted = requests.filter((r) => r.path === '/resource-reuse/counted.png');
+		expect(counted).toHaveLength(1);
+		expect(counted[0]!.method).toBe('GET');
+	});
+
+	it('再利用された画像も pages に記録される', async () => {
+		const pages = await result.accessor.getPages();
+		const page = pages.find((p) => p.url.pathname === '/resource-reuse/counted.png');
+		expect(page).toBeDefined();
+		expect(page!.status).toBe(200);
+		expect(page!.contentType).toBe('image/png');
+	});
+
+	it('再利用された画像は resources にも記録される', async () => {
+		const resources = await result.accessor.getResources();
+		const resource = resources.find((r) => r.url.includes('/resource-reuse/counted.png'));
+		expect(resource).toBeDefined();
+		expect(resource!.status).toBe(200);
+		expect(resource!.contentType).toBe('image/png');
+	});
+
+	it('サブリソースに無い直リンク画像は従来どおり HEAD でフォールバックする', () => {
+		const uncounted = requests.filter((r) => r.path === '/resource-reuse/uncounted.png');
+		expect(uncounted).toHaveLength(1);
+		expect(uncounted[0]!.method).toBe('HEAD');
+	});
+
+	it('フォールバックした画像も pages に記録される', async () => {
+		const pages = await result.accessor.getPages();
+		const page = pages.find((p) => p.url.pathname === '/resource-reuse/uncounted.png');
+		expect(page).toBeDefined();
+		expect(page!.status).toBe(200);
+		expect(page!.contentType).toBe('image/png');
+	});
+
+	it('リダイレクトするサブリソース（非2xx行）は再利用せず HEAD でフォールバックする', () => {
+		const redirected = requests.filter(
+			(r) => r.path === '/resource-reuse/redirected.png',
+		);
+		// 1回目: ブラウザレンダリング時の GET（301 を観測）
+		// 2回目: 直リンク処理時の HEAD フォールバック
+		expect(redirected.map((r) => r.method)).toEqual(['GET', 'HEAD']);
+	});
+
+	it('リダイレクト画像の pages 行はリダイレクト追跡済みの最終ステータスを持つ', async () => {
+		const pages = await result.accessor.getPages();
+		const page = pages.find((p) => p.url.pathname === '/resource-reuse/redirected.png');
+		expect(page).toBeDefined();
+		expect(page!.status).toBe(200);
+		expect(page!.contentType).toBe('image/png');
+	});
+
+	it('external サブリソース（127.0.0.1）への直リンクも再利用され HEAD が飛ばない', () => {
+		const ext = requests.filter((r) => r.path === '/resource-reuse/ext.png');
+		expect(ext.map((r) => r.method)).toEqual(['GET']);
+	});
+
+	it('再利用された external 画像は isTarget=false で pages に記録される', async () => {
+		const pages = await result.accessor.getPages();
+		const page = pages.find(
+			(p) =>
+				p.url.hostname === '127.0.0.1' && p.url.pathname === '/resource-reuse/ext.png',
+		);
+		expect(page).toBeDefined();
+		expect(page!.status).toBe(200);
+		expect(page!.contentType).toBe('image/png');
+		expect(page!.isTarget).toBe(false);
+	});
+});
+
+describe('Resource reuse (list mode)', () => {
+	let result: CrawlResult;
+
+	beforeAll(async () => {
+		// list mode (recursive: false): the root page is fully rendered, and every
+		// discovered anchor — internal ones included — is queued as metadataOnly
+		result = await crawl(['http://localhost:8010/resource-reuse/'], { list: true });
+	}, 120_000);
+
+	afterAll(async () => {
+		await cleanup(result);
+	});
+
+	it('metadataOnly の internal 画像も再利用され isTarget=false で記録される', async () => {
+		const pages = await result.accessor.getPages();
+		const page = pages.find((p) => p.url.pathname === '/resource-reuse/counted.png');
+		expect(page).toBeDefined();
+		expect(page!.status).toBe(200);
+		expect(page!.contentType).toBe('image/png');
+		expect(page!.isTarget).toBe(false);
+	});
+});

--- a/packages/test-server/src/routes/resource-reuse.ts
+++ b/packages/test-server/src/routes/resource-reuse.ts
@@ -1,0 +1,97 @@
+import type { Context, Hono } from 'hono';
+
+/**
+ * A 1x1 transparent PNG used as the image payload.
+ */
+const PNG_1X1 = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+	'base64',
+);
+
+/**
+ * A single observed request to one of the counted image endpoints.
+ */
+interface ObservedRequest {
+	/** The HTTP method of the request (e.g., `"GET"`, `"HEAD"`). */
+	method: string;
+	/** The request path. */
+	path: string;
+}
+
+/**
+ * Requests observed by the counted image endpoints, in arrival order.
+ * Exposed via `/resource-reuse/__stats` for E2E assertions.
+ */
+const observedRequests: ObservedRequest[] = [];
+
+/**
+ * Registers routes for testing the resource-reuse optimization: queued URLs
+ * that were already captured as sub-resources during page rendering must not
+ * receive a redundant HEAD pre-flight.
+ *
+ * Each image endpoint records the method of every incoming request so that
+ * tests can assert exactly which requests were made.
+ * @param app - The Hono application instance to register routes on.
+ */
+export function resourceReuseRoutes(app: Hono) {
+	app.get('/resource-reuse/', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Resource Reuse</title></head><body>' +
+				// Reuse case: rendered as a sub-resource AND directly linked
+				'<img src="/resource-reuse/counted.png" alt="counted" width="1" height="1">' +
+				'<a href="/resource-reuse/counted.png">counted image</a>' +
+				// Fallback case: directly linked only — never a sub-resource
+				'<a href="/resource-reuse/uncounted.png">uncounted image</a>' +
+				// Redirect case: sub-resource recorded as 301 — must fall back
+				'<img src="/resource-reuse/redirected.png" alt="redirected" width="1" height="1">' +
+				'<a href="/resource-reuse/redirected.png">redirected image</a>' +
+				// External reuse case: 127.0.0.1 is a different hostname (= external
+				// scope) but the same server — rendered AND directly linked
+				'<img src="http://127.0.0.1:8010/resource-reuse/ext.png" alt="external" width="1" height="1">' +
+				'<a href="http://127.0.0.1:8010/resource-reuse/ext.png">external image</a>' +
+				'</body></html>',
+		),
+	);
+
+	app.on(['GET', 'HEAD'], '/resource-reuse/counted.png', servePng);
+	app.on(['GET', 'HEAD'], '/resource-reuse/uncounted.png', servePng);
+	app.on(['GET', 'HEAD'], '/resource-reuse/ext.png', servePng);
+	app.on(['GET', 'HEAD'], '/resource-reuse/redirected.png', (c) => {
+		recordRequest(c);
+		return c.redirect('/resource-reuse/actual.png', 301);
+	});
+	app.on(['GET', 'HEAD'], '/resource-reuse/actual.png', servePng);
+
+	app.get('/resource-reuse/__stats', (c) => c.json(observedRequests));
+	// Reset hook: the server instance is shared across all E2E files, so tests
+	// must clear the log before crawling to keep their exact-match assertions
+	// independent of earlier runs.
+	app.delete('/resource-reuse/__stats', (c) => {
+		observedRequests.length = 0;
+		return c.json({ ok: true });
+	});
+}
+
+/**
+ * Record the incoming request and serve the 1x1 PNG payload.
+ * @param c - The Hono request context.
+ * @returns The PNG response.
+ */
+function servePng(c: Context) {
+	recordRequest(c);
+	return c.body(new Uint8Array(PNG_1X1), 200, {
+		'Content-Type': 'image/png',
+		'Content-Length': String(PNG_1X1.byteLength),
+	});
+}
+
+/**
+ * Append the request's method and path to the observed-request log.
+ * @param c - The Hono request context.
+ */
+function recordRequest(c: Context) {
+	observedRequests.push({
+		method: c.req.method,
+		path: new URL(c.req.url).pathname,
+	});
+}

--- a/packages/test-server/src/server.ts
+++ b/packages/test-server/src/server.ts
@@ -11,6 +11,7 @@ import { optionsRoutes } from './routes/options.js';
 import { paginationRoutes } from './routes/pagination.js';
 import { recursiveRoutes } from './routes/recursive.js';
 import { redirectRoutes } from './routes/redirect.js';
+import { resourceReuseRoutes } from './routes/resource-reuse.js';
 import { scopeRoutes } from './routes/scope.js';
 import { scrollJackRoutes } from './routes/scroll-jack.js';
 
@@ -31,6 +32,7 @@ export function createApp() {
 	scopeRoutes(app);
 	paginationRoutes(app);
 	scrollJackRoutes(app);
+	resourceReuseRoutes(app);
 	return app;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15530,7 +15530,10 @@ __metadata:
   resolution: "test-server@workspace:packages/test-server"
   dependencies:
     "@hono/node-server": "npm:1.19.9"
+    "@nitpicker/analyze-main-contents": "npm:0.9.0"
+    "@nitpicker/core": "npm:0.9.0"
     "@nitpicker/crawler": "npm:0.9.0"
+    "@nitpicker/types": "npm:0.9.0"
     await-event-emitter: "npm:2.0.2"
     hono: "npm:4.12.2"
     knex: "npm:3.1.0"


### PR DESCRIPTION
## Summary

- **Resource reuse**: skip the redundant HEAD pre-flight for queued URLs already captured as sub-resources during page rendering — PageData is synthesized from the resources table (2xx, non-HTML rows only; everything else falls back to HEAD)
- **Streaming snapshot reads**: `getHtmlOfPage` no longer physically extracts `snapshot-html.zip` per call; the zip central directory is parsed once, cached per path, and each page read inflates only its own entry (~20x faster single reads, zero disk writes)
- **Append data-loss fix**: `write()` used to skip zipping when the zip already existed and then delete the raw snapshot dir, permanently losing every HTML snapshot written during an append session — the zip's entries are now merged into the dir (existing files win) before re-zipping
- **HTML detection unified**: `isHtmlContentType` (case-insensitive + trim) is now the single source of truth; `Page.isPage()` and the link list delegate to it, so `text/HTML` responses no longer diverge between scraping and `completePages` counting
- **Robustness**: a failed `addError` write now rejects `crawling()` instead of dying as an unhandled rejection; `Page.responseHeaders` returns the honest union type (array values like `set-cookie` are no longer cast away)
- **analyze-main-contents fix**: pages without a detectable main content element now report zero counts instead of silently vanishing from the report (the no-main branch was missing the `page` wrapper; the old spec had codified the malformed shape)

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn build` — 13 packages
- [x] `yarn test` — 1216 unit tests (incl. new specs for streaming reads, zip merge, cache invalidation/eviction, HTML detection divergence, addError rejection, multi-value headers)
- [x] e2e suite (21 files / 86 tests) — incl. new `resource-reuse.e2e.ts`, append snapshot-survival assertions, and a crawl→write→analyze pipeline e2e that runs a real plugin against a zipped archive (this e2e is what caught the analyze-main-contents bug)
- [x] Mutation-verified: reverting the `addError` catch or the cache invalidation makes the corresponding new tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)