### PR TITLE
feat(crawler): tree-kill Chromium and persist partial scrape failures

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -342,13 +342,52 @@ closeBrowserSafely(browser, timeoutMs = 30_000)
 
 **なぜ必要か:** viewport 切替（desktop-compact → mobile-small）でページ側の execution context が破壊されると、Chromium のセッションが detached 状態になり、`browser.close()` が CDP ハンドシェイクの応答を待ち続けて永久に settle しないケースがある。タイムアウトを設けず単に `await browser.close().catch(() => {})` だと、deal() ワーカーが完了せずクロール全体がハングする（症状: `📷 mobile-small: skipped — Attempted to use detached Frame` ログの後、CLI が終了しない）。
 
-**SIGKILL の限界:** SIGKILL は Chromium 親プロセスのみに送られ、renderer/network/zygote の子プロセスツリーには伝播しない。puppeteer は `detached: false` で spawn するため process group kill は使えない（負の PID kill は Node プロセス自身も巻き込む）。子は broken IPC を検知してサブ秒で self-exit するため、短時間の orphan 残留は許容している。
+**子プロセスツリーの kill:** Chromium は親プロセスから renderer / network / zygote / GPU などの子プロセスを fork するため、親プロセスのみへの SIGKILL では子が orphan として残ることがある（puppeteer は `detached: false` で spawn するため process group kill 不可。負の PID kill は Node 自身を巻き込む）。`closeBrowserSafely` は `childProcess.kill('SIGKILL')` で Node 側のハンドルを kill した直後に `killProcessTree(pid, 'SIGKILL')`（`crawler/kill-process-tree.ts`）を呼び、POSIX では `ps -A -o pid=,ppid=` を spawn して PPID マップを構築 → BFS で全子孫を列挙 → 葉から順に signal、Windows では `taskkill /T /F /PID <pid>` を spawn して OS レベルで再帰 kill する。`ps`/`taskkill` の呼び出し失敗・ESRCH（既に消滅した PID）は best-effort としてすべて握りつぶし、関数は必ず resolve する。
 
 **観測性:** タイムアウト発火時は `crawlerLog('Force-killed wedged Chromium browser for %s ...')` を出す。`DEBUG=Nitpicker:Crawler` で頻発を検知可能。`closeBrowserSafely` 自体が throw した場合（`browser.process()` が予期せず throw 等）も `handleBrowserClose` が握りつぶしてログするため、finally から例外が伝播することはない。
 
 > **更新手順（タイムアウト値の変更）**: 30 秒という値は重いページや低速環境での余裕を取った設定。変更する場合は `close-browser-safely.ts` の `DEFAULT_CLOSE_TIMEOUT_MS` を編集し、`close-browser-safely.spec.ts` の「defaults to a 30-second timeout」テストを併せて更新。Promise.race の負け側 timer は **必ず `clearTimeout` で clear** すること（`fetch-destination.ts` と同じ規律。詳細は下記「CLI プロセス終了とリソース解放」）。
 >
-> **検証**: `close-browser-safely.spec.ts`（10 ケース: 正常 / hang / reject / null process / 既 killed / デフォルト timeout / 遅延 rejection / timeoutMs=0 / kill が false / 冪等性）と `handle-browser-close.spec.ts`（4 ケース: ログ無し / 強制 kill ログ / closeBrowserSafely throw / 二重故障 finally-safety）。puppeteer Browser 型との整合性は `close-browser-safely.spec.ts` 冒頭の compile-time assertion で担保。
+> **検証**: `close-browser-safely.spec.ts`（13 ケース: 正常 / hang / reject / null process / 既 killed / デフォルト timeout / 遅延 rejection / timeoutMs=0 / kill が false / 冪等性 / tree-kill / pid 無し / close 成功時の no-op）と `handle-browser-close.spec.ts`（4 ケース）、`kill-process-tree.spec.ts`（8 ケース: POSIX BFS 順 / signal 透過 / 列挙 0 件 / killer throw 伝播 / Windows 委譲 / runTreeKill 失敗 / プラットフォーム既定）。puppeteer Browser 型との整合性は `close-browser-safely.spec.ts` 冒頭の compile-time assertion で担保。
+
+### 部分失敗の archive 記録（page_errors）
+
+`#fetchImages` で viewport 切替が失敗するなど、ページ自体は取れたが二次的なスクレイプ手順が失敗するケースは、beholder の `@retryable` が最終的に `changePhase` イベントを `name='retryExhausted'` で emit する。これを stdout に流して捨てるのではなく、archive (SQLite) の **`page_errors` テーブル**にレコードとして残す。
+
+```
+page_errors:
+  id        INTEGER PK
+  pageId    INTEGER FK → pages.id
+  phase     VARCHAR (e.g. 'retryExhausted')
+  message   TEXT (e.g. '📷 mobile-small: skipped — Attempted to use detached Frame')
+  createdAt INTEGER (unix ms)
+  INDEX (pageId)
+```
+
+イベントフロー:
+
+```
+beholder.Scraper#fetchImages catch
+  → emit changePhase { name: 'retryExhausted', message, url: null, ... }
+Crawler の scraper.on('changePhase')
+  → forward as 'changePhase' event
+  → name === 'retryExhausted' なら #pendingPhaseErrors Map に url.href キーで buffer
+Crawler #runDeal の worker
+  → scrapePage 完了 → #handleResult が 'page' / 'externalPage' を emit
+  → #drainPhaseErrors(url, isExternal) で buffer を flush し 'pageError' を emit
+  → 失敗 path（catch）でも同様に drain、最後に finally で Map から delete（leak 防止）
+CrawlerOrchestrator
+  → on('pageError') で writeQueue 経由で archive.addPageError(url, phase, message, isExternal)
+  → 'page' が先に enqueue されているため WriteQueue 上で setPage → insertPageError の順序保証
+```
+
+`Database.#getIdByUrl` は URL から pages.id を upsert で解決するため、`insertPageError` は setPage より先に走っても FK が満たされ、エラーがロストすることはない。
+
+**既存 archive の自動マイグレーション:** `Database.#init` で `migratePageErrors`（`archive/migrate-page-errors.ts`）を呼び、`page_errors` テーブルが無ければ作成する（idempotent）。`pages` テーブルすら無い空 archive は `initSchema` 経路に任せる。マイグレーションが実走した場合のみ stderr に `[migrate] page_errors table created` を出す。
+
+> **更新手順（新しい phase を記録する）**: `retryExhausted` 以外の phase（例: `setViewport`、`getImages` など）を保存対象に増やす場合は、`crawler/crawler.ts` の `scraper.on('changePhase')` 内の判定（`if (e.name === 'retryExhausted')`）を拡張する。phase 名は文字列のまま `page_errors.phase` 列に入るので、新しい phase 種別をクエリで区別する場合は値を decide してから入れること。
+>
+> **検証**: `migrate-page-errors.spec.ts`（3 ケース: 作成 / 冪等性 / 空 archive スキップ）、`database.spec.ts > insertPageError`（3 ケース: 事前未保存 URL / 複数行追加 / external フラグ）、`archive.spec.ts > addPageError`（separate Database 接続で row 検証）、`crawler-orchestrator.spec.ts > pageError ハンドラ`（archive.addPageError の呼び出し + 失敗時の reject 伝播）。
 
 ### CLI プロセス終了とリソース解放
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -344,11 +344,11 @@ closeBrowserSafely(browser, timeoutMs = 30_000)
 
 **子プロセスツリーの kill:** Chromium は親プロセスから renderer / network / zygote / GPU などの子プロセスを fork するため、親プロセスのみへの SIGKILL では子が orphan として残ることがある（puppeteer は `detached: false` で spawn するため process group kill 不可。負の PID kill は Node 自身を巻き込む）。`closeBrowserSafely` は `childProcess.kill('SIGKILL')` で Node 側のハンドルを kill した直後に `killProcessTree(pid, 'SIGKILL')`（`crawler/kill-process-tree.ts`）を呼び、POSIX では `ps -A -o pid=,ppid=` を spawn して PPID マップを構築 → BFS で全子孫を列挙 → 葉から順に signal、Windows では `taskkill /T /F /PID <pid>` を spawn して OS レベルで再帰 kill する。`ps`/`taskkill` の呼び出し失敗・ESRCH（既に消滅した PID）は best-effort としてすべて握りつぶし、関数は必ず resolve する。
 
-**観測性:** タイムアウト発火時は `crawlerLog('Force-killed wedged Chromium browser for %s ...')` を出す。`DEBUG=Nitpicker:Crawler` で頻発を検知可能。`closeBrowserSafely` 自体が throw した場合（`browser.process()` が予期せず throw 等）も `handleBrowserClose` が握りつぶしてログするため、finally から例外が伝播することはない。
+**観測性:** タイムアウト発火時は `crawlerLog('Force-killed wedged Chromium browser for %s ...')` を出す。さらに `killProcessTree` 内の best-effort 失敗（`process.kill` の ESRCH/EPERM / `ps` 起動失敗・非 0 exit / `taskkill` 起動失敗・非 0 exit）も DI された logger 経由でログされる。`closeBrowserSafely` は `crawlerLog` を渡すので **`DEBUG=Nitpicker:Crawler` を有効にすると本番の tree-kill 失敗が観測可能**。`closeBrowserSafely` 自体が throw した場合（`browser.process()` が予期せず throw 等）も `handleBrowserClose` が握りつぶしてログするため、finally から例外が伝播することはない。
 
 > **更新手順（タイムアウト値の変更）**: 30 秒という値は重いページや低速環境での余裕を取った設定。変更する場合は `close-browser-safely.ts` の `DEFAULT_CLOSE_TIMEOUT_MS` を編集し、`close-browser-safely.spec.ts` の「defaults to a 30-second timeout」テストを併せて更新。Promise.race の負け側 timer は **必ず `clearTimeout` で clear** すること（`fetch-destination.ts` と同じ規律。詳細は下記「CLI プロセス終了とリソース解放」）。
 >
-> **検証**: `close-browser-safely.spec.ts`（13 ケース: 正常 / hang / reject / null process / 既 killed / デフォルト timeout / 遅延 rejection / timeoutMs=0 / kill が false / 冪等性 / tree-kill / pid 無し / close 成功時の no-op）と `handle-browser-close.spec.ts`（4 ケース）、`kill-process-tree.spec.ts`（8 ケース: POSIX BFS 順 / signal 透過 / 列挙 0 件 / killer throw 伝播 / Windows 委譲 / runTreeKill 失敗 / プラットフォーム既定）。puppeteer Browser 型との整合性は `close-browser-safely.spec.ts` 冒頭の compile-time assertion で担保。
+> **検証**: `close-browser-safely.spec.ts`（13 ケース: 正常 / hang / reject / null process / 既 killed / デフォルト timeout / 遅延 rejection / timeoutMs=0 / kill が false / 冪等性 / tree-kill / pid 無し / close 成功時の no-op）、`handle-browser-close.spec.ts`（4 ケース）、`kill-process-tree.spec.ts`（**15 ケース**: POSIX BFS 順 / signal 透過 / 列挙 0 件 / killer throw 伝播 / Windows 委譲 / runTreeKill 失敗 / プラットフォーム既定 / **Spawner 注入で Windows taskkill 引数検証 / POSIX ps 引数検証 / 4 つの失敗パス（ps 起動失敗 / ps 非 0 exit / taskkill 起動失敗 / taskkill 非 0 exit）の log 検証 / process.kill ESRCH の log 検証**）。puppeteer Browser 型との整合性は `close-browser-safely.spec.ts` 冒頭の compile-time assertion で担保。
 
 ### 部分失敗の archive 記録（page_errors）
 
@@ -364,18 +364,24 @@ page_errors:
   INDEX (pageId)
 ```
 
-イベントフロー:
+イベントフロー（関連ファイルは `crawler/` 配下に集約）:
 
 ```
 beholder.Scraper#fetchImages catch
   → emit changePhase { name: 'retryExhausted', message, url: null, ... }
-Crawler の scraper.on('changePhase')
+
+createChangePhaseHandler  (create-change-phase-handler.ts)
   → forward as 'changePhase' event
   → name === 'retryExhausted' なら #pendingPhaseErrors Map に url.href キーで buffer
+
 Crawler #runDeal の worker
   → scrapePage 完了 → #handleResult が 'page' / 'externalPage' を emit
-  → #drainPhaseErrors(url, isExternal) で buffer を flush し 'pageError' を emit
-  → 失敗 path（catch）でも同様に drain、最後に finally で Map から delete（leak 防止）
+  → drainPhaseErrors  (drain-phase-errors.ts) で buffer を flush し 'pageError' を emit
+  → 失敗 path（catch）でも同様に drain
+  → 最後に logUndrainedPhaseErrors  (log-undrained-phase-errors.ts) で
+     finally の取りこぼし（predicted-discard 等）を `DEBUG=Nitpicker:Crawler`
+     にログしつつ Map から delete（leak 防止）
+
 CrawlerOrchestrator
   → on('pageError') で writeQueue 経由で archive.addPageError(url, phase, message, isExternal)
   → 'page' が先に enqueue されているため WriteQueue 上で setPage → insertPageError の順序保証
@@ -383,11 +389,21 @@ CrawlerOrchestrator
 
 `Database.#getIdByUrl` は URL から pages.id を upsert で解決するため、`insertPageError` は setPage より先に走っても FK が満たされ、エラーがロストすることはない。
 
+**関連ヘルパー**（純粋関数として extract、各々独立して単体テスト可能）:
+
+| ファイル                         | 役割                                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------------------- |
+| `create-change-phase-handler.ts` | scraper.on('changePhase') 用の listener factory。emit/update/formatLog/buffer/urlHref を DI |
+| `drain-phase-errors.ts`          | buffer の per-URL flush。emit + delete を idempotent に実行                                 |
+| `log-undrained-phase-errors.ts`  | finally で残った buffer エントリをログして削除（predicted-discard 等の取りこぼし観測）      |
+
 **既存 archive の自動マイグレーション:** `Database.#init` で `migratePageErrors`（`archive/migrate-page-errors.ts`）を呼び、`page_errors` テーブルが無ければ作成する（idempotent）。`pages` テーブルすら無い空 archive は `initSchema` 経路に任せる。マイグレーションが実走した場合のみ stderr に `[migrate] page_errors table created` を出す。
 
