### PR TITLE
feat(crawler): prioritise likely-HTML URLs in the crawl queue

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ flowchart TD
 
     Deal --> RobotsCheck["robots.txt チェック（RobotsChecker）"]
     RobotsCheck --> Checks["除外チェック / fetchExternal チェック"]
-    Deal --> Push["push() で発見した URL を動的にキューに追加"]
+    Deal --> Push["発見した URL を動的にキューに追加<br/>（HTML らしい URL は unshift で先頭へ優先 / それ以外は push で末尾へ）"]
 
     Deal --> Beholder["Scraper（@d-zero/beholder）<br/>インプロセス実行"]
     Beholder --> Head["HEAD リクエスト（User-Agent 付き）"]
@@ -136,6 +136,8 @@ crawler/src/
 │   ├── should-skip-url.ts      # URL 除外判定
 │   ├── find-scope-entry.ts     # スコープ判定の単一エントリポイント（hostname+port+path で最深一致を返す or null）
 │   ├── is-external-url.ts      # 外部 URL 判定（findScopeEntry の薄ラッパ）
+│   ├── is-likely-html-url.ts   # URL 拡張子から HTML らしさを判定（キュー優先度用、HEAD 前）
+│   ├── partition-urls-by-html.ts    # URL 群を HTML / 非 HTML に分割（unshift / push 振り分け）
 │   ├── inject-scope-auth.ts    # スコープ認証注入（matchedScope を直接受け取る）
 │   ├── handle-scrape-end.ts    # スクレイプ成功ハンドラ
 │   ├── handle-ignore-and-skip.ts    # スキップハンドラ
@@ -299,9 +301,14 @@ PageData を合成する。
 - `@d-zero/dealer` の `deal()` がスケジューリングと並列制御を担当
 - `interval` オプションでリクエスト間の待機時間を設定可能
 - スクレイピングはインプロセス（`@d-zero/beholder`）で実行。各 URL ごとにブラウザを起動・終了
-- `push()` で発見した新 URL を動的にキューに追加
-- `onPush` コールバックで `withoutHashAndAuth` による重複排除
+- 発見した新 URL を動的にキューに追加する際、HTML らしい URL は `unshift()` でキュー先頭へ優先投入し、それ以外（画像・PDF・CSS/JS 等）は `push()` で末尾へ追加する。これにより HTML ページのクロールがアセット/ドキュメント取得より先に進む。バッチ（予測ページネーション等）は `partitionUrlsByHtml()`（`crawler/partition-urls-by-html.ts`）で HTML 群と非 HTML 群に分割し、HTML 群を 1 回の `unshift(...html)` で投入することで昇順を維持する（1 件ずつ unshift すると逆順になるため）
+- HTML 判定は HEAD/GET 前の URL のみで行うため、実 `Content-Type` ではなく `isLikelyHtmlUrl()`（`crawler/is-likely-html-url.ts`）の拡張子ヒューリスティックを使う: 拡張子なし・ディレクトリ型 URL（`/`, `/about/`）と末尾ドット URL、`.html`/`.htm`/`.php`/`.aspx`/`.jsp`/`.ashx` 等を HTML 扱い、非 HTTP（`mailto:` 等）と `.jpg`/`.pdf`/`.css`/`.js` 等を非 HTML 扱い。**誤判定しても fetch 順が変わるだけで網羅性・正確性には影響しない**
+- `onPush` コールバックで `withoutHashAndAuth` による重複排除（`push()` / `unshift()` どちらも通る）
 - `signal` オプションで `AbortSignal` を渡し、中断時に新規ワーカーの起動を停止
+
+> **更新手順（HTML 優先判定の拡張）**: HTML を返す拡張子が取りこぼされている場合は `crawler/is-likely-html-url.ts` の `HTML_EXTENSIONS` セット（ドット付きキー）に追記し、cspell が未知語を弾く拡張子は `cspell.json` の「HTML page file extensions」ブロックにも追加する。判定ロジックの単体テストは `is-likely-html-url.spec.ts`、優先投入の配線テストは `crawler.spec.ts` の「discovered-URL queue prioritisation」、分割の単体テストは `partition-urls-by-html.spec.ts`。
+>
+> **`unshift` API の所在**: キュー先頭への優先投入は `@d-zero/dealer` の `deal()` setup コールバック第 6 引数 `unshift` に依存する（**1.9.0 で追加**）。優先制御の挙動を変える場合は dealer 側（`d-zero-dev/tools` の `packages/@d-zero/dealer`、`Dealer.unshift` / `deal.js`）を参照すること。
 
 ### クロール中断メカニズム
 