-> **更新手順（新しい phase を記録する）**: `retryExhausted` 以外の phase（例: `setViewport`、`getImages` など）を保存対象に増やす場合は、`crawler/crawler.ts` の `scraper.on('changePhase')` 内の判定（`if (e.name === 'retryExhausted')`）を拡張する。phase 名は文字列のまま `page_errors.phase` 列に入るので、新しい phase 種別をクエリで区別する場合は値を decide してから入れること。
+**downstream の未実装**: 本 PR の射程は `page_errors` への記録まで。`query` / `report-google-sheets` / `mcp-server` から表示する仕組みは未実装で、現状は `sqlite3 file.nitpicker 'SELECT * FROM page_errors'` で直接見るしかない。次の PR で expose 予定。
+
+> **更新手順（新しい phase を記録する）**: `retryExhausted` 以外の phase（例: `setViewport`、`getImages` など）を保存対象に増やす場合は、`crawler/create-change-phase-handler.ts` の `if (event.name === 'retryExhausted')` 判定を拡張する。phase 名は文字列のまま `page_errors.phase` 列に入るので、新しい phase 種別をクエリで区別する場合は値を decide してから入れること。
 >
-> **検証**: `migrate-page-errors.spec.ts`（3 ケース: 作成 / 冪等性 / 空 archive スキップ）、`database.spec.ts > insertPageError`（3 ケース: 事前未保存 URL / 複数行追加 / external フラグ）、`archive.spec.ts > addPageError`（separate Database 接続で row 検証）、`crawler-orchestrator.spec.ts > pageError ハンドラ`（archive.addPageError の呼び出し + 失敗時の reject 伝播）。
+> **検証**: `migrate-page-errors.spec.ts`（3 ケース: 作成 / 冪等性 / 空 archive スキップ）、`database.spec.ts > insertPageError`（3 ケース）、`archive.spec.ts > addPageError`（separate Database 接続で row 検証）、`crawler-orchestrator.spec.ts > pageError ハンドラ`（archive.addPageError の呼び出し + 失敗時の reject 伝播）、`drain-phase-errors.spec.ts`（6 ケース）、`create-change-phase-handler.spec.ts`（9 ケース）、`log-undrained-phase-errors.spec.ts`（5 ケース）。**worker → drain wiring の直接 e2e テストは puppeteer mock コストの兼ね合いで意図的に省略**（`Crawler.#drainPhaseErrors` の JSDoc に known gap として明記）。
 
 ### CLI プロセス終了とリソース解放
 

--- a/packages/@nitpicker/crawler/src/archive/archive.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.spec.ts
@@ -240,3 +240,52 @@ describe('write: append 時のスナップショットマージ', () => {
 		}
 	});
 });
+
+describe('addPageError', () => {
+	const archiveFilePath = path.resolve(workingDir, 'add-page-error-test.nitpicker');
+	const tmpDirPattern = path.resolve(
+		workingDir,
+		Archive.TMP_DIR_PREFIX + 'add-page-error-test',
+	);
+
+	afterAll(async () => {
+		await remove(tmpDirPattern).catch(() => {});
+		await remove(archiveFilePath).catch(() => {});
+	});
+
+	it('persists a page_errors row even before setPage runs', async () => {
+		const archive = await Archive.create({
+			filePath: archiveFilePath,
+			cwd: workingDir,
+		});
+		try {
+			await archive.addPageError(
+				'http://localhost/viewport-failure',
+				'retryExhausted',
+				'📷 mobile-small: skipped — Attempted to use detached Frame',
+			);
+
+			// Verify via a separate Database connection to the working tmp dir
+			// (mirrors the setPage tests above — Archive does not expose its
+			// internal Database publicly).
+			const dbPath = path.resolve(tmpDirPattern, Archive.SQLITE_DB_FILE_NAME);
+			const db = await Database.connect({
+				workingDir: tmpDirPattern,
+				filename: dbPath,
+			});
+			try {
+				const rows = await db.getKnex().from('page_errors').select('phase', 'message');
+				expect(rows).toEqual([
+					{
+						phase: 'retryExhausted',
+						message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+					},
+				]);
+			} finally {
+				await db.destroy();
+			}
+		} finally {
+			await archive.close();
+		}
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/archive.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.ts
@@ -91,6 +91,21 @@ export default class Archive extends ArchiveAccessor {
 	}
 
 	/**
+	 * Records a partial scrape failure against the page identified by `url`.
+	 *
+	 * The corresponding `pages` row is created on demand (or matched if it
+	 * already exists), so the call works even if the page's normal data has
+	 * not been written yet.
+	 * @param url - URL of the affected page.
+	 * @param phase - Scrape phase name (typically `'retryExhausted'`).
+	 * @param message - Human-readable failure message.
+	 * @param isExternal - Whether the URL is external. Defaults to `false`.
+	 */
+	async addPageError(url: string, phase: string, message: string, isExternal = false) {
+		dbLog('Add page error: %s [%s]', url, phase);
+		await this.#db.insertPageError(url, phase, message, isExternal);
+	}
+	/**
 	 * Closes the archive. If the archive file does not yet exist on disk,
 	 * it writes the archive first. If the temporary directory still exists,
 	 * it is removed.
@@ -224,6 +239,7 @@ export default class Archive extends ArchiveAccessor {
 		dbLog('Set skipped page: %s', url);
 		await this.#db.setSkippedPage(url, reason, isExternal);
 	}
+
 	/**
 	 * Assigns natural URL sort order values to all pages in the database
 	 * that do not yet have an `order` field set.

--- a/packages/@nitpicker/crawler/src/archive/database.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.spec.ts
@@ -951,6 +951,82 @@ describe('getJSON (getConfig 経由)', () => {
 	});
 });
 
+describe('insertPageError', () => {
+	const dbPath = path.resolve(workingDir, 'page-errors-test.sqlite');
+
+	afterAll(async () => {
+		await remove(dbPath);
+	});
+
+	it('records a page_errors row keyed to the page even if the page is not scraped yet', async () => {
+		const db = await Database.connect({
+			workingDir,
+			filename: dbPath,
+		});
+
+		// The orchestrator may write the page error BEFORE setPage runs;
+		// insertPageError must therefore upsert the page row on demand.
+		await db.insertPageError(
+			'https://example.com/wedged-viewport',
+			'retryExhausted',
+			'📷 mobile-small: skipped — Attempted to use detached Frame',
+		);
+
+		const knex = db.getKnex();
+		const rows = await knex('page_errors').select('phase', 'message');
+		expect(rows).toEqual([
+			{
+				phase: 'retryExhausted',
+				message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+			},
+		]);
+
+		const pages = await knex('pages').select('url', 'scraped');
+		expect(pages).toEqual([{ url: 'https://example.com/wedged-viewport', scraped: 0 }]);
+	});
+
+	it('appends a second row when the same URL fails for another phase', async () => {
+		const db = await Database.connect({
+			workingDir,
+			filename: dbPath,
+		});
+
+		await db.insertPageError(
+			'https://example.com/wedged-viewport',
+			'retryExhausted',
+			'📷 desktop-compact: skipped — Session closed',
+		);
+
+		const knex = db.getKnex();
+		const rows = await knex('page_errors').select('phase', 'message').orderBy('id');
+		expect(rows).toHaveLength(2);
+		expect(rows[1]).toEqual({
+			phase: 'retryExhausted',
+			message: '📷 desktop-compact: skipped — Session closed',
+		});
+	});
+
+	it('flags the page row as external when isExternal is true', async () => {
+		const db = await Database.connect({
+			workingDir,
+			filename: dbPath,
+		});
+
+		await db.insertPageError(
+			'https://external.example.com/oops',
+			'retryExhausted',
+			'oops',
+			true,
+		);
+
+		const knex = db.getKnex();
+		const [row] = await knex('pages')
+			.where('url', 'https://external.example.com/oops')
+			.select('isExternal');
+		expect(row.isExternal).toBe(1);
+	});
+});
+
 describe('getResourceByUrl', () => {
 	const resourceDbPath = path.resolve(workingDir, 'get-resource-by-url-test.sqlite');
 

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -33,6 +33,7 @@ import { initSchema } from './init-schema.js';
 import { LibsqlDialect } from './libsql-dialect.js';
 import { limitedPageIds } from './limited-page-ids.js';
 import { migrateInfoRoots } from './migrate-info-roots.js';
+import { migratePageErrors } from './migrate-page-errors.js';
 import { redirectTable } from './redirect-table.js';
 
 const retrySetting: RetryDecoratorOptions = {
@@ -575,6 +576,33 @@ export class Database extends EventEmitter<DatabaseEvent> {
 	}
 
 	/**
+	 * Records a partial scrape failure against the page identified by `url`.
+	 *
+	 * The page row is resolved (or inserted as a stub) via
+	 * {@link Database.#getIdByUrl} so the error can be recorded even before
+	 * `setPage` has run — useful when the failure fires during scraping
+	 * (e.g. mid-`scrapeStart`) and the orchestrator enqueues this write
+	 * before the success write for the same URL.
+	 *
+	 * A single page can have multiple `page_errors` rows (e.g. both
+	 * `desktop-compact` and `mobile-small` viewports failing).
+	 * @param url - URL of the page being scraped.
+	 * @param phase - Scrape phase name (typically `'retryExhausted'`).
+	 * @param message - Human-readable failure message.
+	 * @param isExternal - Whether the URL is external. Defaults to `false`.
+	 */
+	@ErrorEmitter()
+	@retry(retrySetting)
+	async insertPageError(url: string, phase: string, message: string, isExternal = false) {
+		const pageId = await this.#getIdByUrl(url, isExternal ? 1 : 0);
+		await this.#instance('page_errors').insert({
+			pageId,
+			phase,
+			message,
+			createdAt: Date.now(),
+		});
+	}
+	/**
 	 * Inserts a sub-resource into the `resources` table.
 	 * Ignores duplicate URLs (uses `ON CONFLICT IGNORE`).
 	 * @param resource - The resource data to insert.
@@ -740,6 +768,7 @@ export class Database extends EventEmitter<DatabaseEvent> {
 				skipReason: reason,
 			});
 	}
+
 	/**
 	 * Assigns natural URL sort order values to all internal pages.
 	 * Pages are sorted using {@link pathComparator} and assigned sequential order numbers.
@@ -954,6 +983,7 @@ export class Database extends EventEmitter<DatabaseEvent> {
 	async #init() {
 		await initSchema(this.#instance);
 		await migrateInfoRoots(this.#instance);
+		await migratePageErrors(this.#instance);
 	}
 
 	/**

--- a/packages/@nitpicker/crawler/src/archive/init-schema.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.ts
@@ -123,5 +123,20 @@ export async function initSchema(instance: Knex) {
 			t.unique(['resourceId', 'pageId']);
 			t.index('resourceId');
 			t.index('pageId');
+		})
+		.createTable('page_errors', (t) => {
+			// Records partial scrape failures (e.g. a viewport switch that
+			// detaches the frame and trips beholder's @retryable into the
+			// `retryExhausted` phase). A page can have zero or more rows here
+			// in addition to its normal `pages` entry — the page itself is
+			// considered successfully scraped, but image capture or another
+			// secondary step failed for at least one device preset.
+			t.increments('id');
+			t.integer('pageId').notNullable().unsigned().references('pages.id');
+			t.string('phase').notNullable();
+			t.text('message').notNullable();
+			t.integer('createdAt').notNullable();
+
+			t.index('pageId');
 		});
 }

--- a/packages/@nitpicker/crawler/src/archive/migrate-page-errors.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-page-errors.spec.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import knex from 'knex';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { LibsqlDialect } from './libsql-dialect.js';
+import { migratePageErrors } from './migrate-page-errors.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__mock__');
+
+/**
+ * Builds a knex instance against a temp SQLite file that simulates an old
+ * archive: the `pages` table exists but `page_errors` does not yet.
+ * @param fileName - Name of the SQLite file relative to workingDir.
+ * @returns The connected knex instance + the file path so callers can clean
+ *   it up.
+ */
+async function buildLegacyArchive(fileName: string) {
+	const filename = path.resolve(workingDir, fileName);
+	await fs.rm(filename, { force: true });
+	const instance = knex({
+		client: LibsqlDialect as never,
+		connection: { filename },
+		useNullAsDefault: true,
+	});
+	await instance.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url');
+	});
+	return { instance, filename };
+}
+
+afterEach(async () => {
+	for (const name of [
+		'migrate-page-errors.sqlite',
+		'migrate-page-errors-idempotent.sqlite',
+		'migrate-page-errors-empty.sqlite',
+	]) {
+		await fs.rm(path.resolve(workingDir, name), { force: true });
+	}
+});
+
+describe('migratePageErrors', () => {
+	it('creates page_errors with the expected columns when the table is missing', async () => {
+		const { instance } = await buildLegacyArchive('migrate-page-errors.sqlite');
+
+		await migratePageErrors(instance);
+
+		expect(await instance.schema.hasTable('page_errors')).toBe(true);
+		expect(await instance.schema.hasColumn('page_errors', 'id')).toBe(true);
+		expect(await instance.schema.hasColumn('page_errors', 'pageId')).toBe(true);
+		expect(await instance.schema.hasColumn('page_errors', 'phase')).toBe(true);
+		expect(await instance.schema.hasColumn('page_errors', 'message')).toBe(true);
+		expect(await instance.schema.hasColumn('page_errors', 'createdAt')).toBe(true);
+
+		await instance.destroy();
+	});
+
+	it('is idempotent — calling twice on an up-to-date schema is a no-op', async () => {
+		const { instance } = await buildLegacyArchive(
+			'migrate-page-errors-idempotent.sqlite',
+		);
+
+		await migratePageErrors(instance);
+		// Insert a marker row so the second run can be observed not to touch data.
+		await instance('pages').insert({ url: 'https://example.com/' });
+		const [page] = await instance('pages').select('id', 'url');
+		await instance('page_errors').insert({
+			pageId: page.id,
+			phase: 'retryExhausted',
+			message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+			createdAt: 1_700_000_000_000,
+		});
+
+		await migratePageErrors(instance);
+
+		const [row] = await instance('page_errors').select('phase', 'message');
+		expect(row.phase).toBe('retryExhausted');
+		expect(row.message).toBe(
+			'📷 mobile-small: skipped — Attempted to use detached Frame',
+		);
+
+		await instance.destroy();
+	});
+
+	it('exits without writing when the archive predates the pages table entirely', async () => {
+		// An entirely empty archive — no migration should touch it. The regular
+		// initSchema path is responsible for creating both tables at once.
+		const filename = path.resolve(workingDir, 'migrate-page-errors-empty.sqlite');
+		await fs.rm(filename, { force: true });
+		const instance = knex({
+			client: LibsqlDialect as never,
+			connection: { filename },
+			useNullAsDefault: true,
+		});
+
+		await migratePageErrors(instance);
+
+		expect(await instance.schema.hasTable('page_errors')).toBe(false);
+
+		await instance.destroy();
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/migrate-page-errors.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-page-errors.ts
@@ -1,0 +1,38 @@
+import type { Knex } from 'knex';
+
+/**
+ * Adds the `page_errors` table to archives created before partial-failure
+ * recording landed.
+ *
+ * `page_errors` captures secondary scrape failures (e.g. a viewport switch
+ * that detaches the frame and surfaces `retryExhausted`) so they show up in
+ * the archive instead of being lost to stdout logs. Older `.nitpicker` files
+ * predate this table; this migration creates it idempotently.
+ *
+ * Idempotent: when the table already exists, the function exits without
+ * touching the schema or writing to stderr. When it has to run, a single
+ * notice is written so the user knows the file was upgraded.
+ * @param instance - The Knex query builder instance connected to the database.
+ */
+export async function migratePageErrors(instance: Knex): Promise<void> {
+	const hasTable = await instance.schema.hasTable('page_errors');
+	if (hasTable) {
+		return;
+	}
+	const hasPages = await instance.schema.hasTable('pages');
+	if (!hasPages) {
+		// Empty archive; the regular initSchema path will create both tables.
+		return;
+	}
+	await instance.schema.createTable('page_errors', (t) => {
+		t.increments('id');
+		t.integer('pageId').notNullable().unsigned().references('pages.id');
+		t.string('phase').notNullable();
+		t.text('message').notNullable();
+		t.integer('createdAt').notNullable();
+
+		t.index('pageId');
+	});
+	// eslint-disable-next-line no-console
+	console.error('[migrate] page_errors table created');
+}

--- a/packages/@nitpicker/crawler/src/crawler-orchestrator.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler-orchestrator.spec.ts
@@ -37,6 +37,11 @@ vi.mock('./crawler/crawler.js', () => {
 
 		/** Emits `error` and then `crawlEnd`, simulating a crawl with one error. */
 		start() {
+			const driver = fakeCrawlerDriver;
+			if (driver) {
+				driver(this);
+				return;
+			}
 			const error: CrawlerError = {
 				pid: process.pid,
 				isMainProcess: true,
@@ -51,8 +56,19 @@ vi.mock('./crawler/crawler.js', () => {
 	return { default: FakeCrawler };
 });
 
+/**
+ * Optional per-test override of the FakeCrawler's `start()` behaviour. When
+ * set, the FakeCrawler delegates to this function instead of running its
+ * default error-then-crawlEnd emission. Tests should reset it to `null` in
+ * `afterEach` to avoid leaking state.
+ */
+let fakeCrawlerDriver:
+	| ((handlers: { handlers: Map<string, (payload: never) => void> }) => void)
+	| null = null;
+
 afterEach(() => {
 	vi.restoreAllMocks();
+	fakeCrawlerDriver = null;
 });
 
 describe('CrawlerOrchestrator.crawling: error イベントの書き込み失敗', () => {
@@ -85,6 +101,78 @@ describe('CrawlerOrchestrator.crawling: error イベントの書き込み失敗'
 		).rejects.toThrow('db-write-failure');
 
 		expect(fakeArchive.addError).toHaveBeenCalledOnce();
+	});
+});
+
+describe('CrawlerOrchestrator.crawling: pageError ハンドラ', () => {
+	it('pageError イベントが archive.addPageError 経由で書き込まれる', async () => {
+		const addPageError = vi.fn(() => Promise.resolve());
+		const fakeArchive = {
+			on: vi.fn(),
+			setConfig: vi.fn(() => Promise.resolve()),
+			getConfig: vi.fn(() => Promise.resolve({ analyze: [] })),
+			setUrlOrder: vi.fn(() => Promise.resolve()),
+			getResourceByUrl: vi.fn(() => Promise.resolve(null)),
+			addPageError,
+			filePath: '/tmp/orchestrator-pageerror-test.nitpicker',
+		} as unknown as Archive;
+
+		const archiveModule = await import('./archive/archive.js');
+		vi.spyOn(archiveModule.default, 'create').mockResolvedValueOnce(fakeArchive);
+
+		fakeCrawlerDriver = (crawler) => {
+			crawler.handlers.get('pageError')?.({
+				url: 'https://example.com/page',
+				phase: 'retryExhausted',
+				message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+				isExternal: false,
+			} as never);
+			crawler.handlers.get('crawlEnd')?.(undefined as never);
+		};
+
+		await CrawlerOrchestrator.crawling(['https://example.com/'], {
+			cwd: '/tmp',
+			filePath: '/tmp/orchestrator-pageerror-test.nitpicker',
+		});
+
+		expect(addPageError).toHaveBeenCalledExactlyOnceWith(
+			'https://example.com/page',
+			'retryExhausted',
+			'📷 mobile-small: skipped — Attempted to use detached Frame',
+			false,
+		);
+	});
+
+	it('archive.addPageError が reject すると crawling() 全体が reject する', async () => {
+		const fakeArchive = {
+			on: vi.fn(),
+			setConfig: vi.fn(() => Promise.resolve()),
+			getConfig: vi.fn(() => Promise.resolve({ analyze: [] })),
+			setUrlOrder: vi.fn(() => Promise.resolve()),
+			getResourceByUrl: vi.fn(() => Promise.resolve(null)),
+			addPageError: vi.fn(() => Promise.reject(new Error('db-page-error-failure'))),
+			filePath: '/tmp/orchestrator-pageerror-reject-test.nitpicker',
+		} as unknown as Archive;
+
+		const archiveModule = await import('./archive/archive.js');
+		vi.spyOn(archiveModule.default, 'create').mockResolvedValueOnce(fakeArchive);
+
+		fakeCrawlerDriver = (crawler) => {
+			crawler.handlers.get('pageError')?.({
+				url: 'https://example.com/page',
+				phase: 'retryExhausted',
+				message: 'oops',
+				isExternal: false,
+			} as never);
+			crawler.handlers.get('crawlEnd')?.(undefined as never);
+		};
+
+		await expect(
+			CrawlerOrchestrator.crawling(['https://example.com/'], {
+				cwd: '/tmp',
+				filePath: '/tmp/orchestrator-pageerror-reject-test.nitpicker',
+			}),
+		).rejects.toThrow('db-page-error-failure');
 	});
 });
 

--- a/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
+++ b/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
@@ -240,6 +240,12 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 					.catch((error) => reject(error));
 			});
 
+			this.#crawler.on('pageError', ({ url, phase, message, isExternal }) => {
+				writeQueue
+					.enqueue(() => this.#archive.addPageError(url, phase, message, isExternal))
+					.catch((error) => reject(error));
+			});
+
 			this.#crawler.on('response', ({ resource }) => {
 				writeQueue
 					.enqueue(() => this.#archive.setResources(resource))

--- a/packages/@nitpicker/crawler/src/crawler/close-browser-safely.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/close-browser-safely.spec.ts
@@ -225,4 +225,72 @@ describe('closeBrowserSafely', () => {
 		expect(kill).not.toHaveBeenCalled();
 		expect(vi.getTimerCount()).toBe(0);
 	});
+
+	it('tree-kills the Chromium process tree on timeout when pid is available', async () => {
+		vi.useFakeTimers();
+		const kill = vi.fn<(signal?: NodeJS.Signals | number) => boolean>(() => true);
+		const killTree = vi.fn<
+			(pid: number, signal: NodeJS.Signals | number) => Promise<void>
+		>(async () => {});
+		const browser = createBrowserStub(() => new Promise<void>(() => {}), {
+			pid: 12_345,
+			kill,
+			killed: false,
+		});
+
+		const promise = closeBrowserSafely(browser, 30_000, { killTree });
+		await vi.advanceTimersByTimeAsync(30_000);
+		const timedOut = await promise;
+
+		expect(timedOut).toBe(true);
+		// The parent is SIGKILL'd via Node's ChildProcess.kill so Node reaps it
+		// correctly, and the whole tree is also walked via killProcessTree.
+		expect(kill).toHaveBeenCalledExactlyOnceWith('SIGKILL');
+		expect(killTree).toHaveBeenCalledExactlyOnceWith(12_345, 'SIGKILL');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('skips tree-kill when the child process has no pid (connected, not launched)', async () => {
+		vi.useFakeTimers();
+		const kill = vi.fn<(signal?: NodeJS.Signals | number) => boolean>(() => true);
+		const killTree = vi.fn<
+			(pid: number, signal: NodeJS.Signals | number) => Promise<void>
+		>(async () => {});
+		// `pid` may be undefined immediately after spawn or when puppeteer.connect()
+		// was used instead of launch(). The OS-level tree-kill needs a PID, so we
+		// fall back to the single-process SIGKILL only.
+		const browser = createBrowserStub(() => new Promise<void>(() => {}), {
+			kill,
+			killed: false,
+		});
+
+		const promise = closeBrowserSafely(browser, 30_000, { killTree });
+		await vi.advanceTimersByTimeAsync(30_000);
+		const timedOut = await promise;
+
+		expect(timedOut).toBe(true);
+		expect(kill).toHaveBeenCalledExactlyOnceWith('SIGKILL');
+		expect(killTree).not.toHaveBeenCalled();
+	});
+
+	it('does not tree-kill when close completes within the timeout', async () => {
+		vi.useFakeTimers();
+		const kill = vi.fn<(signal?: NodeJS.Signals | number) => boolean>(() => true);
+		const killTree = vi.fn<
+			(pid: number, signal: NodeJS.Signals | number) => Promise<void>
+		>(async () => {});
+		const browser = createBrowserStub(async () => {}, {
+			pid: 12_345,
+			kill,
+			killed: false,
+		});
+
+		const promise = closeBrowserSafely(browser, 30_000, { killTree });
+		await vi.advanceTimersByTimeAsync(0);
+		const timedOut = await promise;
+
+		expect(timedOut).toBe(false);
+		expect(kill).not.toHaveBeenCalled();
+		expect(killTree).not.toHaveBeenCalled();
+	});
 });

--- a/packages/@nitpicker/crawler/src/crawler/close-browser-safely.ts
+++ b/packages/@nitpicker/crawler/src/crawler/close-browser-safely.ts
@@ -1,3 +1,5 @@
+import { crawlerLog } from '../debug.js';
+
 import { killProcessTree } from './kill-process-tree.js';
 
 /**
@@ -107,7 +109,8 @@ export async function closeBrowserSafely(
 		// makes the type and the runtime value match.
 		const pid = childProcess.pid;
 		if (typeof pid === 'number') {
-			const killTree = deps.killTree ?? killProcessTree;
+			const killTree =
+				deps.killTree ?? ((p, sig) => killProcessTree(p, sig, { log: crawlerLog }));
 			await killTree(pid, 'SIGKILL');
 		}
 	}

--- a/packages/@nitpicker/crawler/src/crawler/close-browser-safely.ts
+++ b/packages/@nitpicker/crawler/src/crawler/close-browser-safely.ts
@@ -100,9 +100,15 @@ export async function closeBrowserSafely(
 		// Mark the Node ChildProcess as killed so Node's reaping logic treats
 		// it correctly; then walk the OS process tree.
 		childProcess.kill('SIGKILL');
-		if (typeof childProcess.pid === 'number') {
+		// Capture pid once: ChildProcess.pid is technically `number | undefined`
+		// (undefined before spawn settles), and reading it twice across the
+		// `await` below would force the second read to re-widen back to
+		// `number | undefined` regardless of the typeof guard. Snapshotting
+		// makes the type and the runtime value match.
+		const pid = childProcess.pid;
+		if (typeof pid === 'number') {
 			const killTree = deps.killTree ?? killProcessTree;
-			await killTree(childProcess.pid, 'SIGKILL');
+			await killTree(pid, 'SIGKILL');
 		}
 	}
 

--- a/packages/@nitpicker/crawler/src/crawler/close-browser-safely.ts
+++ b/packages/@nitpicker/crawler/src/crawler/close-browser-safely.ts
@@ -1,3 +1,5 @@
+import { killProcessTree } from './kill-process-tree.js';
+
 /**
  * Default time to wait for a graceful `browser.close()` before force-killing
  * the underlying Chromium process, in milliseconds.
@@ -19,6 +21,8 @@ export interface ClosableBrowser {
 	 * was connected to (rather than launched) and therefore owns no process.
 	 */
 	process(): {
+		/** PID of the Chromium parent process, or `undefined` before spawn settles. */
+		readonly pid?: number;
 		/** Sends a signal to the process; returns whether it was delivered. */
 		kill(signal?: NodeJS.Signals | number): boolean;
 		/** Whether a signal has already been successfully sent to the process. */
@@ -27,40 +31,54 @@ export interface ClosableBrowser {
 }
 
 /**
- * Closes a Puppeteer browser, falling back to a hard `SIGKILL` if the graceful
+ * Dependency overrides for {@link closeBrowserSafely}. Used only by tests
+ * to substitute the tree-kill orchestration.
+ */
+export interface CloseBrowserSafelyDeps {
+	/**
+	 * Kills a process and every descendant. Defaults to {@link killProcessTree}.
+	 */
+	killTree?: (pid: number, signal: NodeJS.Signals | number) => Promise<void>;
+}
+
+/**
+ * Closes a Puppeteer browser, falling back to a hard tree-kill if the graceful
  * close hangs.
  *
  * WHY: When a page's Chromium session dies mid-scrape (e.g. a viewport change
  * detaches the frame, surfacing `Attempted to use detached Frame` or
  * `Session closed`), the CDP connection can be left wedged. A bare
  * `await browser.close()` then never settles, stalling the `deal()` worker and
- * hanging the whole crawl. Racing the close against a timeout and SIGKILLing the
- * orphaned Chromium process on expiry guarantees the worker always completes.
+ * hanging the whole crawl. Racing the close against a timeout and SIGKILLing
+ * the Chromium process tree (parent + renderer/network/zygote children) on
+ * expiry guarantees the worker always completes and no orphan subprocesses are
+ * left behind.
  *
  * The losing timer is cleared explicitly in `.finally()` so it never keeps the
  * event loop alive after the race settles (a plain `delay()` in `Promise.race`
  * would leak the timer until it fires).
  *
- * Limitation: SIGKILL is sent only to the Chromium parent process, not to its
- * renderer/network/zygote children. Puppeteer spawns Chromium with
- * `detached: false`, so we cannot kill the whole process group (a negative-PID
- * signal would also hit our own Node process). The orphaned children detect
- * their broken IPC pipe and self-exit, typically within sub-seconds, so this
- * is a brief leak rather than a permanent one — but it is intrinsic to the
- * single-process kill strategy.
+ * The tree-kill happens via {@link killProcessTree}, which enumerates
+ * descendants through `ps` (POSIX) or delegates to `taskkill /T /F` (Windows).
+ * `childProcess.kill('SIGKILL')` is still invoked on the parent up-front
+ * because Node's `ChildProcess.killed` flag governs how Node treats the
+ * spawn handle (reaping etc.); without it the parent would linger in Node's
+ * process table even after the OS-level kill.
  * @param browser - The browser to close.
  * @param timeoutMs - Milliseconds to wait for a graceful close before force-killing.
  *   Defaults to {@link DEFAULT_CLOSE_TIMEOUT_MS}.
- * @returns `true` if the graceful close timed out (and a SIGKILL was attempted),
- *   `false` if `close()` settled in time.
+ * @param deps - Test-time overrides (default-free for production callers).
+ * @returns `true` if the graceful close timed out (and a tree-kill was
+ *   attempted), `false` if `close()` settled in time.
  */
 export async function closeBrowserSafely(
 	browser: ClosableBrowser,
 	timeoutMs: number = DEFAULT_CLOSE_TIMEOUT_MS,
+	deps: CloseBrowserSafelyDeps = {},
 ): Promise<boolean> {
 	// Capture the process up-front: after a successful close() puppeteer
 	// releases its internal reference and process() returns null, so we would
-	// have no handle to SIGKILL on timeout.
+	// have no handle to tree-kill on timeout.
 	const childProcess = browser.process();
 
 	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -79,7 +97,13 @@ export async function closeBrowserSafely(
 	});
 
 	if (timedOut && childProcess && !childProcess.killed) {
+		// Mark the Node ChildProcess as killed so Node's reaping logic treats
+		// it correctly; then walk the OS process tree.
 		childProcess.kill('SIGKILL');
+		if (typeof childProcess.pid === 'number') {
+			const killTree = deps.killTree ?? killProcessTree;
+			await killTree(childProcess.pid, 'SIGKILL');
+		}
 	}
 
 	return timedOut;

--- a/packages/@nitpicker/crawler/src/crawler/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.ts
@@ -21,6 +21,7 @@ import pkg from '../../package.json' with { type: 'json' };
 import { crawlerLog } from '../debug.js';
 
 import { detectPaginationPattern } from './detect-pagination-pattern.js';
+import { drainPhaseErrors } from './drain-phase-errors.js';
 import { fetchDestination } from './fetch-destination.js';
 import { findScopeEntry } from './find-scope-entry.js';
 import { formatCrawlProgress } from './format-crawl-progress.js';
@@ -245,26 +246,15 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 	}
 
 	/**
-	 * Drains the {@link Crawler.#pendingPhaseErrors} buffer for a URL and emits
-	 * one `pageError` event per buffered failure.
-	 *
-	 * Safe to call multiple times for the same URL: the buffer is removed on
-	 * the first call so subsequent invocations are no-ops.
+	 * Thin instance-bound adapter over {@link drainPhaseErrors}. Flushes
+	 * `#pendingPhaseErrors` for `url` as `pageError` events. Idempotent.
 	 * @param url - URL whose buffered errors should be flushed.
 	 * @param isExternal - Whether the URL is external to the crawl scope.
 	 */
 	#drainPhaseErrors(url: ExURL, isExternal: boolean): void {
-		const errors = this.#pendingPhaseErrors.get(url.href);
-		if (!errors || errors.length === 0) return;
-		this.#pendingPhaseErrors.delete(url.href);
-		for (const err of errors) {
-			void this.emit('pageError', {
-				url: url.href,
-				phase: err.phase,
-				message: err.message,
-				isExternal,
-			});
-		}
+		drainPhaseErrors(this.#pendingPhaseErrors, url.href, isExternal, (payload) => {
+			void this.emit('pageError', payload);
+		});
 	}
 	/**
 	 * Emits error events for a deal-level failure.
@@ -718,9 +708,20 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 						if (isExternal) {
 							externalDoneUrls.add(protocolAgnosticKey(url.withoutHashAndAuth));
 						}
-						// Defensive: clear any leftover entries (e.g. predicted
-						// URLs that were discarded before #drainPhaseErrors ran)
-						// so the buffer cannot leak across crawls.
+						// Defensive: clear any leftover entries so the buffer cannot
+						// leak across crawls. If entries still exist here, neither
+						// the success nor the catch path drained them — typically
+						// because a predicted URL was discarded before reaching the
+						// drain point. Log the drop so production runs that hit
+						// this case are observable via DEBUG=Nitpicker:Crawler.
+						const remaining = this.#pendingPhaseErrors.get(url.href);
+						if (remaining && remaining.length > 0) {
+							crawlerLog(
+								'Dropped %d phase error(s) for %s (no archive entry created)',
+								remaining.length,
+								url.href,
+							);
+						}
 						this.#pendingPhaseErrors.delete(url.href);
 					}
 				};

--- a/packages/@nitpicker/crawler/src/crawler/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.ts
@@ -61,6 +61,17 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 	readonly #linkList = new LinkList();
 	/** Merged crawler configuration (user overrides + defaults). */
 	readonly #options: CrawlerOptions;
+	/**
+	 * Phase errors observed during {@link Crawler.#launchBrowserAndScrape},
+	 * buffered per URL href so they can be emitted as `pageError` events
+	 * AFTER the corresponding `page` / `externalPage` event. This ordering
+	 * lets the orchestrator's WriteQueue serialise `setPage` before
+	 * `insertPageError`, so the FK resolution via URL always finds the row.
+	 */
+	readonly #pendingPhaseErrors = new Map<
+		string /* url.href */,
+		{ phase: string; message: string }[]
+	>();
 	/** Set of resource URLs (without hash) already captured, for deduplication. */
 	readonly #resources = new Set<string>();
 	/** URLs restored from a previous session that still need to be scraped. */
@@ -233,6 +244,28 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 		});
 	}
 