@@ -977,5 +984,5 @@ Nitpicker は D-ZERO が公開する以下の外部パッケージに依存し�
 ### バージョン更新時の注意
 
 - **`@d-zero/beholder`**: `ScrapeResult` の型が変わると crawler 全体に影響
-- **`@d-zero/dealer`**: `deal()` の API が変わると crawler の並列処理に影響。`Lanes` の型が変わると core・cli・report-google-sheets の進捗表示に影響
+- **`@d-zero/dealer`**: `deal()` の API が変わると crawler の並列処理に影響。`Lanes` の型が変わると core・cli・report-google-sheets の進捗表示に影響。**crawler は 1.9.0 で追加された `deal()` setup コールバックの第 6 引数 `unshift`（キュー先頭への優先投入）に依存するため、1.9.0 未満へのダウングレード不可**。ソースは `d-zero-dev/tools` の `packages/@d-zero/dealer`
 - **`@d-zero/shared`**: サブパスエクスポートの追加・削除に注意。`@d-zero/shared/parse-url` 形式でインポートすること

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ CrawlerOrchestrator.crawling(urls, options)
     → 各 URL: puppeteer.launch() → Scraper.scrapeStart(page, ...)
       → ScrapeResult を戻り値で返却
     → LinkList.done() + WriteQueue 経由で Archive にページデータ保存