+	/**
+	 * Drains the {@link Crawler.#pendingPhaseErrors} buffer for a URL and emits
+	 * one `pageError` event per buffered failure.
+	 *
+	 * Safe to call multiple times for the same URL: the buffer is removed on
+	 * the first call so subsequent invocations are no-ops.
+	 * @param url - URL whose buffered errors should be flushed.
+	 * @param isExternal - Whether the URL is external to the crawl scope.
+	 */
+	#drainPhaseErrors(url: ExURL, isExternal: boolean): void {
+		const errors = this.#pendingPhaseErrors.get(url.href);
+		if (!errors || errors.length === 0) return;
+		this.#pendingPhaseErrors.delete(url.href);
+		for (const err of errors) {
+			void this.emit('pageError', {
+				url: url.href,
+				phase: err.phase,
+				message: err.message,
+				isExternal,
+			});
+		}
+	}
 	/**
 	 * Emits error events for a deal-level failure.
 	 *
@@ -422,6 +455,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 			}
 		}
 	}
+
 	/**
 	 * Launches a fresh Puppeteer browser, runs the beholder scraper, and cleans up.
 	 *
@@ -478,6 +512,17 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 					update(msg);
 				}
 				void this.emit('changePhase', e);
+
+				// retryExhausted fires when beholder's @retryable gives up on a
+				// secondary scrape step (e.g. a viewport switch detaching the
+				// frame in #fetchImages). The page itself still completes, so
+				// we buffer the failure and emit it as a pageError after the
+				// page event has been emitted.
+				if (e.name === 'retryExhausted') {
+					const list = this.#pendingPhaseErrors.get(url.href) ?? [];
+					list.push({ phase: e.name, message: e.message });
+					this.#pendingPhaseErrors.set(url.href, list);
+				}
 			});
 
 			const result = await scraper.scrapeStart(page, url, {
@@ -639,6 +684,11 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 						this.#handleResult(result, url, enqueue, paginationState, concurrency);
 						this.#handleResources(result.resources);
 						log(formatResultSummary(result));
+
+						// Phase errors must be emitted AFTER 'page' / 'externalPage'
+						// so the orchestrator's WriteQueue sees `setPage` before
+						// `insertPageError` and the URL→pageId resolution succeeds.
+						this.#drainPhaseErrors(url, isExternal);
 					} catch (error) {
 						crawlerLog('Worker error for %s: %O', url.href, error);
 						log(c.red('Error'));
@@ -661,10 +711,17 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 							isExternal,
 							error: workerError,
 						});
+						// Hard-error path: persist whatever phase errors we have
+						// already buffered so they are not lost.
+						this.#drainPhaseErrors(url, isExternal);
 					} finally {
 						if (isExternal) {
 							externalDoneUrls.add(protocolAgnosticKey(url.withoutHashAndAuth));
 						}
+						// Defensive: clear any leftover entries (e.g. predicted
+						// URLs that were discarded before #drainPhaseErrors ran)
+						// so the buffer cannot leak across crawls.
+						this.#pendingPhaseErrors.delete(url.href);
 					}
 				};
 			},

--- a/packages/@nitpicker/crawler/src/crawler/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.ts
@@ -20,6 +20,7 @@ import c from 'ansi-colors';
 import pkg from '../../package.json' with { type: 'json' };
 import { crawlerLog } from '../debug.js';
 
+import { createChangePhaseHandler } from './create-change-phase-handler.js';
 import { detectPaginationPattern } from './detect-pagination-pattern.js';
 import { drainPhaseErrors } from './drain-phase-errors.js';
 import { fetchDestination } from './fetch-destination.js';
@@ -35,6 +36,7 @@ import { injectScopeAuth } from './inject-scope-auth.js';
 import { isHtmlContentType } from './is-html-content-type.js';
 import LinkList from './link-list.js';
 import { linkToPageData } from './link-to-page-data.js';
+import { logUndrainedPhaseErrors } from './log-undrained-phase-errors.js';
 import { partitionUrlsByHtml } from './partition-urls-by-html.js';
 import { protocolAgnosticKey } from './protocol-agnostic-key.js';
 import { resourceToPageData } from './resource-to-page-data.js';
@@ -248,6 +250,15 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 	/**
 	 * Thin instance-bound adapter over {@link drainPhaseErrors}. Flushes
 	 * `#pendingPhaseErrors` for `url` as `pageError` events. Idempotent.
+	 *
+	 * **Test gap (known)**: this adapter is invoked from the worker body in
+	 * {@link Crawler.#runDeal} at three call sites — after `#handleResult`,
+	 * inside the worker's `catch`, and via `logUndrainedPhaseErrors` in
+	 * `finally`. The drain logic itself is unit-tested in
+	 * `drain-phase-errors.spec.ts`; the wiring (whether the worker actually
+	 * calls it on each path) is verified by code review only, because
+	 * driving the worker requires a Puppeteer + beholder mock stack whose
+	 * cost outweighs the regression it would catch.
 	 * @param url - URL whose buffered errors should be flushed.
 	 * @param isExternal - Whether the URL is external to the crawl scope.
 	 */
@@ -496,24 +507,16 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 			}
 			const scraper = new Scraper();
 
-			scraper.on('changePhase', (e) => {
-				const msg = formatPhaseLog(e);
-				if (msg) {
-					update(msg);
-				}
-				void this.emit('changePhase', e);
-
-				// retryExhausted fires when beholder's @retryable gives up on a
-				// secondary scrape step (e.g. a viewport switch detaching the
-				// frame in #fetchImages). The page itself still completes, so
-				// we buffer the failure and emit it as a pageError after the
-				// page event has been emitted.
-				if (e.name === 'retryExhausted') {
-					const list = this.#pendingPhaseErrors.get(url.href) ?? [];
-					list.push({ phase: e.name, message: e.message });
-					this.#pendingPhaseErrors.set(url.href, list);
-				}
-			});
+			scraper.on(
+				'changePhase',
+				createChangePhaseHandler({
+					emit: (event) => void this.emit('changePhase', event),
+					update,
+					formatLog: formatPhaseLog,
+					buffer: this.#pendingPhaseErrors,
+					urlHref: url.href,
+				}),
+			);
 
 			const result = await scraper.scrapeStart(page, url, {
 				isExternal,
@@ -708,21 +711,13 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 						if (isExternal) {
 							externalDoneUrls.add(protocolAgnosticKey(url.withoutHashAndAuth));
 						}
-						// Defensive: clear any leftover entries so the buffer cannot
-						// leak across crawls. If entries still exist here, neither
-						// the success nor the catch path drained them — typically
-						// because a predicted URL was discarded before reaching the
-						// drain point. Log the drop so production runs that hit
-						// this case are observable via DEBUG=Nitpicker:Crawler.
-						const remaining = this.#pendingPhaseErrors.get(url.href);
-						if (remaining && remaining.length > 0) {
-							crawlerLog(
-								'Dropped %d phase error(s) for %s (no archive entry created)',
-								remaining.length,
-								url.href,
-							);
-						}
-						this.#pendingPhaseErrors.delete(url.href);
+						// Phase errors still in the buffer here were not drained
+						// by the success or catch paths — typically because a
+						// predicted URL was discarded before reaching the drain
+						// point. The helper logs the drop (observable via
+						// DEBUG=Nitpicker:Crawler) and removes the entry so the
+						// Map cannot leak across crawls.
+						logUndrainedPhaseErrors(this.#pendingPhaseErrors, url.href, crawlerLog);
 					}
 				};
 			},

--- a/packages/@nitpicker/crawler/src/crawler/create-change-phase-handler.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/create-change-phase-handler.spec.ts
@@ -1,0 +1,169 @@
+import type { BufferedPhaseError } from './drain-phase-errors.js';
+import type { ChangePhaseEvent } from '@d-zero/beholder';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createChangePhaseHandler } from './create-change-phase-handler.js';
+
+/**
+ * Builds a `ChangePhaseEvent` with the fields the handler actually touches.
+ * Extra fields are defaulted so individual tests stay focused.
+ * @param overrides - Fields to override on the default event shape.
+ * @returns A {@link ChangePhaseEvent} suitable for the handler.
+ */
+function makeEvent(overrides: Partial<ChangePhaseEvent> = {}): ChangePhaseEvent {
+	return {
+		pid: 1234,
+		name: 'openPage',
+		url: null,
+		isExternal: false,
+		message: 'msg',
+		...overrides,
+	};
+}
+
+/**
+ * Builds a `ChangePhaseHandlerOptions` value with sensible defaults.
+ * Tests override only the fields they care about.
+ * @param overrides
+ */
+function buildOptions(
+	overrides: Partial<Parameters<typeof createChangePhaseHandler>[0]> = {},
+): Parameters<typeof createChangePhaseHandler>[0] {
+	return {
+		emit: vi.fn(),
+		update: vi.fn(),
+		formatLog: vi.fn(() => 'formatted'),
+		buffer: new Map<string, BufferedPhaseError[]>(),
+		urlHref: 'https://example.com/',
+		...overrides,
+	};
+}
+
+describe('createChangePhaseHandler', () => {
+	it('forwards every event through emit unchanged', () => {
+		const emit = vi.fn();
+		const handler = createChangePhaseHandler(buildOptions({ emit }));
+
+		const event = makeEvent({ name: 'openPage', message: 'opening' });
+		handler(event);
+
+		expect(emit).toHaveBeenCalledExactlyOnceWith(event);
+	});
+
+	it('does not buffer events whose name is not retryExhausted', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>();
+		const handler = createChangePhaseHandler(buildOptions({ buffer }));
+
+		handler(makeEvent({ name: 'openPage', message: 'opening' }));
+		handler(makeEvent({ name: 'getImages', message: 'images' }));
+
+		expect(buffer.size).toBe(0);
+	});
+
+	it('buffers a retryExhausted event into the per-URL buffer', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>();
+		const handler = createChangePhaseHandler(
+			buildOptions({ buffer, urlHref: 'https://example.com/wedged' }),
+		);
+
+		handler(
+			makeEvent({
+				name: 'retryExhausted',
+				message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+			}),
+		);
+
+		expect(buffer.get('https://example.com/wedged')).toEqual([
+			{
+				phase: 'retryExhausted',
+				message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+			},
+		]);
+	});
+
+	it('appends a second retryExhausted to the same URL bucket', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>();
+		const handler = createChangePhaseHandler(
+			buildOptions({ buffer, urlHref: 'https://example.com/wedged' }),
+		);
+
+		handler(makeEvent({ name: 'retryExhausted', message: 'first' }));
+		handler(makeEvent({ name: 'retryExhausted', message: 'second' }));
+
+		expect(buffer.get('https://example.com/wedged')).toEqual([
+			{ phase: 'retryExhausted', message: 'first' },
+			{ phase: 'retryExhausted', message: 'second' },
+		]);
+	});
+
+	it('keys the buffer strictly by the supplied urlHref (no cross-URL contamination)', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>();
+		const handlerA = createChangePhaseHandler(
+			buildOptions({ buffer, urlHref: 'https://example.com/a' }),
+		);
+		const handlerB = createChangePhaseHandler(
+			buildOptions({ buffer, urlHref: 'https://example.com/b' }),
+		);
+
+		handlerA(makeEvent({ name: 'retryExhausted', message: 'a-err' }));
+		handlerB(makeEvent({ name: 'retryExhausted', message: 'b-err' }));
+
+		expect(buffer.get('https://example.com/a')).toEqual([
+			{ phase: 'retryExhausted', message: 'a-err' },
+		]);
+		expect(buffer.get('https://example.com/b')).toEqual([
+			{ phase: 'retryExhausted', message: 'b-err' },
+		]);
+	});
+
+	it('calls update with the formatLog output when it is a non-empty string', () => {
+		const update = vi.fn();
+		const formatLog = vi.fn(() => 'opening page');
+		const handler = createChangePhaseHandler(buildOptions({ update, formatLog }));
+
+		const event = makeEvent({ name: 'openPage', message: 'opening' });
+		handler(event);
+
+		expect(formatLog).toHaveBeenCalledExactlyOnceWith(event);
+		expect(update).toHaveBeenCalledExactlyOnceWith('opening page');
+	});
+
+	it('skips update when formatLog returns null (phase with no log line)', () => {
+		// formatLog returns null for scrapeStart/scrapeEnd etc. The handler
+		// must not spam the progress UI with empty lines.
+		const update = vi.fn();
+		const formatLog = vi.fn(() => null);
+		const handler = createChangePhaseHandler(buildOptions({ update, formatLog }));
+
+		handler(makeEvent({ name: 'scrapeStart' }));
+
+		expect(formatLog).toHaveBeenCalledOnce();
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it('skips update when formatLog returns an empty string', () => {
+		const update = vi.fn();
+		const handler = createChangePhaseHandler(
+			buildOptions({ update, formatLog: () => '' }),
+		);
+
+		handler(makeEvent({ name: 'whatever' }));
+
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it('still forwards via emit even when update is skipped', () => {
+		// Phases with no log line must still reach external listeners — emit() is
+		// the single source of truth for the changePhase channel.
+		const emit = vi.fn();
+		const handler = createChangePhaseHandler(
+			buildOptions({ emit, formatLog: () => null }),
+		);
+
+		const event = makeEvent({ name: 'scrapeStart' });
+		handler(event);
+
+		expect(emit).toHaveBeenCalledExactlyOnceWith(event);
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/create-change-phase-handler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/create-change-phase-handler.ts
@@ -1,0 +1,78 @@
+import type { BufferedPhaseError } from './drain-phase-errors.js';
+import type { ChangePhaseEvent } from '@d-zero/beholder';
+
+/**
+ * Options for {@link createChangePhaseHandler}. Declared structurally so
+ * tests can pass plain `vi.fn()` stubs without spinning up a real Crawler.
+ */
+export interface ChangePhaseHandlerOptions {
+	/**
+	 * Forwards the raw {@link ChangePhaseEvent} so external listeners on the
+	 * Crawler still see every transition (typically `this.emit.bind(this)`
+	 * narrowed to the `changePhase` channel).
+	 */
+	emit: (event: ChangePhaseEvent) => void;
+	/** Receives the formatted progress log line. Skipped when empty. */
+	update: (log: string) => void;
+	/**
+	 * Renders the human-readable progress message for an event. Injected so
+	 * the handler stays free of the Crawler's internal log formatter.
+	 * Returns `null` for events that should not surface to `update`.
+	 */
+	formatLog: (event: ChangePhaseEvent) => string | null;
+	/**
+	 * Per-URL buffer of `retryExhausted` failures. The handler appends to
+	 * this map; it does not drain (that is `drainPhaseErrors`'s job).
+	 */
+	buffer: Map<string, BufferedPhaseError[]>;
+	/** URL href used as the buffer key for this scrape. */
+	urlHref: string;
+}
+
+/**
+ * Builds the `scraper.on('changePhase', ...)` listener used by
+ * {@link Crawler.#launchBrowserAndScrape}.
+ *
+ * Three responsibilities:
+ * 1. Render the phase log via the injected `formatLog` and pipe it to `update`.
+ * 2. Forward the raw event so external consumers (CLI progress UI etc.) see
+ *    every transition.
+ * 3. Buffer `retryExhausted` events into the per-URL phase-error map so they
+ *    can be drained as `pageError` events AFTER the `page` event fires.
+ *
+ * WHY a factory: the listener captures per-scrape state (`buffer`, `urlHref`,
+ * `update`). Extracting the factory makes the wiring directly unit-testable
+ * with plain stubs, instead of requiring a mocked Puppeteer + beholder + dealer
+ * stack to drive the worker.
+ *
+ * **Caller contract**: register the returned handler at most once per
+ * `scraper` instance. The Crawler creates a fresh Scraper per URL so this
+ * holds today; if scraper pooling is ever introduced, register exactly one
+ * handler per scrape and unregister it on completion to avoid duplicate
+ * buffer entries.
+ * @param options - Wiring dependencies for the handler.
+ * @returns A function suitable for `scraper.on('changePhase', ...)`.
+ */
+export function createChangePhaseHandler(
+	options: ChangePhaseHandlerOptions,
+): (event: ChangePhaseEvent) => void {
+	const { emit, update, formatLog, buffer, urlHref } = options;
+	return (event) => {
+		const msg = formatLog(event);
+		if (msg) {
+			update(msg);
+		}
+		emit(event);
+
+		// retryExhausted fires when beholder's @retryable gives up on a
+		// secondary scrape step (e.g. a viewport switch detaching the frame
+		// in #fetchImages). The page itself still completes, so we buffer
+		// the failure here and emit it as a pageError after the page event
+		// has been emitted.
+		if (event.name === 'retryExhausted') {
+			const list = buffer.get(urlHref) ?? [];
+			list.push({ phase: event.name, message: event.message });
+			buffer.set(urlHref, list);
+		}
+	};
+}

--- a/packages/@nitpicker/crawler/src/crawler/drain-phase-errors.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/drain-phase-errors.spec.ts
@@ -1,0 +1,122 @@
+import type { BufferedPhaseError } from './drain-phase-errors.js';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { drainPhaseErrors } from './drain-phase-errors.js';
+
+describe('drainPhaseErrors', () => {
+	it('returns 0 and never calls emit when the buffer has no entry for the URL', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>();
+		const emit = vi.fn();
+
+		const count = drainPhaseErrors(buffer, 'https://example.com/', false, emit);
+
+		expect(count).toBe(0);
+		expect(emit).not.toHaveBeenCalled();
+		expect(buffer.size).toBe(0);
+	});
+
+	it('returns 0 and never calls emit when the buffered entry is an empty array', () => {
+		// An empty array can land in the buffer if a caller calls set() with []
+		// directly. The drain must still treat it as a no-op rather than
+		// emitting a zero-record stream.
+		const buffer = new Map<string, BufferedPhaseError[]>([['https://example.com/', []]]);
+		const emit = vi.fn();
+
+		const count = drainPhaseErrors(buffer, 'https://example.com/', false, emit);
+
+		expect(count).toBe(0);
+		expect(emit).not.toHaveBeenCalled();
+	});
+
+	it('emits one pageError payload per buffered record and deletes the entry', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>([
+			[
+				'https://example.com/page',
+				[
+					{
+						phase: 'retryExhausted',
+						message: '📷 desktop-compact: skipped — Session closed',
+					},
+					{
+						phase: 'retryExhausted',
+						message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+					},
+				],
+			],
+		]);
+		const emit = vi.fn();
+
+		const count = drainPhaseErrors(buffer, 'https://example.com/page', false, emit);
+
+		expect(count).toBe(2);
+		expect(emit).toHaveBeenCalledTimes(2);
+		expect(emit.mock.calls[0]).toEqual([
+			{
+				url: 'https://example.com/page',
+				phase: 'retryExhausted',
+				message: '📷 desktop-compact: skipped — Session closed',
+				isExternal: false,
+			},
+		]);
+		expect(emit.mock.calls[1]).toEqual([
+			{
+				url: 'https://example.com/page',
+				phase: 'retryExhausted',
+				message: '📷 mobile-small: skipped — Attempted to use detached Frame',
+				isExternal: false,
+			},
+		]);
+		// The entry is removed so a follow-up drain or finally delete is a no-op.
+		expect(buffer.has('https://example.com/page')).toBe(false);
+	});
+
+	it('propagates the isExternal flag into every emitted payload', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>([
+			[
+				'https://external.example.com/oops',
+				[{ phase: 'retryExhausted', message: 'oops' }],
+			],
+		]);
+		const emit = vi.fn();
+
+		drainPhaseErrors(buffer, 'https://external.example.com/oops', true, emit);
+
+		expect(emit).toHaveBeenCalledExactlyOnceWith({
+			url: 'https://external.example.com/oops',
+			phase: 'retryExhausted',
+			message: 'oops',
+			isExternal: true,
+		});
+	});
+
+	it('does not touch entries for other URLs in the buffer', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>([
+			['https://example.com/a', [{ phase: 'retryExhausted', message: 'a-err' }]],
+			['https://example.com/b', [{ phase: 'retryExhausted', message: 'b-err' }]],
+		]);
+		const emit = vi.fn();
+
+		drainPhaseErrors(buffer, 'https://example.com/a', false, emit);
+
+		expect(emit).toHaveBeenCalledTimes(1);
+		expect(buffer.has('https://example.com/a')).toBe(false);
+		expect(buffer.get('https://example.com/b')).toEqual([
+			{ phase: 'retryExhausted', message: 'b-err' },
+		]);
+	});
+
+	it('is idempotent — a second call for the same URL is a no-op', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>([
+			['https://example.com/', [{ phase: 'retryExhausted', message: 'err' }]],
+		]);
+		const emit = vi.fn();
+
+		const first = drainPhaseErrors(buffer, 'https://example.com/', false, emit);
+		const second = drainPhaseErrors(buffer, 'https://example.com/', false, emit);
+
+		expect(first).toBe(1);
+		expect(second).toBe(0);
+		expect(emit).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/drain-phase-errors.ts
+++ b/packages/@nitpicker/crawler/src/crawler/drain-phase-errors.ts
@@ -1,0 +1,68 @@
+/**
+ * A buffered phase-error record awaiting emission as a `pageError` event.
+ *
+ * `phase` is the beholder phase name (typically `'retryExhausted'`) and
+ * `message` is the human-readable failure text.
+ */
+export interface BufferedPhaseError {
+	/** Scrape phase name. */
+	phase: string;
+	/** Human-readable failure message. */
+	message: string;
+}
+
+/**
+ * Emitter signature accepted by {@link drainPhaseErrors} for the `pageError`
+ * event. Declared structurally so the Crawler's typed event emitter can be
+ * adapted with a thin closure at the call site without leaking through here.
+ */
+export type DrainPhaseErrorsEmit = (payload: {
+	/** URL of the affected page. */
+	url: string;
+	/** Scrape phase name. */
+	phase: string;
+	/** Human-readable failure message. */
+	message: string;
+	/** Whether the URL is external to the crawl scope. */
+	isExternal: boolean;
+}) => void;
+
+/**
+ * Drains the buffered phase errors for a URL: removes the entry from
+ * `buffer` and invokes `emit` once per buffered record.
+ *
+ * WHY a standalone function: the Crawler buffers `retryExhausted` events
+ * keyed by `url.href` during scrapeStart, then flushes them as
+ * `pageError` events AFTER `page` / `externalPage` has been emitted so the
+ * orchestrator's WriteQueue serialises `setPage` before `insertPageError`.
+ * Extracting the drain step here makes the flush + delete contract
+ * directly unit-testable without spinning up a real Crawler.
+ *
+ * Idempotent: calling twice for the same `urlHref` is safe — the second
+ * call sees an empty buffer and is a no-op.
+ * @param buffer - The pending-phase-errors map, keyed by URL href.
+ * @param urlHref - URL whose buffered errors should be drained.
+ * @param isExternal - Whether the URL is external to the crawl scope.
+ * @param emit - Callback invoked once per buffered phase-error record.
+ * @returns The number of phase-error events emitted (0 when the buffer
+ *   had no entry for `urlHref`).
+ */
+export function drainPhaseErrors(
+	buffer: Map<string, BufferedPhaseError[]>,
+	urlHref: string,
+	isExternal: boolean,
+	emit: DrainPhaseErrorsEmit,
+): number {
+	const errors = buffer.get(urlHref);
+	if (!errors || errors.length === 0) return 0;
+	buffer.delete(urlHref);
+	for (const err of errors) {
+		emit({
+			url: urlHref,
+			phase: err.phase,
+			message: err.message,
+			isExternal,
+		});
+	}
+	return errors.length;
+}

--- a/packages/@nitpicker/crawler/src/crawler/kill-process-tree.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/kill-process-tree.spec.ts
@@ -1,0 +1,148 @@
+import type { ProcessKiller } from './kill-process-tree.js';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { killProcessTree } from './kill-process-tree.js';
+
+/**
+ * Builds a {@link ProcessKiller} whose `kill` is a `vi.fn()` so call order
+ * and arguments can be asserted directly.
+ * @returns The mock killer.
+ */
+function createMockKiller(): ProcessKiller & { kill: ReturnType<typeof vi.fn> } {
+	return { kill: vi.fn() };
+}
+
+describe('killProcessTree (POSIX)', () => {
+	it('kills the root when it has no descendants', async () => {
+		const killer = createMockKiller();
+		const listDescendants = vi.fn(() => Promise.resolve([] as readonly number[]));
+
+		await killProcessTree(1234, 'SIGKILL', {
+			platform: 'linux',
+			listDescendants,
+			killer,
+		});
+
+		expect(killer.kill).toHaveBeenCalledExactlyOnceWith(1234, 'SIGKILL');
+		expect(listDescendants).toHaveBeenCalledExactlyOnceWith(1234);
+	});
+
+	it('kills descendants leaves-first, then the root', async () => {
+		const killer = createMockKiller();
+		// BFS order from root 100: child=200, grand=300 (under 200), great=400 (under 300)
+		const listDescendants = vi.fn(() =>
+			Promise.resolve([200, 300, 400] as readonly number[]),
+		);
+
+		await killProcessTree(100, 'SIGKILL', {
+			platform: 'darwin',
+			listDescendants,
+			killer,
+		});
+
+		expect(killer.kill).toHaveBeenCalledTimes(4);
+		// Reversed (leaves first): 400, 300, 200, then root 100.
+		expect(killer.kill.mock.calls).toStrictEqual([
+			[400, 'SIGKILL'],
+			[300, 'SIGKILL'],
+			[200, 'SIGKILL'],
+			[100, 'SIGKILL'],
+		]);
+	});
+
+	it('passes the supplied signal through to every kill', async () => {
+		const killer = createMockKiller();
+		const listDescendants = vi.fn(() => Promise.resolve([200] as readonly number[]));
+
+		await killProcessTree(100, 'SIGTERM', {
+			platform: 'linux',
+			listDescendants,
+			killer,
+		});
+
+		expect(killer.kill.mock.calls).toStrictEqual([
+			[200, 'SIGTERM'],
+			[100, 'SIGTERM'],
+		]);
+	});
+
+	it('still kills the root when descendant enumeration returns empty', async () => {
+		// Simulates `ps` failing or returning no rows for our PID.
+		const killer = createMockKiller();
+		const listDescendants = vi.fn(() => Promise.resolve([] as readonly number[]));
+
+		await killProcessTree(999, 'SIGKILL', {
+			platform: 'linux',
+			listDescendants,
+			killer,
+		});
+
+		expect(killer.kill).toHaveBeenCalledExactlyOnceWith(999, 'SIGKILL');
+	});
+
+	it('does not reject when the killer itself throws on every call', async () => {
+		// Default POSIX killer swallows ESRCH/EPERM, but custom killers may
+		// not — verify the orchestrator does not crash if one PID errors.
+		const killer: ProcessKiller = {
+			kill() {
+				throw new Error('boom');
+			},
+		};
+		const listDescendants = () => Promise.resolve([200, 300] as readonly number[]);
+
+		// The current implementation does NOT catch arbitrary killer errors,
+		// only the default killer swallows them. Document this contract: callers
+		// using a custom killer must make it best-effort themselves.
+		await expect(
+			killProcessTree(100, 'SIGKILL', {
+				platform: 'linux',
+				listDescendants,
+				killer,
+			}),
+		).rejects.toThrow('boom');
+	});
+});
+
+describe('killProcessTree (Windows)', () => {
+	it('delegates to runTreeKill and does not enumerate descendants', async () => {
+		const runTreeKill = vi.fn(() => Promise.resolve());
+		const killer = createMockKiller();
+		const listDescendants = vi.fn(() => Promise.resolve([200, 300] as readonly number[]));
+
+		await killProcessTree(7777, 'SIGKILL', {
+			platform: 'win32',
+			runTreeKill,
+			killer,
+			listDescendants,
+		});
+
+		expect(runTreeKill).toHaveBeenCalledExactlyOnceWith(7777);
+		// Windows path skips the POSIX enumeration entirely.
+		expect(listDescendants).not.toHaveBeenCalled();
+		expect(killer.kill).not.toHaveBeenCalled();
+	});
+
+	it('resolves even when runTreeKill rejects (best-effort cleanup contract)', async () => {
+		// Real implementation uses spawn + close listener that resolves on
+		// any exit code, but custom test doubles may reject. Document the
+		// orchestrator's lack of additional catching here.
+		const runTreeKill = vi.fn(() => Promise.reject(new Error('taskkill missing')));
+
+		await expect(
+			killProcessTree(7777, 'SIGKILL', {
+				platform: 'win32',
+				runTreeKill,
+			}),
+		).rejects.toThrow('taskkill missing');
+	});
+});
+
+describe('killProcessTree (default deps integration)', () => {
+	it('defaults to the current process platform when none is supplied', async () => {
+		// Smoke test: invoke with a fake PID that almost certainly does not exist.
+		// On every supported platform the function must resolve without throwing,
+		// because both default killers swallow ENOENT/ESRCH.
+		await expect(killProcessTree(999_999_999)).resolves.toBeUndefined();
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/kill-process-tree.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/kill-process-tree.spec.ts
@@ -1,4 +1,7 @@
-import type { ProcessKiller } from './kill-process-tree.js';
+import type { ProcessKiller, Spawner } from './kill-process-tree.js';
+import type { ChildProcess } from 'node:child_process';
+
+import { EventEmitter } from 'node:events';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -11,6 +14,46 @@ import { killProcessTree } from './kill-process-tree.js';
  */
 function createMockKiller(): ProcessKiller & { kill: ReturnType<typeof vi.fn> } {
 	return { kill: vi.fn() };
+}
+
+/**
+ * Minimal {@link ChildProcess} stand-in for tests: an EventEmitter plus a
+ * piped stdout that the caller can write to via `pushStdout`. The real
+ * ChildProcess type is structurally a superset of this for the methods our
+ * implementation actually touches (`on`, `stdout.on('data')`).
+ */
+interface FakeChild {
+	/** Emits the `close` event with the supplied exit code. */
+	close(code: number | null): void;
+	/** Emits the `error` event with the supplied Error. */
+	emitError(error: Error): void;
+	/** Pushes a chunk of bytes to the fake stdout. */
+	pushStdout(chunk: string | Buffer): void;
+	/** Cast helper to satisfy the {@link Spawner} return type. */
+	asChildProcess(): ChildProcess;
+}
+
+/**
+ * Creates a {@link FakeChild} suitable for handing back from a fake {@link Spawner}.
+ */
+function createFakeChild(): FakeChild {
+	const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter };
+	const stdout = new EventEmitter();
+	(child as unknown as { stdout: EventEmitter }).stdout = stdout;
+	return {
+		close(code) {
+			child.emit('close', code);
+		},
+		emitError(error) {
+			child.emit('error', error);
+		},
+		pushStdout(chunk) {
+			stdout.emit('data', Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		},
+		asChildProcess() {
+			return child as unknown as ChildProcess;
+		},
+	};
 }
 
 describe('killProcessTree (POSIX)', () => {
@@ -144,5 +187,157 @@ describe('killProcessTree (default deps integration)', () => {
 		// On every supported platform the function must resolve without throwing,
 		// because both default killers swallow ENOENT/ESRCH.
 		await expect(killProcessTree(999_999_999)).resolves.toBeUndefined();
+	});
+});
+
+describe('killProcessTree default runWindowsTaskkill (via Spawner injection)', () => {
+	it('spawns taskkill /T /F /PID <pid> with stdio ignored', async () => {
+		const child = createFakeChild();
+		const spawner = vi.fn<Spawner>(() => child.asChildProcess());
+
+		const promise = killProcessTree(7777, 'SIGKILL', {
+			platform: 'win32',
+			spawn: spawner,
+		});
+		// Resolve the spawn (taskkill exits 0).
+		child.close(0);
+		await promise;
+
+		expect(spawner).toHaveBeenCalledExactlyOnceWith(
+			'taskkill',
+			['/T', '/F', '/PID', '7777'],
+			{ stdio: 'ignore' },
+		);
+	});
+
+	it('logs and resolves when taskkill cannot be spawned (ENOENT)', async () => {
+		const child = createFakeChild();
+		const spawner = vi.fn<Spawner>(() => child.asChildProcess());
+		const log = vi.fn();
+
+		const promise = killProcessTree(7777, 'SIGKILL', {
+			platform: 'win32',
+			spawn: spawner,
+			log,
+		});
+		child.emitError(new Error('spawn taskkill ENOENT'));
+		await promise;
+
+		expect(log).toHaveBeenCalledOnce();
+		expect(log.mock.calls[0]![0]).toMatch(/taskkill invocation failed/);
+	});
+
+	it('logs and resolves when taskkill exits non-zero (e.g. PID already gone)', async () => {
+		const child = createFakeChild();
+		const spawner = vi.fn<Spawner>(() => child.asChildProcess());
+		const log = vi.fn();
+
+		const promise = killProcessTree(7777, 'SIGKILL', {
+			platform: 'win32',
+			spawn: spawner,
+			log,
+		});
+		child.close(128);
+		await promise;
+
+		expect(log).toHaveBeenCalledOnce();
+		expect(log.mock.calls[0]![0]).toMatch(/taskkill exited with non-zero/);
+	});
+});
+
+describe('killProcessTree default POSIX ps enumeration (via Spawner injection)', () => {
+	it('spawns ps -A -o pid=,ppid= and BFS-walks the parsed output', async () => {
+		const child = createFakeChild();
+		const spawner = vi.fn<Spawner>(() => child.asChildProcess());
+		const killer = createMockKiller();
+
+		const promise = killProcessTree(100, 'SIGKILL', {
+			platform: 'linux',
+			spawn: spawner,
+			killer,
+		});
+		// Process table: 200 is child of 100, 300 is grandchild via 200.
+		// Plus an unrelated 400 with ppid=999 (should NOT be killed).
+		child.pushStdout('100 1\n200 100\n300 200\n400 999\n');
+		child.close(0);
+		await promise;
+
+		expect(spawner).toHaveBeenCalledExactlyOnceWith('ps', ['-A', '-o', 'pid=,ppid='], {
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+		// Leaves first: 300, 200, then root 100. 400 untouched.
+		expect(killer.kill.mock.calls).toStrictEqual([
+			[300, 'SIGKILL'],
+			[200, 'SIGKILL'],
+			[100, 'SIGKILL'],
+		]);
+	});
+
+	it('logs and falls back to killing only the root when ps cannot be spawned', async () => {
+		const child = createFakeChild();
+		const spawner = vi.fn<Spawner>(() => child.asChildProcess());
+		const killer = createMockKiller();
+		const log = vi.fn();
+
+		const promise = killProcessTree(100, 'SIGKILL', {
+			platform: 'linux',
+			spawn: spawner,
+			killer,
+			log,
+		});
+		child.emitError(new Error('spawn ps ENOENT'));
+		await promise;
+
+		expect(killer.kill).toHaveBeenCalledExactlyOnceWith(100, 'SIGKILL');
+		expect(log).toHaveBeenCalledOnce();
+		expect(log.mock.calls[0]![0]).toMatch(/ps invocation failed/);
+	});
+
+	it('logs and falls back to killing only the root when ps exits non-zero', async () => {
+		const child = createFakeChild();
+		const spawner = vi.fn<Spawner>(() => child.asChildProcess());
+		const killer = createMockKiller();
+		const log = vi.fn();
+
+		const promise = killProcessTree(100, 'SIGKILL', {
+			platform: 'linux',
+			spawn: spawner,
+			killer,
+			log,
+		});
+		child.pushStdout('garbage that does not parse\n');
+		child.close(1);
+		await promise;
+
+		expect(killer.kill).toHaveBeenCalledExactlyOnceWith(100, 'SIGKILL');
+		expect(log).toHaveBeenCalledOnce();
+		expect(log.mock.calls[0]![0]).toMatch(/ps exited with non-zero/);
+	});
+});
+
+describe('killProcessTree default POSIX killer logging', () => {
+	it('logs each swallowed process.kill error (ESRCH/EPERM)', async () => {
+		// Cannot stub process.kill cleanly without affecting Node internals,
+		// so the integration smoke approach: target an obviously dead PID.
+		// The default killer swallows the resulting ESRCH and logs it.
+		const log = vi.fn();
+		const child = createFakeChild();
+		const spawner = vi.fn<Spawner>(() => child.asChildProcess());
+
+		const promise = killProcessTree(999_999_998, 'SIGKILL', {
+			platform: 'linux',
+			spawn: spawner,
+			log,
+		});
+		// Empty process table → no descendants → killer attempts only the root.
+		child.close(0);
+		await promise;
+
+		expect(log).toHaveBeenCalled();
+		// log uses debug-style printf placeholders; assert format + the
+		// interpolated PID argument separately.
+		const lastCall = log.mock.calls.at(-1)!;
+		expect(lastCall[0]).toMatch(/process\.kill\(%d, %s\) failed/);
+		expect(lastCall[1]).toBe(999_999_998);
 	});
 });

--- a/packages/@nitpicker/crawler/src/crawler/kill-process-tree.ts
+++ b/packages/@nitpicker/crawler/src/crawler/kill-process-tree.ts
@@ -1,0 +1,190 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Sends a signal to a single process.
+ *
+ * Abstracted from `process.kill` so tests can verify exactly which PIDs are
+ * signalled without actually touching the OS.
+ */
+export interface ProcessKiller {
+	/**
+	 * Sends `signal` to the process with the given PID. Implementations should
+	 * swallow ESRCH ("no such process") since the target may have already
+	 * exited between enumeration and the kill call.
+	 * @param pid - The PID to signal.
+	 * @param signal - The signal name (e.g. `'SIGKILL'`) or number.
+	 */
+	kill(pid: number, signal: NodeJS.Signals | number): void;
+}
+
+/**
+ * Dependency overrides for {@link killProcessTree}.
+ *
+ * Default implementations shell out to `ps` (POSIX) or `taskkill` (Windows),
+ * which makes them awkward to unit-test directly. Injecting these lets tests
+ * verify the orchestration without invoking real processes.
+ */
+export interface KillProcessTreeDeps {
+	/**
+	 * Lists the PIDs of every descendant of `rootPid` in BFS order
+	 * (parents before children). Used only on POSIX.
+	 */
+	listDescendants?: (rootPid: number) => Promise<readonly number[]>;
+	/** Signals a single PID. Used only on POSIX. */
+	killer?: ProcessKiller;
+	/**
+	 * Performs an OS-level tree-kill. Used only on Windows, where `taskkill
+	 * /T /F` handles the entire tree atomically.
+	 */
+	runTreeKill?: (rootPid: number) => Promise<void>;
+	/** Override for `process.platform` so cross-platform paths can be tested. */
+	platform?: NodeJS.Platform;
+}
+
+/**
+ * Kills a process and every one of its descendants.
+ *
+ * WHY: After SIGKILL'ing Chromium's parent process, its renderer / network /
+ * zygote subprocesses linger on Linux/macOS because puppeteer spawns Chromium
+ * with `detached: false`, so we cannot use a process-group signal (a
+ * negative-PID kill would also hit our own Node process). Enumerating
+ * descendants via `ps -A -o pid=,ppid=` and signalling each one — leaves
+ * first — closes the orphan gap. On Windows `taskkill /T /F /PID <pid>`
+ * performs the equivalent OS-level tree kill atomically.
+ *
+ * Best-effort: ESRCH (process already gone) and `ps`/`taskkill` invocation
+ * failures are swallowed, so the function never rejects on a partial-kill
+ * outcome. The caller treats this as a hard cleanup that must always
+ * resolve.
+ * @param rootPid - The PID at the root of the tree.
+ * @param signal - The signal to send. Defaults to `'SIGKILL'`. Ignored on
+ *   Windows (`taskkill /F` is always forceful).
+ * @param deps - Test-time overrides.
+ */
+export async function killProcessTree(
+	rootPid: number,
+	signal: NodeJS.Signals | number = 'SIGKILL',
+	deps: KillProcessTreeDeps = {},
+): Promise<void> {
+	const platform = deps.platform ?? process.platform;
+
+	if (platform === 'win32') {
+		const runTreeKill = deps.runTreeKill ?? runWindowsTaskkill;
+		await runTreeKill(rootPid);
+		return;
+	}
+
+	const listDescendants = deps.listDescendants ?? listPosixDescendants;
+	const killer = deps.killer ?? POSIX_DEFAULT_KILLER;
+
+	const descendants = await listDescendants(rootPid);
+	// BFS produces parents before children; reverse so leaves die first and
+	// cannot re-spawn anything via their own watchdog before their parent goes.
+	for (const pid of descendants.toReversed()) {
+		killer.kill(pid, signal);
+	}
+	killer.kill(rootPid, signal);
+}
+
+/**
+ * Default POSIX killer: `process.kill` with ESRCH/EPERM swallowed.
+ *
+ * Lives at module scope so it is shared across calls instead of being
+ * re-allocated for every {@link killProcessTree} invocation.
+ */
+const POSIX_DEFAULT_KILLER: ProcessKiller = {
+	kill(pid, signal) {
+		try {
+			process.kill(pid, signal);
+		} catch {
+			// Already dead (ESRCH) or denied (EPERM) — best-effort.
+		}
+	},
+};
+
+/**
+ * Walks the process table on POSIX and returns every descendant of
+ * `rootPid` in BFS order.
+ *
+ * Shells out to `ps -A -o pid=,ppid=` via `spawn` (no shell), parses each
+ * row into `(pid, ppid)`, builds a parent-to-children map, then breadth-first
+ * walks from `rootPid`.
+ *
+ * Failure to invoke `ps` (missing binary, permission denied, non-zero exit)
+ * returns an empty array so the caller can still kill the root.
+ * @param rootPid - The PID whose descendants to list.
+ * @returns A promise resolving to descendant PIDs.
+ */
+async function listPosixDescendants(rootPid: number): Promise<readonly number[]> {
+	const parentToChildren = await readPosixProcessMap();
+	const descendants: number[] = [];
+	const queue: number[] = [rootPid];
+	while (queue.length > 0) {
+		const pid = queue.shift()!;
+		const children = parentToChildren.get(pid);
+		if (!children) continue;
+		for (const child of children) {
+			descendants.push(child);
+			queue.push(child);
+		}
+	}
+	return descendants;
+}
+
+/**
+ * Reads the full POSIX process table by spawning `ps` and parsing its output.
+ *
+ * Format requested: `pid=,ppid=` (no headers). Each line is `<pid> <ppid>`.
+ * @returns A promise resolving to a parent-PID-to-children map. Empty on
+ *   any invocation failure.
+ */
+async function readPosixProcessMap(): Promise<ReadonlyMap<number, readonly number[]>> {
+	return new Promise((resolve) => {
+		const proc = spawn('ps', ['-A', '-o', 'pid=,ppid='], {
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+		let output = '';
+		proc.stdout.on('data', (chunk: Buffer) => {
+			output += chunk.toString('utf8');
+		});
+		proc.on('error', () => resolve(new Map()));
+		proc.on('close', (code) => {
+			if (code !== 0) {
+				resolve(new Map());
+				return;
+			}
+			const map = new Map<number, number[]>();
+			for (const line of output.split('\n')) {
+				const match = /^\s*(\d+)\s+(\d+)/.exec(line);
+				if (!match) continue;
+				const pid = Number(match[1]);
+				const ppid = Number(match[2]);
+				const list = map.get(ppid);
+				if (list) {
+					list.push(pid);
+				} else {
+					map.set(ppid, [pid]);
+				}
+			}
+			resolve(map);
+		});
+	});
+}
+
+/**
+ * Forces a tree-kill on Windows via `taskkill /T /F /PID <pid>`.
+ *
+ * The `/T` flag walks descendants; `/F` forces termination. Any failure
+ * (ENOENT for taskkill, non-zero exit because the PID is already gone) is
+ * swallowed.
+ * @param rootPid - The PID at the root of the tree.
+ */
+async function runWindowsTaskkill(rootPid: number): Promise<void> {
+	return new Promise<void>((resolve) => {
+		const proc = spawn('taskkill', ['/T', '/F', '/PID', String(rootPid)], {
+			stdio: 'ignore',
+		});
+		proc.on('error', () => resolve());
+		proc.on('close', () => resolve());
+	});
+}

--- a/packages/@nitpicker/crawler/src/crawler/kill-process-tree.ts
+++ b/packages/@nitpicker/crawler/src/crawler/kill-process-tree.ts
@@ -1,3 +1,5 @@
+import type { ChildProcess } from 'node:child_process';
+
 import { spawn } from 'node:child_process';
 
 /**
@@ -16,6 +18,34 @@ export interface ProcessKiller {
 	 */
 	kill(pid: number, signal: NodeJS.Signals | number): void;
 }
+
+/**
+ * Spawner signature accepted by {@link KillProcessTreeDeps}. Matches Node's
+ * `child_process.spawn` in the only shape this module uses: command name,
+ * arguments, and an options object with `stdio`. Declared structurally so
+ * tests can pass a `vi.fn()` returning a tiny EventEmitter without dragging
+ * in the full Node typings.
+ */
+export type Spawner = (
+	command: string,
+	args: readonly string[],
+	options: { stdio: 'ignore' | readonly ('ignore' | 'pipe')[] },
+) => ChildProcess;
+
+/**
+ * Debug logger compatible with the `debug` package's printf-style API.
+ *
+ * Called only when a best-effort kill path fails (ESRCH, ENOENT for `ps` or
+ * `taskkill`, non-zero exit code). Production callers should pass the
+ * crawler-namespaced logger so failures show up under
+ * `DEBUG=Nitpicker:Crawler`.
+ */
+export type KillProcessTreeLogger = (
+	/** printf-style format string. */
+	formatter: string,
+	/** Arguments interpolated into the format string. */
+	...args: readonly unknown[]
+) => void;
 
 /**
  * Dependency overrides for {@link killProcessTree}.
@@ -39,6 +69,18 @@ export interface KillProcessTreeDeps {
 	runTreeKill?: (rootPid: number) => Promise<void>;
 	/** Override for `process.platform` so cross-platform paths can be tested. */
 	platform?: NodeJS.Platform;
+	/**
+	 * `child_process.spawn` substitute used when `runTreeKill` is not
+	 * supplied (i.e. the default Windows path). Lets tests assert the exact
+	 * command + args without mocking the global module.
+	 */
+	spawn?: Spawner;
+	/**
+	 * Receives a single line per best-effort failure path (ENOENT,
+	 * non-zero exit, etc.). Defaults to a no-op so production callers stay
+	 * silent unless they opt in.
+	 */
+	log?: KillProcessTreeLogger;
 }
 
 /**
@@ -67,15 +109,19 @@ export async function killProcessTree(
 	deps: KillProcessTreeDeps = {},
 ): Promise<void> {
 	const platform = deps.platform ?? process.platform;
+	const log = deps.log ?? noopLog;
 
 	if (platform === 'win32') {
-		const runTreeKill = deps.runTreeKill ?? runWindowsTaskkill;
+		const runTreeKill =
+			deps.runTreeKill ?? ((pid) => runWindowsTaskkill(pid, deps.spawn ?? spawn, log));
 		await runTreeKill(rootPid);
 		return;
 	}
 
-	const listDescendants = deps.listDescendants ?? listPosixDescendants;
-	const killer = deps.killer ?? POSIX_DEFAULT_KILLER;
+	const listDescendants =
+		deps.listDescendants ??
+		((pid) => listPosixDescendants(pid, deps.spawn ?? spawn, log));
+	const killer = deps.killer ?? makePosixDefaultKiller(log);
 
 	const descendants = await listDescendants(rootPid);
 	// BFS produces parents before children; reverse so leaves die first and
@@ -86,21 +132,28 @@ export async function killProcessTree(
 	killer.kill(rootPid, signal);
 }
 
+/** No-op {@link KillProcessTreeLogger} used when the caller does not supply one. */
+const noopLog: KillProcessTreeLogger = () => {};
+
 /**
- * Default POSIX killer: `process.kill` with ESRCH/EPERM swallowed.
- *
- * Lives at module scope so it is shared across calls instead of being
- * re-allocated for every {@link killProcessTree} invocation.
+ * Builds the default POSIX killer: `process.kill` with ESRCH/EPERM swallowed
+ * and logged via `log` so production callers can observe how often the tree
+ * walk hits already-dead PIDs.
+ * @param log - Receives one line per swallowed error.
+ * @returns A {@link ProcessKiller}.
  */
-const POSIX_DEFAULT_KILLER: ProcessKiller = {
-	kill(pid, signal) {
-		try {
-			process.kill(pid, signal);
-		} catch {
-			// Already dead (ESRCH) or denied (EPERM) — best-effort.
-		}
-	},
-};
+function makePosixDefaultKiller(log: KillProcessTreeLogger): ProcessKiller {
+	return {
+		kill(pid, signal) {
+			try {
+				process.kill(pid, signal);
+			} catch (error) {
+				// Already dead (ESRCH) or denied (EPERM) — best-effort.
+				log('process.kill(%d, %s) failed: %O', pid, String(signal), error);
+			}
+		},
+	};
+}
 
 /**
  * Walks the process table on POSIX and returns every descendant of
@@ -113,10 +166,16 @@ const POSIX_DEFAULT_KILLER: ProcessKiller = {
  * Failure to invoke `ps` (missing binary, permission denied, non-zero exit)
  * returns an empty array so the caller can still kill the root.
  * @param rootPid - The PID whose descendants to list.
+ * @param spawner
+ * @param log
  * @returns A promise resolving to descendant PIDs.
  */
-async function listPosixDescendants(rootPid: number): Promise<readonly number[]> {
-	const parentToChildren = await readPosixProcessMap();
+async function listPosixDescendants(
+	rootPid: number,
+	spawner: Spawner,
+	log: KillProcessTreeLogger,
+): Promise<readonly number[]> {
+	const parentToChildren = await readPosixProcessMap(spawner, log);
 	const descendants: number[] = [];
 	const queue: number[] = [rootPid];
 	while (queue.length > 0) {
@@ -135,21 +194,33 @@ async function listPosixDescendants(rootPid: number): Promise<readonly number[]>
  * Reads the full POSIX process table by spawning `ps` and parsing its output.
  *
  * Format requested: `pid=,ppid=` (no headers). Each line is `<pid> <ppid>`.
+ * @param spawner - Substitute for `child_process.spawn`.
+ * @param log - Receives a single line if `ps` cannot be invoked or exits non-zero.
  * @returns A promise resolving to a parent-PID-to-children map. Empty on
  *   any invocation failure.
  */
-async function readPosixProcessMap(): Promise<ReadonlyMap<number, readonly number[]>> {
+async function readPosixProcessMap(
+	spawner: Spawner,
+	log: KillProcessTreeLogger,
+): Promise<ReadonlyMap<number, readonly number[]>> {
 	return new Promise((resolve) => {
-		const proc = spawn('ps', ['-A', '-o', 'pid=,ppid='], {
+		const proc = spawner('ps', ['-A', '-o', 'pid=,ppid='], {
 			stdio: ['ignore', 'pipe', 'ignore'],
 		});
 		let output = '';
-		proc.stdout.on('data', (chunk: Buffer) => {
+		proc.stdout?.on('data', (chunk: Buffer) => {
 			output += chunk.toString('utf8');
 		});
-		proc.on('error', () => resolve(new Map()));
+		proc.on('error', (error) => {
+			log('ps invocation failed: %O', error);
+			resolve(new Map());
+		});
 		proc.on('close', (code) => {
 			if (code !== 0) {
+				log(
+					'ps exited with non-zero code %s — skipping descendant tree-kill',
+					String(code),
+				);
 				resolve(new Map());
 				return;
 			}
@@ -176,15 +247,29 @@ async function readPosixProcessMap(): Promise<ReadonlyMap<number, readonly numbe
  *
  * The `/T` flag walks descendants; `/F` forces termination. Any failure
  * (ENOENT for taskkill, non-zero exit because the PID is already gone) is
- * swallowed.
+ * logged via `log` and swallowed so the caller's cleanup always resolves.
  * @param rootPid - The PID at the root of the tree.
+ * @param spawner - Substitute for `child_process.spawn`.
+ * @param log - Receives a single line per failure.
  */
-async function runWindowsTaskkill(rootPid: number): Promise<void> {
+async function runWindowsTaskkill(
+	rootPid: number,
+	spawner: Spawner,
+	log: KillProcessTreeLogger,
+): Promise<void> {
 	return new Promise<void>((resolve) => {
-		const proc = spawn('taskkill', ['/T', '/F', '/PID', String(rootPid)], {
+		const proc = spawner('taskkill', ['/T', '/F', '/PID', String(rootPid)], {
 			stdio: 'ignore',
 		});
-		proc.on('error', () => resolve());
-		proc.on('close', () => resolve());
+		proc.on('error', (error) => {
+			log('taskkill invocation failed: %O', error);
+			resolve();
+		});
+		proc.on('close', (code) => {
+			if (code !== 0) {
+				log('taskkill exited with non-zero code %s for PID %d', String(code), rootPid);
+			}
+			resolve();
+		});
 	});
 }

--- a/packages/@nitpicker/crawler/src/crawler/kill-process-tree.ts
+++ b/packages/@nitpicker/crawler/src/crawler/kill-process-tree.ts
@@ -1,6 +1,6 @@
-import type { ChildProcess } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
 
-import { spawn } from 'node:child_process';
+import { spawn as nodeSpawn } from 'node:child_process';
 
 /**
  * Sends a signal to a single process.
@@ -20,16 +20,16 @@ export interface ProcessKiller {
 }
 
 /**
- * Spawner signature accepted by {@link KillProcessTreeDeps}. Matches Node's
- * `child_process.spawn` in the only shape this module uses: command name,
- * arguments, and an options object with `stdio`. Declared structurally so
- * tests can pass a `vi.fn()` returning a tiny EventEmitter without dragging
- * in the full Node typings.
+ * Spawner signature accepted by `KillProcessTreeDeps`. Pins
+ * `child_process.spawn` to the `(command, args, options)` overload — the
+ * bare import is a union of many overloads (including `(command, options)`)
+ * that does not narrow to this shape without a wrapper. Tests can pass a
+ * `vi.fn()` returning a tiny EventEmitter cast to `ChildProcess`.
  */
 export type Spawner = (
 	command: string,
 	args: readonly string[],
-	options: { stdio: 'ignore' | readonly ('ignore' | 'pipe')[] },
+	options: SpawnOptions,
 ) => ChildProcess;
 
 /**
@@ -111,16 +111,17 @@ export async function killProcessTree(
 	const platform = deps.platform ?? process.platform;
 	const log = deps.log ?? noopLog;
 
+	const spawner = deps.spawn ?? defaultSpawner;
+
 	if (platform === 'win32') {
 		const runTreeKill =
-			deps.runTreeKill ?? ((pid) => runWindowsTaskkill(pid, deps.spawn ?? spawn, log));
+			deps.runTreeKill ?? ((pid) => runWindowsTaskkill(pid, spawner, log));
 		await runTreeKill(rootPid);
 		return;
 	}
 
 	const listDescendants =
-		deps.listDescendants ??
-		((pid) => listPosixDescendants(pid, deps.spawn ?? spawn, log));
+		deps.listDescendants ?? ((pid) => listPosixDescendants(pid, spawner, log));
 	const killer = deps.killer ?? makePosixDefaultKiller(log);
 
 	const descendants = await listDescendants(rootPid);
@@ -132,8 +133,21 @@ export async function killProcessTree(
 	killer.kill(rootPid, signal);
 }
 
-/** No-op {@link KillProcessTreeLogger} used when the caller does not supply one. */
+/** No-op `KillProcessTreeLogger` used when the caller does not supply one. */
 const noopLog: KillProcessTreeLogger = () => {};
+
+/**
+ * Default {@link Spawner}: a thin wrapper around `node:child_process.spawn`
+ * that pins the call signature to `(command, args, options)`. The bare
+ * `spawn` import has many overloads — including `(command, options)` — so it
+ * is not assignable to our narrower `Spawner` shape; wrapping it removes the
+ * variance without changing runtime behaviour.
+ * @param command
+ * @param args
+ * @param options
+ */
+const defaultSpawner: Spawner = (command, args, options) =>
+	nodeSpawn(command, args, options);
 
 /**
  * Builds the default POSIX killer: `process.kill` with ESRCH/EPERM swallowed

--- a/packages/@nitpicker/crawler/src/crawler/log-undrained-phase-errors.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/log-undrained-phase-errors.spec.ts
@@ -1,0 +1,84 @@
+import type { BufferedPhaseError } from './drain-phase-errors.js';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { logUndrainedPhaseErrors } from './log-undrained-phase-errors.js';
+
+describe('logUndrainedPhaseErrors', () => {
+	it('returns 0 and never calls log when nothing was buffered', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>();
+		const log = vi.fn();
+
+		const dropped = logUndrainedPhaseErrors(buffer, 'https://example.com/', log);
+
+		expect(dropped).toBe(0);
+		expect(log).not.toHaveBeenCalled();
+		expect(buffer.has('https://example.com/')).toBe(false);
+	});
+
+	it('returns 0 and never calls log when the entry exists but is empty', () => {
+		// Defensive — a caller can set [] directly. The function must treat
+		// it as a no-op rather than emitting a "Dropped 0" message.
+		const buffer = new Map<string, BufferedPhaseError[]>([['https://example.com/', []]]);
+		const log = vi.fn();
+
+		const dropped = logUndrainedPhaseErrors(buffer, 'https://example.com/', log);
+
+		expect(dropped).toBe(0);
+		expect(log).not.toHaveBeenCalled();
+		// Even an empty bucket is removed from the Map to keep it bounded.
+		expect(buffer.has('https://example.com/')).toBe(false);
+	});
+
+	it('logs once with the buffered count and URL, then clears the entry', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>([
+			[
+				'https://example.com/wedged',
+				[
+					{ phase: 'retryExhausted', message: 'desktop-compact failed' },
+					{ phase: 'retryExhausted', message: 'mobile-small failed' },
+				],
+			],
+		]);
+		const log = vi.fn();
+
+		const dropped = logUndrainedPhaseErrors(buffer, 'https://example.com/wedged', log);
+
+		expect(dropped).toBe(2);
+		expect(log).toHaveBeenCalledExactlyOnceWith(
+			'Dropped %d phase error(s) for %s (no archive entry created)',
+			2,
+			'https://example.com/wedged',
+		);
+		expect(buffer.has('https://example.com/wedged')).toBe(false);
+	});
+
+	it('does not touch entries for other URLs in the buffer', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>([
+			['https://example.com/a', [{ phase: 'retryExhausted', message: 'a-err' }]],
+			['https://example.com/b', [{ phase: 'retryExhausted', message: 'b-err' }]],
+		]);
+		const log = vi.fn();
+
+		logUndrainedPhaseErrors(buffer, 'https://example.com/a', log);
+
+		expect(buffer.has('https://example.com/a')).toBe(false);
+		expect(buffer.get('https://example.com/b')).toEqual([
+			{ phase: 'retryExhausted', message: 'b-err' },
+		]);
+	});
+
+	it('is idempotent — a second call for the same URL is a silent no-op', () => {
+		const buffer = new Map<string, BufferedPhaseError[]>([
+			['https://example.com/', [{ phase: 'retryExhausted', message: 'err' }]],
+		]);
+		const log = vi.fn();
+
+		const first = logUndrainedPhaseErrors(buffer, 'https://example.com/', log);
+		const second = logUndrainedPhaseErrors(buffer, 'https://example.com/', log);
+
+		expect(first).toBe(1);
+		expect(second).toBe(0);
+		expect(log).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/log-undrained-phase-errors.ts
+++ b/packages/@nitpicker/crawler/src/crawler/log-undrained-phase-errors.ts
@@ -1,0 +1,57 @@
+import type { BufferedPhaseError } from './drain-phase-errors.js';
+
+/**
+ * Debug logger compatible with the `debug` package's printf-style API.
+ *
+ * Receives a single line per URL whose buffered phase errors were
+ * undrained at finally time.
+ */
+export type PhaseErrorDropLogger = (
+	/** printf-style format string. */
+	formatter: string,
+	/** Arguments interpolated into the format string. */
+	...args: readonly unknown[]
+) => void;
+
+/**
+ * Logs and clears any phase errors still buffered for `urlHref` at
+ * worker-finally time.
+ *
+ * WHY: a Crawler worker's finally clause runs for every code path —
+ * success, hard error, and the early `return` taken for predicted URLs
+ * that were discarded after probing. The success and catch branches
+ * drain via `drainPhaseErrors`, but the predicted-discard branch
+ * skips drain entirely, so any `retryExhausted` events captured during
+ * its probe would silently leak from the Map.
+ *
+ * Calling this function as the final cleanup step:
+ * - Surfaces the drop via `DEBUG=Nitpicker:Crawler` so production runs
+ *   are observable instead of silent.
+ * - Removes the buffer entry so it does not grow across crawls.
+ *
+ * Safe to call after a successful drain: the buffer entry is already
+ * gone and both the log and the delete become no-ops.
+ * @param buffer - The pending-phase-errors map, keyed by URL href.
+ * @param urlHref - URL whose buffer entry should be flushed.
+ * @param log - Receives one line if any undrained errors are present.
+ * @returns The number of phase-error records dropped (0 when nothing
+ *   was buffered).
+ */
+export function logUndrainedPhaseErrors(
+	buffer: Map<string, BufferedPhaseError[]>,
+	urlHref: string,
+	log: PhaseErrorDropLogger,
+): number {
+	const remaining = buffer.get(urlHref);
+	if (!remaining || remaining.length === 0) {
+		buffer.delete(urlHref);
+		return 0;
+	}
+	log(
+		'Dropped %d phase error(s) for %s (no archive entry created)',
+		remaining.length,
+		urlHref,
+	);
+	buffer.delete(urlHref);
+	return remaining.length;
+}

--- a/packages/@nitpicker/crawler/src/crawler/types.ts
+++ b/packages/@nitpicker/crawler/src/crawler/types.ts
@@ -184,4 +184,27 @@ export interface CrawlerEventTypes {
 	 * (e.g., scrapeStart, headRequest, openPage, success).
 	 */
 	changePhase: ChangePhaseEvent;
+
+	/**
+	 * Emitted when a secondary scrape step fails for a URL but the page itself
+	 * is otherwise scraped successfully (e.g. a viewport switch in
+	 * `#fetchImages` detaches the frame and `@retryable` gives up). The
+	 * orchestrator persists these as `page_errors` rows so the failure is
+	 * visible in the archive instead of being lost to stdout logs.
+	 *
+	 * For ordering, this event is always emitted AFTER `page` / `externalPage`
+	 * for the same URL, so the orchestrator's WriteQueue serialises the
+	 * `pages` upsert before the `page_errors` insert and the FK resolution
+	 * via URL succeeds.
+	 */
+	pageError: {
+		/** URL of the affected page. */
+		url: string;
+		/** Scrape phase name (typically `'retryExhausted'`). */
+		phase: string;
+		/** Human-readable failure message. */
+		message: string;
+		/** Whether the URL is external to the crawl scope. */
+		isExternal: boolean;
+	};
 }


### PR DESCRIPTION
## Summary

ユーザー報告（#68 マージ後）の 2 点に対応:

1. **Chromium 子プロセスツリーの確実 kill** — 親プロセスへの SIGKILL では renderer / network / zygote の子プロセスが orphan として残ることがあった
2. **viewport 切替失敗を archive (SQLite) にエラー記録** — 現状は `📷 mobile-small: skipped — Attempted to use detached Frame` のログが stdout に流れて捨てられていたが、これを DB の新規 `page_errors` テーブルに保存する

## スコープ境界（重要）

本 PR は **データを archive に保存するところまで**。`page_errors` を読み取って表示する側（`query` / `report-google-sheets` / `mcp-server`）は **未対応**。後続 PR で `page_errors` を以下に露出する:
- `report-google-sheets`: 新規シート "Page Errors" を追加（あるいは Pages シートに列追加）
- `mcp-server`: `get_page_errors(url?)` ツール
- `query`: CLI から page_errors を JSON で吐く子コマンド

現状はクロール時にデータが捕捉されるが UI には現れない。`sqlite3 .nitpicker SELECT * FROM page_errors` で直接見れる。

## Phase 1: `kill-process-tree` (e91c0f2)

- 新規 `kill-process-tree.ts`: POSIX は `ps -A -o pid=,ppid=` で BFS 列挙 → 葉から signal、Windows は `taskkill /T /F /PID` に委譲
- `closeBrowserSafely` が `childProcess.kill('SIGKILL')` 直後に `killProcessTree(pid, 'SIGKILL')` を呼ぶ
- best-effort: ESRCH / spawn 失敗 / 非 0 exit はすべて握りつぶし、関数は必ず resolve
- **2ae9f98 で観測性改善**: 各失敗パスに debug log を追加。`DEBUG=Nitpicker:Crawler` で本番運用時のリーク検知が可能に

## Phase 2: `page_errors` テーブル (ee3c832)

### スキーマ
```
page_errors (id PK, pageId FK → pages.id, phase, message, createdAt INTEGER ms)
  INDEX (pageId)
```

### イベントフロー
```
beholder Scraper #fetchImages catch
  → emit changePhase { name: 'retryExhausted', message, url: null }
Crawler scraper.on('changePhase')  (createChangePhaseHandler 経由)
  → forward as 'changePhase'
  → name === 'retryExhausted' なら #pendingPhaseErrors Map に url.href キーで buffer
Crawler #runDeal の worker
  → #scrapePage 完了 → #handleResult が 'page' / 'externalPage' を emit
  → drainPhaseErrors で 'pageError' を emit
  → finally に logUndrainedPhaseErrors で predicted-discard 等の取りこぼしを観測
CrawlerOrchestrator
  → on('pageError') で writeQueue 経由で archive.addPageError
  → 'page' が先に enqueue されているため WriteQueue 上で setPage → insertPageError の順序保証
```

### 既存 archive の自動マイグレーション
`Database.#init` で `migratePageErrors` を呼び、`page_errors` テーブルが無ければ作成（idempotent）。実走時のみ `[migrate] page_errors table created` を stderr に出す。

## Phase 3: docs (a60ac91)
- ARCHITECTURE.md「ブラウザクローズの安全策」を tree-kill ありに更新
- 新セクション「部分失敗の archive 記録（page_errors）」を追加

## レビュー反映 (ee5ffe0, 2ae9f98)
code-review / qa-engineer の指摘を反映:
- `closeBrowserSafely`: pid を await 前に snapshot
- `drainPhaseErrors` / `createChangePhaseHandler` / `logUndrainedPhaseErrors` をそれぞれ独立 file に extract して単体テスト可能に
- `kill-process-tree` に Spawner / logger DI を追加、Windows taskkill 引数を unit テストで検証
- best-effort kill 失敗を `DEBUG=Nitpicker:Crawler` で観測可能に
- worker → drain wiring は known test gap として `#drainPhaseErrors` JSDoc に明記（puppeteer mock コストが見合わないため）

## Test plan

- [x] yarn lint (0 errors, warning は既存ファイルのみ)
- [x] yarn build (13/13 projects)
- [x] yarn test (1322 passed, 47 new tests)
  - kill-process-tree: 15 ケース (BFS / signal透過 / 列挙0件 / killer throw / Windows委譲 / runTreeKill失敗 / プラットフォーム既定 / **新規**: Windows taskkill spawn 引数 / POSIX ps spawn 引数 / 失敗ログ × 4)
  - close-browser-safely: 13 ケース (既存 10 + tree-kill / pid 無し / close 成功時 no-op)
  - drain-phase-errors: 6 ケース
  - create-change-phase-handler: 9 ケース (forward / buffer / 複数 URL / log skip / etc)
  - log-undrained-phase-errors: 5 ケース
  - handle-browser-close: 4 ケース
  - migrate-page-errors: 3 ケース
  - database.insertPageError: 3 ケース
  - archive.addPageError: 1 ケース
  - orchestrator pageError: 2 ケース

## 後方互換性

破壊的変更なし（v0.x 系の純追加）。既存 `.nitpicker` を開くと自動マイグレーションで `page_errors` が追加される（既存データに変更なし）。CLI / API のシグネチャは無変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)