-    → push() で発見した新 URL を動的にキューに追加
+    → 発見した新 URL を動的にキューに追加（HTML らしい URL は unshift で先頭へ優先、それ以外は push で末尾へ。判定は URL の拡張子ヒューリスティック isLikelyHtmlUrl）
   → crawlEnd 時に WriteQueue.drain() で未完了の書き込みを待機
   → CrawlerOrchestrator.write()（tmpDir を .nitpicker tar に圧縮）
 ```

--- a/cspell.json
+++ b/cspell.json
@@ -81,6 +81,16 @@
 
 		// CI / GitHub Actions (Chromium sandbox on ubuntu runners)
 		"apparmor",
-		"userns"
+		"userns",
+
+		// HTML page file extensions (isLikelyHtmlUrl heuristic)
+		"xhtml",
+		"shtml",
+		"phtml",
+		"mhtml",
+		"jspx",
+		"ashx",
+		"jsf",
+		"htaccess"
 	]
 }

--- a/packages/@nitpicker/cli/package.json
+++ b/packages/@nitpicker/cli/package.json
@@ -31,7 +31,7 @@
 		"clean": "tsc --build --clean"
 	},
 	"dependencies": {
-		"@d-zero/dealer": "1.7.0",
+		"@d-zero/dealer": "1.9.0",
 		"@d-zero/readtext": "1.1.19",
 		"@d-zero/roar": "2.1.0",
 		"@d-zero/shared": "0.20.1",

--- a/packages/@nitpicker/core/package.json
+++ b/packages/@nitpicker/core/package.json
@@ -27,7 +27,7 @@
 		"clean": "tsc --build --clean"
 	},
 	"dependencies": {
-		"@d-zero/dealer": "1.7.0",
+		"@d-zero/dealer": "1.9.0",
 		"@d-zero/shared": "0.20.1",
 		"@nitpicker/crawler": "0.9.0",
 		"@nitpicker/types": "0.9.0",

--- a/packages/@nitpicker/crawler/package.json
+++ b/packages/@nitpicker/crawler/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"@d-zero/beholder": "2.1.2",
-		"@d-zero/dealer": "1.7.0",
+		"@d-zero/dealer": "1.9.0",
 		"@d-zero/fs": "0.2.2",
 		"@d-zero/shared": "0.20.1",
 		"ansi-colors": "4.1.3",

--- a/packages/@nitpicker/crawler/src/crawler/crawler.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.spec.ts
@@ -1,4 +1,5 @@
 import type { CrawlerEventTypes } from './types.js';
+import type { ExURL } from '@d-zero/shared/parse-url';
 
 import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -35,15 +36,24 @@ vi.mock('./robots-checker.js', () => {
 /**
  * Configure the mocked deal() to synchronously drive every queued URL
  * through the crawler's worker callback, mirroring the dealer contract.
+ *
+ * The `push` / `unshift` queue callbacks handed to the factory are shared spies
+ * (one pair per crawl, as the real dealer binds them to a single queue) so tests
+ * can assert how newly-discovered URLs are routed (HTML → front, asset → tail).
+ * URLs added via the spies are not re-fed into the loop — the mock only drives
+ * the initial `items`, which is sufficient to observe the routing decision.
+ * @returns The shared `push` and `unshift` spies passed to the worker factory.
  */
 async function driveDeal() {
+	const push = vi.fn(async () => {});
+	const unshift = vi.fn(async () => {});
 	const { deal } = await import('@d-zero/dealer');
 	vi.mocked(deal).mockImplementation(async (items, factory) => {
 		for (const [index, item] of (items as unknown[]).entries()) {
 			const noop = () => {};
-			const noopAsync = async () => {};
+			// factory signature: (process, update, index, setLineHeader, push, unshift)
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- deal factory signature is complex; cast is intentional in test
-			const workFn = (factory as Function)(item, noop, index, noop, noopAsync) as
+			const workFn = (factory as Function)(item, noop, index, noop, push, unshift) as
 				| (() => Promise<void>)
 				| undefined;
 			if (workFn) {
@@ -51,6 +61,7 @@ async function driveDeal() {
 			}
 		}
 	});
+	return { push, unshift };
 }
 
 /**
@@ -401,6 +412,108 @@ describe('Crawler', () => {
 			expect(errors).toHaveLength(0);
 			expect(fetchSpy).toHaveBeenCalledTimes(1);
 			expect(pages[0]!.result.status).toBe(200);
+		});
+	});
+
+	describe('discovered-URL queue prioritisation', () => {
+		/**
+		 * Build a minimal non-HTML scrape result whose anchorList is returned by
+		 * the HEAD pre-flight. A non-HTML content type makes #scrapePage skip the
+		 * browser and return the pre-flight result verbatim, so the supplied
+		 * anchors flow into handleScrapeEnd → enqueue without launching Puppeteer.
+		 * @param anchors - Anchors to expose on the scraped page.
+		 * @returns A PageData-shaped object for fetchDestination to resolve with.
+		 */
+		function nonHtmlResultWithAnchors(anchors: { href: ExURL; textContent: string }[]) {
+			return {
+				url: parseUrl('https://example.com/feed.xml')!,
+				redirectPaths: [],
+				isTarget: false,
+				isExternal: false,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'application/xml',
+				contentLength: 0,
+				responseHeaders: {},
+				meta: { title: '' },
+				anchorList: anchors,
+				imageList: [],
+				html: '',
+				isSkipped: false,
+			};
+		}
+
+		it('HTML らしい発見 URL は unshift、アセット URL は push に振り分けられる', async () => {
+			const { push, unshift } = await driveDeal();
+			const { default: Crawler } = await import('./crawler.js');
+
+			const htmlAnchor = parseUrl('https://example.com/about')!;
+			const assetAnchor = parseUrl('https://example.com/doc.pdf')!;
+
+			const fetchDestMod = await import('./fetch-destination.js');
+			vi.spyOn(fetchDestMod, 'fetchDestination').mockResolvedValue(
+				nonHtmlResultWithAnchors([
+					{ href: htmlAnchor, textContent: 'About' },
+					{ href: assetAnchor, textContent: 'PDF' },
+				]) as Awaited<ReturnType<typeof fetchDestMod.fetchDestination>>,
+			);
+
+			const crawler = new Crawler(defaultOptions);
+			let crawlEndEmitted = false;
+			crawler.on('crawlEnd', () => {
+				crawlEndEmitted = true;
+			});
+
+			crawler.start([parseUrl('https://example.com/feed.xml')!]);
+
+			await vi.waitFor(() => {
+				expect(crawlEndEmitted).toBe(true);
+			});
+
+			expect(unshift).toHaveBeenCalledTimes(1);
+			expect(unshift).toHaveBeenCalledWith(htmlAnchor);
+			expect(push).toHaveBeenCalledTimes(1);
+			expect(push).toHaveBeenCalledWith(assetAnchor);
+		});
+
+		it('予測ページネーション URL は1回の unshift で昇順のままバッチ投入される', async () => {
+			const { unshift } = await driveDeal();
+			const { default: Crawler } = await import('./crawler.js');
+
+			// Two consecutive numeric anchors trigger pagination prediction.
+			const page2 = parseUrl('https://example.com/page/2')!;
+			const page3 = parseUrl('https://example.com/page/3')!;
+
+			const fetchDestMod = await import('./fetch-destination.js');
+			vi.spyOn(fetchDestMod, 'fetchDestination').mockResolvedValue(
+				nonHtmlResultWithAnchors([
+					{ href: page2, textContent: 'Page 2' },
+					{ href: page3, textContent: 'Page 3' },
+				]) as Awaited<ReturnType<typeof fetchDestMod.fetchDestination>>,
+			);
+
+			// parallels: 3 → three predicted URLs (page/4, page/5, page/6).
+			const crawler = new Crawler({ ...defaultOptions, parallels: 3 });
+			let crawlEndEmitted = false;
+			crawler.on('crawlEnd', () => {
+				crawlEndEmitted = true;
+			});
+
+			crawler.start([parseUrl('https://example.com/feed.xml')!]);
+
+			await vi.waitFor(() => {
+				expect(crawlEndEmitted).toBe(true);
+			});
+
+			// The predicted batch must arrive as ONE unshift call (not three reversed
+			// individual calls), preserving ascending page order at the queue front.
+			const batchCall = unshift.mock.calls.find((args) => args.length === 3);
+			expect(batchCall).toBeDefined();
+			expect((batchCall as unknown as ExURL[]).map((u) => u.withoutHashAndAuth)).toEqual([
+				'https://example.com/page/4',
+				'https://example.com/page/5',
+				'https://example.com/page/6',
+			]);
 		});
 	});
 

--- a/packages/@nitpicker/crawler/src/crawler/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.ts
@@ -33,6 +33,7 @@ import { injectScopeAuth } from './inject-scope-auth.js';
 import { isHtmlContentType } from './is-html-content-type.js';
 import LinkList from './link-list.js';
 import { linkToPageData } from './link-to-page-data.js';
+import { partitionUrlsByHtml } from './partition-urls-by-html.js';
 import { protocolAgnosticKey } from './protocol-agnostic-key.js';
 import { resourceToPageData } from './resource-to-page-data.js';
 import { RobotsChecker } from './robots-checker.js';
@@ -286,7 +287,9 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 	 * - `error`: Creates a fallback PageData, marks as done, and emits `error`.
 	 * @param result - The scrape result from beholder
 	 * @param url - The URL that was scraped
-	 * @param push - Dealer's push callback to enqueue newly discovered URLs
+	 * @param enqueue - Callback to enqueue newly discovered URLs into the dealer
+	 *   queue, prioritising likely-HTML URLs to the front (see {@link partitionUrlsByHtml}).
+	 *   Accepts a batch so a group of URLs (e.g. predicted pagination) keeps its order.
 	 * @param paginationState - Mutable state for predicted pagination cascade prevention
 	 * @param paginationState.lastPushedUrl
 	 * @param paginationState.lastPushedWasPredicted
@@ -295,7 +298,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 	#handleResult(
 		result: ScrapeResult,
 		url: ExURL,
-		push: (...items: ExURL[]) => Promise<void>,
+		enqueue: (...urls: ExURL[]) => Promise<void>,
 		paginationState?: { lastPushedUrl: string | null; lastPushedWasPredicted: boolean },
 		concurrency?: number,
 	) {
@@ -309,7 +312,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 					this.#options,
 					(newUrl, opts) => {
 						this.#linkList.add(newUrl, opts);
-						void push(newUrl);
+						void enqueue(newUrl);
 
 						// Predicted pagination detection
 						if (!paginationState || !concurrency) return;
@@ -339,13 +342,17 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 									newUrl.withoutHashAndAuth,
 									concurrency,
 								);
+								const specUrls: ExURL[] = [];
 								for (const specUrlStr of urls) {
 									const specUrl = parseUrl(specUrlStr, this.#options);
 									if (specUrl) {
 										this.#linkList.add(specUrl, { predicted: true });
-										void push(specUrl);
+										specUrls.push(specUrl);
 									}
 								}
+								// Enqueue as one batch so ascending page order is kept
+								// at the front of the queue (see enqueue in #runDeal).
+								if (specUrls.length > 0) void enqueue(...specUrls);
 								paginationState.lastPushedUrl = newUrl.withoutHashAndAuth;
 								paginationState.lastPushedWasPredicted = true;
 								return;
@@ -543,7 +550,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 
 		await deal(
 			initialUrls,
-			(url, update, _index, setLineHeader, push) => {
+			(url, update, _index, setLineHeader, push, unshift) => {
 				const matchedScope = findScopeEntry(url, this.#scope, this.#options);
 				const isExternal = matchedScope === null;
 				const urlText = isExternal ? c.dim(url.href) : c.cyan(url.href);
@@ -553,6 +560,20 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 				}
 				this.#linkList.add(url);
 				this.#linkList.progress(url);
+
+				// Likely-HTML URLs jump to the front of the queue (unshift) so page
+				// crawling advances ahead of asset/document fetches; everything else
+				// is appended (push). partitionUrlsByHtml splits the batch by the
+				// URL-only heuristic. Variadic so a batch (e.g. predicted pagination)
+				// keeps its order: a single unshift(...html) preserves ascending order
+				// at the front, whereas unshifting one-by-one would reverse it.
+				const enqueue = (...newUrls: ExURL[]): Promise<void> => {
+					const [html, other] = partitionUrlsByHtml(newUrls);
+					const ops: Promise<void>[] = [];
+					if (html.length > 0) ops.push(unshift(...html));
+					if (other.length > 0) ops.push(push(...other));
+					return Promise.all(ops).then(() => {});
+				};
 
 				return async () => {
 					const log = createTimedUpdate(update, this.#options.verbose);
@@ -610,7 +631,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 						}
 
 						log('Saving results%dots%');
-						this.#handleResult(result, url, push, paginationState, concurrency);
+						this.#handleResult(result, url, enqueue, paginationState, concurrency);
 						this.#handleResources(result.resources);
 						log(formatResultSummary(result));
 					} catch (error) {

--- a/packages/@nitpicker/crawler/src/crawler/is-likely-html-url.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/is-likely-html-url.spec.ts
@@ -1,0 +1,96 @@
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { describe, it, expect } from 'vitest';
+
+import { isLikelyHtmlUrl } from './is-likely-html-url.js';
+
+describe('isLikelyHtmlUrl', () => {
+	it.each([
+		'https://example.com/',
+		'https://example.com/about/',
+		'https://example.com/blog',
+		'http://example.com/path/to/page',
+	])('returns true for extensionless / directory-style URL %s', (raw) => {
+		expect(isLikelyHtmlUrl(parseUrl(raw)!)).toBe(true);
+	});
+
+	it('returns true for a bare trailing-dot URL (extname === ".")', () => {
+		const url = parseUrl('https://example.com/index.')!;
+		// Guard the assumption the branch depends on: parse-url surfaces "." here.
+		expect(url.extname).toBe('.');
+		expect(isLikelyHtmlUrl(url)).toBe(true);
+	});
+
+	it.each([
+		'https://example.com/index.html',
+		'https://example.com/index.htm',
+		'https://example.com/page.xhtml',
+		'https://example.com/page.shtml',
+		'https://example.com/page.mhtml',
+		'https://example.com/page.php',
+		'https://example.com/legacy.php5',
+		'https://example.com/page.asp',
+		'https://example.com/page.aspx',
+		'https://example.com/handler.ashx',
+		'https://example.com/page.jsp',
+		'https://example.com/page.jsf',
+		'https://example.com/page.cfm',
+		'https://example.com/handler.do',
+	])('returns true for known HTML extension %s', (raw) => {
+		expect(isLikelyHtmlUrl(parseUrl(raw)!)).toBe(true);
+	});
+
+	it.each([
+		['https://example.com/PAGE.HTML', true],
+		['https://example.com/LEGACY.PHP5', true],
+		['https://example.com/PHOTO.JPG', false],
+	])('classifies %s case-insensitively', (raw, expected) => {
+		expect(isLikelyHtmlUrl(parseUrl(raw)!)).toBe(expected);
+	});
+
+	it.each([
+		'https://example.com/page.php?id=1',
+		'https://example.com/search?q=foo',
+		'https://example.com/index.html?ref=nav',
+	])('classifies query-string HTML URL %s by its path extension', (raw) => {
+		expect(isLikelyHtmlUrl(parseUrl(raw)!)).toBe(true);
+	});
+
+	it('classifies a query-string non-HTML URL by its path extension', () => {
+		expect(isLikelyHtmlUrl(parseUrl('https://example.com/data.json?v=2')!)).toBe(false);
+	});
+
+	it.each([
+		'https://example.com/photo.jpg',
+		'https://example.com/doc.pdf',
+		'https://example.com/style.css',
+		'https://example.com/app.js',
+		'https://example.com/data.json',
+		'https://example.com/archive.zip',
+		'https://example.com/feed.xml',
+	])('returns false for non-HTML asset/document URL %s', (raw) => {
+		expect(isLikelyHtmlUrl(parseUrl(raw)!)).toBe(false);
+	});
+
+	it('treats a compound extension by its last segment (.tar.gz → non-HTML)', () => {
+		const url = parseUrl('https://example.com/archive.tar.gz')!;
+		expect(url.extname).toBe('.gz');
+		expect(isLikelyHtmlUrl(url)).toBe(false);
+	});
+
+	it('treats a dotfile with no real extension as HTML (extname === null)', () => {
+		const url = parseUrl('https://example.com/.htaccess')!;
+		expect(url.extname).toBeNull();
+		expect(isLikelyHtmlUrl(url)).toBe(true);
+	});
+
+	it.each(['mailto:hello@example.com', 'tel:+81312345678'])(
+		'returns false for non-HTTP URL %s',
+		(raw) => {
+			expect(isLikelyHtmlUrl(parseUrl(raw)!)).toBe(false);
+		},
+	);
+
+	it('returns false for a non-HTTP URL even when it carries an HTML-looking extension', () => {
+		expect(isLikelyHtmlUrl(parseUrl('ftp://example.com/page.html')!)).toBe(false);
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/is-likely-html-url.ts
+++ b/packages/@nitpicker/crawler/src/crawler/is-likely-html-url.ts
@@ -1,0 +1,68 @@
+import type { ExURL } from '@d-zero/shared/parse-url';
+
+/**
+ * File extensions (lowercased, leading dot included) that typically denote a
+ * document served as `text/html`. Both static pages (`.html`) and the common
+ * server-side template / handler extensions (`.php`, `.aspx`, `.jsp`, `.ashx`,
+ * `.jsf` …) are listed because they usually serve an HTML page.
+ *
+ * A few entries (`.cgi`, `.do`, `.action`) are ambiguous — they sometimes
+ * return JSON or binary — but are kept here because a misclassification only
+ * changes fetch order, never correctness (see {@link isLikelyHtmlUrl}).
+ *
+ * Keys keep the leading dot so they can be compared directly against
+ * `ExURL.extname` (Node `Path.extname` output) without stripping it.
+ */
+const HTML_EXTENSIONS: ReadonlySet<string> = new Set([
+	'.html',
+	'.htm',
+	'.xhtml',
+	'.shtml',
+	'.mhtml',
+	'.php',
+	'.php3',
+	'.php4',
+	'.php5',
+	'.phtml',
+	'.asp',
+	'.aspx',
+	'.ashx',
+	'.jsp',
+	'.jspx',
+	'.jsf',
+	'.cfm',
+	'.cgi',
+	'.do',
+	'.action',
+]);
+
+/**
+ * Heuristically decide whether a discovered URL is likely to resolve to an
+ * HTML page, based solely on the URL itself.
+ *
+ * WHY URL-only: this runs at enqueue time — before any HEAD/GET — so the actual
+ * `Content-Type` is unknown. The crawler uses the result to prioritise the
+ * dealer queue (likely-HTML URLs are `unshift`ed to the front so page crawling
+ * advances ahead of asset/document fetches), so a heuristic is acceptable: a
+ * misclassification only changes fetch order, never correctness.
+ *
+ * Classification rules:
+ * - Non-HTTP URLs (`mailto:`, `tel:`, …) are never HTML pages.
+ * - Extensionless / directory-style URLs (`/`, `/about/`), and bare trailing-dot
+ *   URLs (`/index.`, whose `extname` is `"."`), are treated as HTML — these are
+ *   the overwhelmingly common shape for navigable pages.
+ * - URLs whose extension is in {@link HTML_EXTENSIONS} are HTML; every other
+ *   extension (`.jpg`, `.pdf`, `.css`, `.js`, …) is treated as non-HTML.
+ * @param url - The parsed URL to classify.
+ * @returns `true` when the URL is likely an HTML page.
+ */
+export function isLikelyHtmlUrl(url: ExURL): boolean {
+	if (!url.isHTTP) {
+		return false;
+	}
+	const extname = url.extname;
+	if (!extname || extname === '.') {
+		return true;
+	}
+	return HTML_EXTENSIONS.has(extname.toLowerCase());
+}

--- a/packages/@nitpicker/crawler/src/crawler/partition-urls-by-html.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/partition-urls-by-html.spec.ts
@@ -1,0 +1,84 @@
+import type { ExURL } from '@d-zero/shared/parse-url';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { describe, it, expect } from 'vitest';
+
+import { partitionUrlsByHtml } from './partition-urls-by-html.js';
+
+/**
+ * Parse a list of URL strings into ExURL objects for test input.
+ * @param raws - URL strings to parse.
+ * @returns The parsed ExURL objects.
+ */
+function urls(raws: string[]): ExURL[] {
+	return raws.map((raw) => parseUrl(raw)!);
+}
+
+/**
+ * Map a partition result to its URL strings for readable assertions.
+ * @param result - The `[html, other]` tuple from partitionUrlsByHtml.
+ * @returns A `[html, other]` tuple of `withoutHashAndAuth` strings.
+ */
+function hrefs(result: [ExURL[], ExURL[]]): [string[], string[]] {
+	return [
+		result[0].map((u) => u.withoutHashAndAuth),
+		result[1].map((u) => u.withoutHashAndAuth),
+	];
+}
+
+describe('partitionUrlsByHtml', () => {
+	it('splits a mixed batch into HTML and non-HTML groups', () => {
+		const input = urls([
+			'https://example.com/about',
+			'https://example.com/photo.jpg',
+			'https://example.com/contact.php',
+			'https://example.com/styles.css',
+		]);
+		expect(hrefs(partitionUrlsByHtml(input))).toEqual([
+			['https://example.com/about', 'https://example.com/contact.php'],
+			['https://example.com/photo.jpg', 'https://example.com/styles.css'],
+		]);
+	});
+
+	it('puts every URL in the HTML group when all are likely HTML', () => {
+		const input = urls([
+			'https://example.com/page/4',
+			'https://example.com/page/5',
+			'https://example.com/page/6',
+		]);
+		expect(hrefs(partitionUrlsByHtml(input))).toEqual([
+			[
+				'https://example.com/page/4',
+				'https://example.com/page/5',
+				'https://example.com/page/6',
+			],
+			[],
+		]);
+	});
+
+	it('puts every URL in the other group when none are likely HTML', () => {
+		const input = urls(['https://example.com/a.pdf', 'https://example.com/b.zip']);
+		expect(hrefs(partitionUrlsByHtml(input))).toEqual([
+			[],
+			['https://example.com/a.pdf', 'https://example.com/b.zip'],
+		]);
+	});
+
+	it('preserves input order within each group', () => {
+		const input = urls([
+			'https://example.com/3',
+			'https://example.com/x.css',
+			'https://example.com/1',
+			'https://example.com/y.js',
+			'https://example.com/2',
+		]);
+		expect(hrefs(partitionUrlsByHtml(input))).toEqual([
+			['https://example.com/3', 'https://example.com/1', 'https://example.com/2'],
+			['https://example.com/x.css', 'https://example.com/y.js'],
+		]);
+	});
+
+	it('returns two empty groups for an empty input', () => {
+		expect(partitionUrlsByHtml([])).toEqual([[], []]);
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/partition-urls-by-html.ts
+++ b/packages/@nitpicker/crawler/src/crawler/partition-urls-by-html.ts
@@ -1,0 +1,28 @@
+import type { ExURL } from '@d-zero/shared/parse-url';
+
+import { isLikelyHtmlUrl } from './is-likely-html-url.js';
+
+/**
+ * Split URLs into a likely-HTML group and a non-HTML group, preserving input
+ * order within each group.
+ *
+ * Used by the crawler's enqueue path to route discovered URLs: likely-HTML URLs
+ * are `unshift`ed to the front of the dealer queue (so page crawling advances
+ * ahead of asset/document fetches) while the rest are `push`ed to the tail.
+ * Keeping the order stable within each group means a batch (e.g. predicted
+ * pagination URLs) stays in ascending order at the front when unshifted as one
+ * call. Classification is delegated to {@link isLikelyHtmlUrl}.
+ * @param urls - The discovered URLs to partition.
+ * @returns A `[html, other]` tuple: likely-HTML URLs and the remainder, each in
+ *   original input order.
+ */
+export function partitionUrlsByHtml(
+	urls: readonly ExURL[],
+): [html: ExURL[], other: ExURL[]] {
+	const html: ExURL[] = [];
+	const other: ExURL[] = [];
+	for (const url of urls) {
+		(isLikelyHtmlUrl(url) ? html : other).push(url);
+	}
+	return [html, other];
+}

--- a/packages/@nitpicker/report-google-sheets/package.json
+++ b/packages/@nitpicker/report-google-sheets/package.json
@@ -27,7 +27,7 @@
 		"clean": "tsc --build --clean"
 	},
 	"dependencies": {
-		"@d-zero/dealer": "1.7.0",
+		"@d-zero/dealer": "1.9.0",
 		"@d-zero/google-auth": "0.5.6",
 		"@d-zero/google-sheets": "0.9.0",
 		"@d-zero/shared": "0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,13 +819,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d-zero/dealer@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@d-zero/dealer@npm:1.7.0"
+"@d-zero/dealer@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@d-zero/dealer@npm:1.9.0"
   dependencies:
-    "@d-zero/shared": "npm:0.20.1"
+    "@d-zero/shared": "npm:0.22.0"
     ansi-colors: "npm:4.1.3"
-  checksum: 10c0/ac74b090f31272c0b22f563989ef00cb857331e7de19bc6d193a8ebc573fdaacfc82689c8e95bcaea59cad44ae2ab7a063c4db48210c534c597ccc41e86a39d6
+  checksum: 10c0/70418ef52bd13280a9a03347776bdd27d046ea5249fff7fcef008e95cbca4f3167a8b9ea851ab174571f2885ee2e01dcc858c1bf7d633618be2d51ff793c8b0c
   languageName: node
   linkType: hard
 
@@ -2463,7 +2463,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nitpicker/cli@workspace:packages/@nitpicker/cli"
   dependencies:
-    "@d-zero/dealer": "npm:1.7.0"
+    "@d-zero/dealer": "npm:1.9.0"
     "@d-zero/readtext": "npm:1.1.19"
     "@d-zero/roar": "npm:2.1.0"
     "@d-zero/shared": "npm:0.20.1"
@@ -2490,7 +2490,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nitpicker/core@workspace:packages/@nitpicker/core"
   dependencies:
-    "@d-zero/dealer": "npm:1.7.0"
+    "@d-zero/dealer": "npm:1.9.0"
     "@d-zero/shared": "npm:0.20.1"
     "@nitpicker/crawler": "npm:0.9.0"
     "@nitpicker/types": "npm:0.9.0"
@@ -2505,7 +2505,7 @@ __metadata:
   resolution: "@nitpicker/crawler@workspace:packages/@nitpicker/crawler"
   dependencies:
     "@d-zero/beholder": "npm:2.1.2"
-    "@d-zero/dealer": "npm:1.7.0"
+    "@d-zero/dealer": "npm:1.9.0"
     "@d-zero/fs": "npm:0.2.2"
     "@d-zero/shared": "npm:0.20.1"
     "@types/debug": "npm:4.1.12"
@@ -2548,7 +2548,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nitpicker/report-google-sheets@workspace:packages/@nitpicker/report-google-sheets"
   dependencies:
-    "@d-zero/dealer": "npm:1.7.0"
+    "@d-zero/dealer": "npm:1.9.0"
     "@d-zero/google-auth": "npm:0.5.6"
     "@d-zero/google-sheets": "npm:0.9.0"
     "@d-zero/shared": "npm:0.20.1"


### PR DESCRIPTION
## 概要

クロールキュー（`@d-zero/dealer`）への新 URL 投入を、**HTML らしい URL はキュー先頭へ `unshift`（優先） / それ以外は末尾へ `push`** に振り分けるようにし、HTML ページのクロールがアセット・ドキュメント取得より先に進むようにした。

判定は HEAD/GET 前の URL のみで行うため、実 `Content-Type` ではなく URL 拡張子ヒューリスティック（`isLikelyHtmlUrl`）を使う。**誤判定しても fetch 順が変わるだけで、網羅性・正確性には影響しない。**

## 変更点

- **`isLikelyHtmlUrl`**（新規）: 拡張子なし・ディレクトリ型 URL（`/`, `/about/`）・末尾ドット URL と、`.html`/`.htm`/`.php`/`.aspx`/`.jsp`/`.ashx` 等を HTML 扱い。非 HTTP（`mailto:` 等）や `.jpg`/`.pdf`/`.css`/`.js` 等は非 HTML 扱い。
- **`partitionUrlsByHtml`**（新規）: URL 群を HTML / 非 HTML に分割。バッチ（予測ページネーション等）を 1 回の `unshift(...html)` で投入し昇順を維持（1 件ずつ unshift すると逆順になるため）。
- **`crawler.ts`**: `deal()` setup の第 6 引数 `unshift` を受け取り、`#handleResult` の enqueue 経路を `push` → 振り分け `enqueue` に変更。
- **`@d-zero/dealer` 1.7.0 → 1.9.0**: `deal()` setup コールバックに `unshift`（キュー先頭投入）が追加されたため。全利用パッケージでバージョンを統一。
- **ドキュメント**: ARCHITECTURE.md / CLAUDE.md のデータフロー、更新手順（拡張子追加箇所・`unshift` API の所在）を追記。

## テスト

- `is-likely-html-url.spec.ts`（38）: 判定の全分岐・エッジ（クエリ付き / 複合拡張子 / dotfile / 末尾ドット / 大文字 / 非 HTTP）。
- `partition-urls-by-html.spec.ts`（5）: 混在バッチ / 全 HTML / 全非 HTML / 順序保持 / 空入力。
- `crawler.spec.ts`: HTML→unshift・非 HTML→push の配線、予測ページネーションの昇順バッチ投入。**いずれも変異テストで「実装を壊すと落ちる」ことを確認済み。**

## 互換性

API / CLI / `.nitpicker` 形式は非破壊（内部のキュー投入順のみの追加的変更）。`@d-zero/dealer` は後方互換アップグレード（`unshift` 追加）。

## プリフライト

- `yarn lint` ✅（cspell 0 issues）
- `yarn build` ✅（13 projects）
- `yarn test` ✅（1261 passed / 143 files）

🤖 Generated with [Claude Code](https://claude.com/claude-code)