### PR TITLE
feat(crawler): skip re-rendering redirect destinations already crawled (#73)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -640,9 +640,46 @@ updatePage(pageData) の処理:
 
 **なぜ tuple 重複削除 / `UNIQUE` 制約を使わないか**: `(pageId, hrefId, hash, textContent)` は一意ではない。同じリンクが header と footer の両方にある等、1 ページ内に同一 tuple が正当に複数存在しうる。行単位では「正当な重複」と「再保存による冗長コピー」を区別できないため、行の dedup は不可。スクレイプ 1 回分を丸ごと置き換えることで、正当な重複を保ったまま冗長コピーを防ぐ。
 
-**既知の制約**: 本修正より前にクロールされたアーカイブは、リダイレクト先ページの anchors / images が「リダイレクト元の数 + 1」倍に膨らんでいることがある（`pages` テーブルは重複しない。発リンク数・被リンク数の**表示**にのみ影響）。in-place の行削除では直せない（正当な重複まで消えるため）。再クロールで解消する。「宛先を毎回再レンダリングしない」根本対応は別途検討。
+**既知の制約**: 本修正より前にクロールされたアーカイブは、リダイレクト先ページの anchors / images が「リダイレクト元の数 + 1」倍に膨らんでいることがある（`pages` テーブルは重複しない。発リンク数・被リンク数の**表示**にのみ影響）。in-place の行削除では直せない（正当な重複まで消えるため）。再クロールで解消する。
 
-> 関連: GitHub issue #70（置き換え修正・実装）/ #73（クローラ層の根本対応・無駄な再レンダリング削減）
+> 関連: GitHub issue #70（置き換え修正・storage 層の対症療法）/ #73（クローラ層の根本対応・下記）
+
+### リダイレクト先の再レンダリング抑止（#73）
+
+上記の置き換えは storage 層の対症療法。根本原因は **クローラがリダイレクト元 URL ごとに宛先 D をフルレンダリングしていた**こと（多対一集約で D が「元 URL 数 + 1」回描画される）。#73 でこれを抑止する。
+
+**フロー:**
+
+1. **HEAD プリフライトで最終到達先を解決する**。`fetch-destination.ts` の HEAD リクエストに `trackRedirects: true` を渡し、follow-redirects が `res.redirects` を埋めるようにした。これで puppeteer を起動する**前**に最終到達先 D が分かる。
+2. **`#scrapePage`（`crawler.ts`）が描画の前に判定する**。最終到達先のキー（`redirectDestKey` = `protocolAgnosticKey`(末尾ホップ or リダイレクト無しなら URL 自身)）が `Crawler#scrapedDestinations` に既にあれば、ブラウザを起動せず `type: 'redirect-edge'` を返す。この CHECK は **metadata-only / 非 HTML ブランチより上**に置く（後述）。
+3. worker が `redirect` イベントを発火 → orchestrator が `Archive.setRedirect`（= `Database.recordRedirect`）でリダイレクト辺だけを記録（宛先の本文は触らない）。
+
+**`redirectPaths` の契約（最重要・破壊厳禁）:**
+
+`redirectPaths` は「リダイレクト無し＝空配列／リダイレクト有り＝`[...中間ホップ, 最終D]`（**元 URL は含めない**）」という契約。HEAD 経路（`fetch-destination.ts`）と browser 経路（`@d-zero/beholder` のスクレイプ結果）の **両方が同じ形状**を返す前提で `resolveRedirectChain` / `updatePage` / `redirectDestKey` が動く。
+
+- follow-redirects の `trackRedirects` は `res.redirects` の **先頭に必ず元の要求 URL** を積む（[follow-redirects README](https://github.com/follow-redirects/follow-redirects#trackredirects) 参照）。さらに HEAD は `path: url.pathname` で送るため、その先頭要素は **クエリが落ちている**。そのまま使うと (a) リダイレクト無しのページまで `redirectPaths` が非空になり自己リダイレクト扱い、(b) `?id=1` と `?id=2` のようなクエリ違いの別ページが `redirectDestKey` で同一視され **2 件目が描画されず消える**。
+- そこで `fetch-destination.ts` は **`res.redirects.map(r => r.url).slice(1)`** で先頭（クエリ落ちの元 URL）を捨て、上記契約に戻す。リダイレクト**先**は Location ヘッダ由来なのでクエリは保持される。
+- **この `slice(1)` を外す／変えると、クエリ別ページ消失バグが即再発する。** ガード: `test-server` の `/query-distinct/` E2E（`?kind=alpha` と `?kind=beta` が両方記録されること）。検索キーワード: 「follow-redirects trackRedirects redirects[0]」「redirectPaths slice」。
+
+**CHECK を metadata-only / 非 HTML ブランチより上に置く理由（#73 #2）:**
+
+metadata-only（title のみ）と非 HTML は `headCheckResult` を `updatePage` に流す。`updatePage` は宛先行を `#insertPage` で UPDATE するため、もし CHECK がこれらの下にあると、**既に描画済みの D を、リダイレクト元の薄い HEAD/title 結果（`isExternal` / `isTarget` / 空 meta）で上書き**してしまう（例: サイト内ページへ 301 する外部リンク）。CHECK を上に置けば edge-only に振り分けられ、D は無傷。ガード: `/clobber/` E2E。
+
+**claim は「実際に描画した宛先」で行う（#73 #5）:**
+
+`#scrapedDestinations.add(...)` のキーは HEAD の推測ではなく **browser の描画結果の `redirectPaths`** から算出する（`renderedKey`）。HEAD と GET で最終到達先が食い違う場合（method 条件付き / JS / meta-refresh リダイレクト）に、HEAD 推測キーで claim すると、後続ソースが **一度も描画されない幽霊行**への辺になってしまうため。claim は描画成功後のみ。
+
+- **既知の制約**: HEAD と GET が食い違う稀なケースでは重複排除が**空振り**して再描画するだけ（データは正しい）。幽霊行は作らない。ガード: `/diverge/` E2E。
+- **並行**: 同一 D への in-flight ソース（並列度が上限）は両方描画しうる。anchors/images は #70 の置き換えで正しく収束。sub-resource は一時的に重複しうるが、#73 前の「ソース数ぶん描画」より遥かに少ない。
+
+**辺記録は本文を壊さない:**
+
+`recordRedirect` は `updatePage` と `#linkRedirectSources` / `resolveRedirectChain` を共有するが、`#insertPage`（宛先行の本文 UPDATE）を**通さない**。空チェーン（sources 空＝実際にはリダイレクトしていない）と解析不能な宛先 URL は、辺もスタブ行も作らず早期 return する（後者は throw すると WriteQueue 経由でクロール全体が abort するため）。ガード: `database.spec.ts` の `recordRedirect` 群。
+
+> 直接リンクとリダイレクトの両方で到達される宛先も同じキーで claim されるため、どちらの経路で先に到達しても D は 1 回だけ描画される。
+>
+> **予測ページネーション**: 投機的に生成された URL がリダイレクトした場合は実在 URL（サーバが 3xx 応答）なので辺を記録する（描画経路と同じ扱い。404/エラーの投機 URL だけ `shouldDiscardPredicted` で破棄）。
 
 ### getPages() vs getPagesWithRefs()
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,10 @@ npx @nitpicker/cli -v | --version                       # `@nitpicker/cli` の�
 CrawlerOrchestrator.crawling(urls, options)
   → Archive.create()（SQLite DB を tmpDir に作成）
   → Crawler → deal()（@d-zero/dealer で並列制御）
-    → 各 URL: puppeteer.launch() → Scraper.scrapeStart(page, ...)
+    → 各 URL: HEAD プリフライト（fetchDestination, trackRedirects で最終到達先を解決）→ puppeteer.launch() → Scraper.scrapeStart(page, ...)
       → ScrapeResult を戻り値で返却
-    → LinkList.done() + WriteQueue 経由で Archive にページデータ保存
+      → リダイレクト先が既に描画済み（#scrapedDestinations にキャッシュ）なら描画せず redirect-edge を返す（#73 多対一リダイレクトの再レンダリング抑止）
+    → LinkList.done() + WriteQueue 経由で Archive にページデータ保存（redirect-edge は setRedirect で辺だけ記録）
     → 発見した新 URL を動的にキューに追加（HTML らしい URL は unshift で先頭へ優先、それ以外は push で末尾へ。判定は URL の拡張子ヒューリスティック isLikelyHtmlUrl）
   → crawlEnd 時に WriteQueue.drain() で未完了の書き込みを待機
   → CrawlerOrchestrator.write()（tmpDir を .nitpicker tar に圧縮）

--- a/packages/@nitpicker/crawler/src/archive/archive.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.ts
@@ -241,6 +241,19 @@ export default class Archive extends ArchiveAccessor {
 		return pageId;
 	}
 	/**
+	 * Records a redirect edge without re-storing the destination's content.
+	 *
+	 * The crawler calls this (instead of {@link setPage}) when a URL redirects to
+	 * a destination that has already been rendered (#73): only the source →
+	 * destination edge is written, leaving the destination's stored title / meta /
+	 * anchors / images untouched.
+	 * @param pageInfo - The HEAD-resolved page data carrying the redirect chain.
+	 */
+	async setRedirect(pageInfo: PageData) {
+		dbLog('Set redirect: %s', pageInfo.url.href);
+		await this.#db.recordRedirect(pageInfo);
+	}
+	/**
 	 * Stores a sub-resource (CSS, JS, image, etc.) in the archive database.
 	 * @param resource - The resource data to store.
 	 */

--- a/packages/@nitpicker/crawler/src/archive/database.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.spec.ts
@@ -662,6 +662,223 @@ describe('re-scrape: 同一ページの再 updatePage', () => {
 	});
 });
 
+describe('recordRedirect: 宛先を再保存せず辺だけ記録する（#73）', () => {
+	/**
+	 * Builds content page data for a directly-scraped destination page.
+	 * @param url - The destination URL.
+	 * @param title - The page title to store.
+	 * @returns Page data accepted by `Database.updatePage`.
+	 */
+	const makeDest = (url: string, title: string) => ({
+		url: parseUrl(url)!,
+		redirectPaths: [] as string[],
+		isExternal: false,
+		status: 200,
+		statusText: 'OK',
+		contentLength: 100,
+		contentType: 'text/html',
+		responseHeaders: {},
+		meta: { title },
+		anchorList: [
+			{ href: parseUrl('http://localhost/x')!, textContent: 'X', isExternal: false },
+			{ href: parseUrl('http://localhost/y')!, textContent: 'Y', isExternal: false },
+		],
+		imageList: [],
+		html: '<html></html>',
+		isSkipped: false,
+	});
+
+	/**
+	 * Builds HEAD-only page data for a source URL that redirects to a destination.
+	 * Carries no real content (empty meta / anchors), mirroring a HEAD pre-flight.
+	 * @param sourceUrl - The redirecting source URL.
+	 * @param destUrl - The redirect destination URL.
+	 * @returns Page data accepted by `Database.recordRedirect`.
+	 */
+	const makeSource = (sourceUrl: string, destUrl: string) => ({
+		url: parseUrl(sourceUrl)!,
+		redirectPaths: [destUrl],
+		isExternal: false,
+		status: 200,
+		statusText: 'OK',
+		contentLength: 0,
+		contentType: 'text/html',
+		responseHeaders: {},
+		meta: {},
+		anchorList: [],
+		imageList: [],
+		html: '',
+		isSkipped: false,
+	});
+
+	it('宛先のタイトル・アンカーを上書きせず、元URLに redirectDestId を立てる', async () => {
+		const dbPath = path.resolve(workingDir, 'record-redirect-keep.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const dest = 'http://localhost/canonical';
+		const source = 'http://localhost/legacy';
+
+		try {
+			// 1) 宛先を一度フルにレンダリングして保存（タイトル + アンカー2件）。
+			await db.updatePage(makeDest(dest, 'Canonical Page'), workingDir, true);
+
+			// 2) 既知の宛先に対するリダイレクト元を辺だけ記録（再レンダリングしない）。
+			await db.recordRedirect(makeSource(source, dest));
+
+			const knex = db.getKnex();
+			const [destPage] = await knex
+				.from('pages')
+				.select('id', 'title')
+				.where('url', dest);
+			const [sourcePage] = await knex
+				.from('pages')
+				.select('id', 'scraped', 'redirectDestId')
+				.where('url', source);
+			const [anchorCount] = await knex
+				.from('anchors')
+				.where('pageId', destPage.id)
+				.count({ c: '*' });
+
+			// 宛先の本文は HEAD の空データで潰されず、そのまま残る。
+			expect(destPage.title).toBe('Canonical Page');
+			expect(Number(anchorCount.c)).toBe(2);
+			// 元URLは scraped 済みかつ宛先を指すリダイレクト辺になる。
+			expect(Number(sourcePage.scraped)).toBe(1);
+			expect(sourcePage.redirectDestId).toBe(destPage.id);
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('自己リダイレクト（元URL===宛先）は辺を立てない', async () => {
+		const dbPath = path.resolve(workingDir, 'record-redirect-self.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/self';
+
+		try {
+			await db.updatePage(makeDest(url, 'Self'), workingDir, true);
+			// redirectPaths が自分自身のみ → sources も自己参照になり、スキップされる。
+			await db.recordRedirect(makeSource(url, url));
+
+			const knex = db.getKnex();
+			const [page] = await knex.from('pages').select('redirectDestId').where('url', url);
+			expect(page.redirectDestId).toBeNull();
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('多段リダイレクトでは中間ホップも宛先を指す辺になる', async () => {
+		const dbPath = path.resolve(workingDir, 'record-redirect-chain.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const dest = 'http://localhost/final';
+
+		try {
+			await db.updatePage(makeDest(dest, 'Final'), workingDir, true);
+			// start -> middle -> final。start と middle の両方が final を指す。
+			await db.recordRedirect({
+				...makeSource('http://localhost/start', dest),
+				redirectPaths: ['http://localhost/middle', dest],
+			});
+
+			const knex = db.getKnex();
+			const [destPage] = await knex.from('pages').select('id').where('url', dest);
+			const [start] = await knex
+				.from('pages')
+				.select('redirectDestId')
+				.where('url', 'http://localhost/start');
+			const [middle] = await knex
+				.from('pages')
+				.select('redirectDestId')
+				.where('url', 'http://localhost/middle');
+
+			expect(start.redirectDestId).toBe(destPage.id);
+			expect(middle.redirectDestId).toBe(destPage.id);
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('元URLが過去にコンテンツを持っていた場合、その旧アンカーを消去する', async () => {
+		const dbPath = path.resolve(workingDir, 'record-redirect-clear.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const dest = 'http://localhost/dest-page';
+		const source = 'http://localhost/was-content';
+
+		try {
+			await db.updatePage(makeDest(dest, 'Dest'), workingDir, true);
+			// 元URLが以前コンテンツページだった（アンカーを持つ）。
+			await db.updatePage(makeDest(source, 'Was content'), workingDir, true);
+
+			const knex = db.getKnex();
+			const [sourcePage] = await knex.from('pages').select('id').where('url', source);
+			const [before] = await knex
+				.from('anchors')
+				.where('pageId', sourcePage.id)
+				.count({ c: '*' });
+			expect(Number(before.c)).toBe(2);
+
+			// 後にリダイレクト元化 → 旧アンカーはクリーンアップされる。
+			await db.recordRedirect(makeSource(source, dest));
+
+			const [after] = await knex
+				.from('anchors')
+				.where('pageId', sourcePage.id)
+				.count({ c: '*' });
+			expect(Number(after.c)).toBe(0);
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('リダイレクトチェーンが空なら辺もスタブ行も作らない', async () => {
+		const dbPath = path.resolve(workingDir, 'record-redirect-empty.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+
+		try {
+			// redirectPaths が空 = 実際にはリダイレクトしていない（自分自身が宛先）。
+			// 辺は無いので、宛先 URL の content-less なスタブ行を作ってはならない。
+			await db.recordRedirect({
+				...makeSource('http://localhost/no-redirect', 'unused'),
+				redirectPaths: [],
+			});
+
+			const knex = db.getKnex();
+			const [row] = await knex.from('pages').count({ c: '*' });
+			expect(Number(row.c)).toBe(0);
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('宛先 URL が解析不能でも例外を投げず、そのURLをスキップする', async () => {
+		const dbPath = path.resolve(workingDir, 'record-redirect-bad-dest.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+
+		try {
+			// 壊れた Location などで宛先が解析不能なとき、throw すると WriteQueue 経由で
+			// クロール全体が abort してしまう。1 本の辺記録は best-effort なのでスキップする。
+			await expect(
+				db.recordRedirect({
+					...makeSource('http://localhost/src', 'unused'),
+					redirectPaths: ['not a valid url'],
+				}),
+			).resolves.toBeUndefined();
+
+			const knex = db.getKnex();
+			const [row] = await knex.from('pages').count({ c: '*' });
+			expect(Number(row.c)).toBe(0);
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+});
+
 describe('Config', () => {
 	const configDbPath = path.resolve(workingDir, 'config-test.sqlite');
 

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -36,6 +36,7 @@ import { limitedPageIds } from './limited-page-ids.js';
 import { migrateInfoRoots } from './migrate-info-roots.js';
 import { migratePageErrors } from './migrate-page-errors.js';
 import { redirectTable } from './redirect-table.js';
+import { resolveRedirectChain } from './resolve-redirect-chain.js';
 
 const retrySetting: RetryDecoratorOptions = {
 	interval: 300,
@@ -667,6 +668,67 @@ export class Database extends EventEmitter<DatabaseEvent> {
 	}
 
 	/**
+	 * Records a redirect edge (source → destination) **without** re-storing the
+	 * destination's content.
+	 *
+	 * The crawler renders a many-to-one redirect destination exactly once. For
+	 * every subsequent source URL that redirects to that already-rendered
+	 * destination, it calls this instead of {@link updatePage} (#73). Routing a
+	 * content-less HEAD result through `updatePage` would funnel it into
+	 * `#insertPage` and overwrite the destination's good title / meta with empty
+	 * values, so the dedicated edge-only path is required.
+	 *
+	 * The destination row is resolved (created on demand if a concurrent in-flight
+	 * render has not committed it yet) so the edge always points at a valid id;
+	 * the single render fills in the destination's content under that same id.
+	 * The destination's existing anchors / images are never touched here.
+	 * @param page - HEAD-resolved page data carrying the redirect chain. Its
+	 *   `anchorList` / `imageList` are ignored (a redirect source owns no content).
+	 */
+	@ErrorEmitter()
+	@retry(retrySetting)
+	async recordRedirect(page: PageData): Promise<void> {
+		const { destUrl, sources } = resolveRedirectChain(
+			page.url.withoutHashAndAuth,
+			page.redirectPaths,
+		);
+
+		// No redirect chain (the URL is itself the already-rendered destination,
+		// reached both directly and via a redirect) → there is no edge to write.
+		// Returning here avoids opening a transaction and, crucially, avoids
+		// `#getIdByUrl` inserting a content-less placeholder row for a destination
+		// that may not have been written yet.
+		if (sources.length === 0) {
+			return;
+		}
+
+		const destUrlObject = parseUrl(destUrl);
+
+		if (!destUrlObject) {
+			// A malformed redirect target should not abort the whole crawl (this
+			// runs inside the WriteQueue, whose rejection aborts the run). Recording
+			// a single redirect edge is best-effort, so skip it and move on. Unlike
+			// `updatePage`, there is no page content at stake here.
+			dbLog('recordRedirect: skip malformed destination URL: %s', destUrl);
+			return;
+		}
+
+		await this.#instance.transaction(async (trx) => {
+			const destId = await this.#getIdByUrl(
+				destUrlObject.withoutHashAndAuth,
+				undefined,
+				trx,
+			);
+			await this.#linkRedirectSources(
+				trx,
+				sources,
+				destId,
+				destUrlObject.withoutHashAndAuth,
+				page.isExternal,
+			);
+		});
+	}
+	/**
 	 * Promote previously-external pages whose URL falls under any of the new scope
 	 * entries back to a "needs scraping" state so that the next crawl picks them up
 	 * as full internal pages.
@@ -876,12 +938,10 @@ export class Database extends EventEmitter<DatabaseEvent> {
 		html?: string | undefined;
 		pageId: number;
 	}> {
-		let destUrl = page.url.withoutHashAndAuth;
-		const redirectPaths = [...page.redirectPaths];
-		if (redirectPaths.length > 0) {
-			destUrl = redirectPaths.pop()!;
-			redirectPaths.unshift(page.url.withoutHashAndAuth);
-		}
+		const { destUrl, sources } = resolveRedirectChain(
+			page.url.withoutHashAndAuth,
+			page.redirectPaths,
+		);
 
 		const destUrlObject = parseUrl(destUrl);
 
@@ -899,29 +959,13 @@ export class Database extends EventEmitter<DatabaseEvent> {
 				trx,
 			);
 
-			const destUrlNormalized = destUrlObject.withoutHashAndAuth;
-			for (const redirect of redirectPaths) {
-				if (redirect === destUrlNormalized) {
-					dbLog('Skip self-redirect: %s', redirect);
-					continue;
-				}
-				dbLog('Set redirected url: %s -> %s', redirect, destUrl);
-				const redirectId = await this.#getIdByUrl(redirect, undefined, trx);
-				await trx<DB_Page>('pages')
-					.where('id', redirectId)
-					.update({
-						scraped: 1,
-						redirectDestId: pageId,
-						isExternal: page.isExternal ? 1 : 0,
-					});
-				// A page that used to be scraped as content can later turn into a
-				// redirect source. It owns no content anymore, so drop any anchors /
-				// images it captured in its former life — otherwise they linger and
-				// leak into referrer / incoming-link reads (which do not filter out
-				// redirect sources).
-				await trx('anchors').where('pageId', redirectId).delete();
-				await trx('images').where('pageId', redirectId).delete();
-			}
+			await this.#linkRedirectSources(
+				trx,
+				sources,
+				pageId,
+				destUrlObject.withoutHashAndAuth,
+				page.isExternal,
+			);
 			let snapshot: { html?: string; pageId: number } = { pageId };
 			if (isTarget && snapshotDir) {
 				snapshot = await this.#updateSnapshotPath(pageId, snapshotDir, trx);
@@ -1019,7 +1063,6 @@ export class Database extends EventEmitter<DatabaseEvent> {
 		}
 		return insertedId;
 	}
-
 	/**
 	 * Initializes the database schema if tables do not exist, then runs lightweight
 	 * migrations that bring older archives up to the current schema.
@@ -1038,7 +1081,6 @@ export class Database extends EventEmitter<DatabaseEvent> {
 		await migrateInfoRoots(this.#instance);
 		await migratePageErrors(this.#instance);
 	}
-
 	/**
 	 * Upserts page data into the `pages` table (inserts if new, updates if existing).
 	 * @param page
@@ -1078,6 +1120,53 @@ export class Database extends EventEmitter<DatabaseEvent> {
 				isSkipped: page.isSkipped,
 			});
 		return pageId;
+	}
+	/**
+	 * Points each redirect-source URL at the destination page, marking it scraped
+	 * and clearing any content it owned in a former life.
+	 *
+	 * Shared by {@link updatePage} (which also renders and stores the destination)
+	 * and {@link recordRedirect} (which only records the edge for a destination
+	 * rendered elsewhere). Self-redirects (source equal to the destination) are
+	 * skipped so a page is never marked as redirecting to itself — that would
+	 * exclude it from reports via the `whereNull('redirectDestId')` filter.
+	 * @param trx - The active transaction.
+	 * @param sources - Redirect-source URLs (normalised): the original URL plus
+	 *   any intermediate hops. Empty when the page was not redirected.
+	 * @param destId - Database id of the redirect destination page.
+	 * @param destUrlNormalized - Normalised destination URL, used to detect and
+	 *   skip self-redirects.
+	 * @param isExternal - Whether the sources are external to the crawl scope.
+	 */
+	async #linkRedirectSources(
+		trx: Knex.Transaction,
+		sources: readonly string[],
+		destId: number,
+		destUrlNormalized: string,
+		isExternal: boolean,
+	): Promise<void> {
+		for (const redirect of sources) {
+			if (redirect === destUrlNormalized) {
+				dbLog('Skip self-redirect: %s', redirect);
+				continue;
+			}
+			dbLog('Set redirected url: %s -> id:%d', redirect, destId);
+			const redirectId = await this.#getIdByUrl(redirect, undefined, trx);
+			await trx<DB_Page>('pages')
+				.where('id', redirectId)
+				.update({
+					scraped: 1,
+					redirectDestId: destId,
+					isExternal: isExternal ? 1 : 0,
+				});
+			// A page that used to be scraped as content can later turn into a
+			// redirect source. It owns no content anymore, so drop any anchors /
+			// images it captured in its former life — otherwise they linger and
+			// leak into referrer / incoming-link reads (which do not filter out
+			// redirect sources).
+			await trx('anchors').where('pageId', redirectId).delete();
+			await trx('images').where('pageId', redirectId).delete();
+		}
 	}
 
 	/**

--- a/packages/@nitpicker/crawler/src/archive/resolve-redirect-chain.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/resolve-redirect-chain.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRedirectChain } from './resolve-redirect-chain.js';
+
+describe('resolveRedirectChain', () => {
+	it('リダイレクトが無い場合は宛先=元URL・sources は空', () => {
+		const result = resolveRedirectChain('http://localhost/page', []);
+		expect(result).toEqual({ destUrl: 'http://localhost/page', sources: [] });
+	});
+
+	it('単一ホップは宛先=最終URL・sources=[元URL]', () => {
+		const result = resolveRedirectChain('http://localhost/old', ['http://localhost/new']);
+		expect(result).toEqual({
+			destUrl: 'http://localhost/new',
+			sources: ['http://localhost/old'],
+		});
+	});
+
+	it('多段ホップは最後を宛先・元URL＋中間ホップを sources にする', () => {
+		const result = resolveRedirectChain('http://localhost/start', [
+			'http://localhost/middle',
+			'http://localhost/dest',
+		]);
+		expect(result).toEqual({
+			destUrl: 'http://localhost/dest',
+			sources: ['http://localhost/start', 'http://localhost/middle'],
+		});
+	});
+
+	it('入力の redirectPaths を破壊しない', () => {
+		const paths = ['http://localhost/a', 'http://localhost/b'];
+		resolveRedirectChain('http://localhost/start', paths);
+		expect(paths).toEqual(['http://localhost/a', 'http://localhost/b']);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/resolve-redirect-chain.ts
+++ b/packages/@nitpicker/crawler/src/archive/resolve-redirect-chain.ts
@@ -1,0 +1,44 @@
+/**
+ * The destination of a redirect chain and the source URLs that point at it.
+ */
+export interface RedirectChain {
+	/** The final destination URL the chain lands on (normalised). */
+	destUrl: string;
+	/**
+	 * The source URLs that redirect to {@link destUrl}: the originally requested
+	 * URL followed by every intermediate hop. Empty when the page was not
+	 * redirected at all.
+	 */
+	sources: string[];
+}
+
+/**
+ * Splits a page's redirect chain into its final destination and the list of
+ * source URLs that point at it.
+ *
+ * The archive stores redirects as edges: every source URL carries a
+ * `redirectDestId` pointing at the destination page, and only the destination
+ * holds content. This helper applies the shared convention — the last entry of
+ * `redirectPaths` is the destination, while the originally requested URL plus
+ * every intermediate hop are the sources. When the page was not redirected,
+ * the destination is the page URL itself and there are no sources.
+ *
+ * Used by both {@link Database.updatePage} (which renders and stores the
+ * destination) and {@link Database.recordRedirect} (the #73 convergence
+ * optimisation, which records the edge for a destination already rendered
+ * elsewhere without touching its content).
+ * @param pageUrl - The originally requested URL (normalised, without hash/auth).
+ * @param redirectPaths - The redirect hop URLs captured during fetch, in order.
+ * @returns The destination URL and the source URLs pointing to it.
+ */
+export function resolveRedirectChain(
+	pageUrl: string,
+	redirectPaths: readonly string[],
+): RedirectChain {
+	if (redirectPaths.length === 0) {
+		return { destUrl: pageUrl, sources: [] };
+	}
+	const paths = [...redirectPaths];
+	const destUrl = paths.pop()!;
+	return { destUrl, sources: [pageUrl, ...paths] };
+}

--- a/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
+++ b/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
@@ -246,6 +246,13 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 					.catch((error) => reject(error));
 			});
 
+			this.#crawler.on('redirect', ({ result }) => {
+				writeQueue
+					.enqueue(() => this.#archive.setRedirect(result))
+					.catch((error) => reject(error));
+				void this.emit('redirect', { result });
+			});
+
 			this.#crawler.on('response', ({ resource }) => {
 				writeQueue
 					.enqueue(() => this.#archive.setResources(resource))

--- a/packages/@nitpicker/crawler/src/crawler/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.ts
@@ -1,4 +1,9 @@
-import type { CrawlerEventTypes, CrawlerOptions, ResourceLookupResult } from './types.js';
+import type {
+	CrawlerEventTypes,
+	CrawlerOptions,
+	ResourceLookupResult,
+	ScrapeOutcome,
+} from './types.js';
 import type {
 	ChangePhaseEvent,
 	PageData,
@@ -39,6 +44,7 @@ import { linkToPageData } from './link-to-page-data.js';
 import { logUndrainedPhaseErrors } from './log-undrained-phase-errors.js';
 import { partitionUrlsByHtml } from './partition-urls-by-html.js';
 import { protocolAgnosticKey } from './protocol-agnostic-key.js';
+import { redirectDestKey } from './redirect-dest-key.js';
 import { resourceToPageData } from './resource-to-page-data.js';
 import { RobotsChecker } from './robots-checker.js';
 import { shouldDiscardPredicted } from './should-discard-predicted.js';
@@ -83,12 +89,17 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 	#resumedPending: ExURL[] = [];
 	/** URLs already scraped in a previous session, used to populate the `seen` set in {@link #runDeal}. */
 	#resumedScraped: string[] = [];
-
 	/** Checker for robots.txt compliance. */
 	readonly #robotsChecker: RobotsChecker;
-
 	/** Maps hostnames to their scope URLs. Defines the crawl boundary for internal/external classification. */
 	readonly #scope = new Map<string /* hostname */, ExURL[]>();
+	/**
+	 * Protocol-agnostic keys of redirect destinations already rendered (and stored)
+	 * during this crawl. When many URLs redirect to one destination, only the first
+	 * renders it; the rest record the redirect edge and skip the browser (#73).
+	 * Keyed by {@link redirectDestKey}. Reset at the start of {@link #runDeal}.
+	 */
+	readonly #scrapedDestinations = new Set<string>();
 
 	/**
 	 * The AbortSignal associated with this crawler's AbortController.
@@ -586,6 +597,9 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 			seen.add(protocolAgnosticKey(url));
 		}
 
+		// Redirect-destination dedup is per-crawl; clear any state from a prior run.
+		this.#scrapedDestinations.clear();
+
 		// external URL の追跡（target は deal の total/done から導出）
 		const externalUrls = new Set<string>();
 		const externalDoneUrls = new Set<string>();
@@ -700,6 +714,30 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 							_index,
 							markBrowserScrape,
 						);
+
+						// Redirect convergence (#73): the destination was already
+						// rendered during this crawl, so only the redirect edge is
+						// recorded and the browser was never launched. Mark the URL
+						// done and emit `redirect` (routed to `Archive.setRedirect`,
+						// which writes the edge without touching the destination's
+						// content). This URL does not count toward pagesScraped.
+						if (result.type === 'redirect-edge') {
+							// Note: a predicted (speculative) URL that reaches here genuinely
+							// redirects (the server returned 3xx), so it is a real URL — we
+							// record its edge rather than discard it. This matches the render
+							// path, where the first predicted source to a destination renders
+							// it and is recorded as a redirect source the same way; only 404 /
+							// error predicted URLs are dropped (by `shouldDiscardPredicted`).
+							this.#linkList.done(
+								url,
+								this.#scope,
+								{ page: result.pageData },
+								this.#options,
+							);
+							void this.emit('redirect', { result: result.pageData });
+							log(c.dim('Redirect (dest already scraped)'));
+							return;
+						}
 
 						// Discard predicted URLs that failed (404, error, etc.)
 						if (isPredicted && shouldDiscardPredicted(result)) {
@@ -823,7 +861,7 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 		metadataOnly: boolean,
 		laneIndex: number,
 		markBrowserScrape: () => void,
-	): Promise<ScrapeResult> {
+	): Promise<ScrapeOutcome> {
 		const isExternal = findScopeEntry(url, this.#scope, this.#options) === null;
 
 		// Non-HTTP protocols (mailto:, tel:, etc.) — let the scraper handle early return
@@ -888,6 +926,29 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 			};
 		}
 
+		// Redirect convergence (#73): `finalKey` is the destination this URL lands
+		// on after following its redirect chain (or the URL itself when it does not
+		// redirect). When that destination has already been rendered and stored
+		// during this crawl, do NOT process this URL further — record the redirect
+		// edge only and skip everything below, regardless of content type. This is
+		// the root fix for the many-to-one redirect duplication (#70): every source
+		// URL that 301s to one destination otherwise re-renders/re-stores it. The
+		// check sits ABOVE the metadata-only and non-HTML branches on purpose — both
+		// route their HEAD/title result through `updatePage`, which would funnel a
+		// content-less result into `#insertPage` and overwrite the already-rendered
+		// destination's title / meta / isExternal. The edge-only path leaves the
+		// destination row intact.
+		//
+		// `finalKey` is also claimed for destinations reached directly (no redirect;
+		// see the claim after a successful render below), so a destination that is
+		// both linked directly and arrived at via a redirect is rendered by whichever
+		// path wins the race, not both.
+		const finalKey = redirectDestKey(url, headCheckResult.redirectPaths);
+		if (this.#scrapedDestinations.has(finalKey)) {
+			crawlerLog('Redirect dest already rendered, edge only: %s', url.href);
+			return { type: 'redirect-edge', pageData: headCheckResult };
+		}
+
 		// Title-only mode — extract <title> via partial GET for HTML, skip browser
 		if (metadataOnly) {
 			if (
@@ -947,6 +1008,27 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 		);
 		if (browserResult.type === 'success') {
 			markBrowserScrape();
+			// Claim the destination that was ACTUALLY rendered, keyed off the
+			// browser's own redirect resolution rather than the HEAD pre-flight's
+			// guess (`finalKey`). The browser is authoritative for what got stored;
+			// if HEAD and the browser disagree on the final URL (method-conditional
+			// / JS / meta-refresh redirects), keying the claim off the HEAD guess
+			// would route a sibling source to an edge pointing at a never-rendered
+			// phantom row. By claiming the rendered URL, a divergent sibling simply
+			// re-renders (dedup misses) instead — correct, just less optimal. In the
+			// common case HEAD and the browser agree, so the keys are identical.
+			//
+			// Claimed only after a successful render, so a failed render leaves the
+			// destination unclaimed and a later source retries it. Concurrent
+			// in-flight sources to the same destination (bounded by the concurrency
+			// limit) may still each render before any claim lands; the storage-layer
+			// replace in `updatePage` (#70) keeps the resulting anchors / images
+			// correct (sub-resources may briefly duplicate, far below the pre-#73
+			// once-per-source blow-up).
+			const renderedKey = browserResult.pageData
+				? redirectDestKey(url, browserResult.pageData.redirectPaths)
+				: finalKey;
+			this.#scrapedDestinations.add(renderedKey);
 		}
 		return browserResult;
 	}

--- a/packages/@nitpicker/crawler/src/crawler/fetch-destination.ts
+++ b/packages/@nitpicker/crawler/src/crawler/fetch-destination.ts
@@ -107,12 +107,19 @@ async function _fetchHead(
 ) {
 	return new Promise<PageData>((resolve, reject) => {
 		const hostHeader = url.port ? `${url.hostname}:${url.port}` : url.hostname;
-		const request: RequestOptions = {
+		// `trackRedirects` makes follow-redirects populate `res.redirects` with the
+		// chain of followed URLs. Without it that array stays empty and the
+		// pre-flight cannot tell where a URL lands — required for the redirect
+		// chain in `redirectPaths` and for the #73 convergence dedup, which decides
+		// whether a redirect destination was already rendered *before* launching
+		// the browser.
+		const request: RequestOptions & { trackRedirects: boolean } = {
 			protocol: url.protocol,
 			hostname: url.hostname,
 			port: url.port || undefined,
 			path: url.pathname,
 			method,
+			trackRedirects: true,
 			headers: {
 				host: hostHeader,
 				...(userAgent ? { 'User-Agent': userAgent } : {}),
@@ -141,7 +148,17 @@ async function _fetchHead(
 			let settled = false;
 
 			const buildPageData = (title: string): PageData => {
-				const redirectPaths = res.redirects.map((r) => r.url);
+				// `res.redirects` (populated by trackRedirects) ALWAYS starts with the
+				// originally requested URL, then each followed hop. We drop that first
+				// entry so `redirectPaths` keeps its established contract: empty when the
+				// URL did not redirect, and `[...intermediate, finalDest]` when it did
+				// (the original URL is NOT included — callers like `resolveRedirectChain`
+				// and `updatePage` re-add it). Keeping the original here would (a) make
+				// `redirectPaths` non-empty for every page, so a direct page looks like a
+				// self-redirect, and (b) leak the query-stripped request-target (the HEAD
+				// request uses `url.pathname`), collapsing query-distinguished pages.
+				// Redirect *targets* come from Location headers and keep their query.
+				const redirectPaths = res.redirects.map((r) => r.url).slice(1);
 				const _contentLength = Number.parseInt(res.headers['content-length'] || '');
 				const contentLength = Number.isFinite(_contentLength) ? _contentLength : null;
 				return {

--- a/packages/@nitpicker/crawler/src/crawler/redirect-dest-key.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/redirect-dest-key.spec.ts
@@ -1,0 +1,37 @@
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { describe, expect, it } from 'vitest';
+
+import { redirectDestKey } from './redirect-dest-key.js';
+
+describe('redirectDestKey', () => {
+	it('リダイレクトが無い場合は元URLのキーを返す', () => {
+		const url = parseUrl('http://localhost/page')!;
+		expect(redirectDestKey(url, [])).toBe('//localhost/page');
+	});
+
+	it('リダイレクトがある場合はチェーン末尾（最終到達先）のキーを返す', () => {
+		const url = parseUrl('http://localhost/old')!;
+		expect(redirectDestKey(url, ['http://localhost/new'])).toBe('//localhost/new');
+	});
+
+	it('多段リダイレクトでも最後のホップを宛先として使う', () => {
+		const url = parseUrl('http://localhost/start')!;
+		expect(
+			redirectDestKey(url, ['http://localhost/middle', 'http://localhost/dest']),
+		).toBe('//localhost/dest');
+	});
+
+	it('http と https の宛先は同じキーに収束する（protocol-agnostic）', () => {
+		const url = parseUrl('http://localhost/old')!;
+		const httpsKey = redirectDestKey(url, ['https://localhost/new']);
+		const httpKey = redirectDestKey(url, ['http://localhost/new']);
+		expect(httpsKey).toBe(httpKey);
+	});
+
+	it('宛先のハッシュ・認証情報はキーから除外される', () => {
+		const url = parseUrl('http://localhost/old')!;
+		expect(redirectDestKey(url, ['http://user:pass@localhost/new#frag'])).toBe(
+			'//localhost/new',
+		);
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/redirect-dest-key.ts
+++ b/packages/@nitpicker/crawler/src/crawler/redirect-dest-key.ts
@@ -1,0 +1,31 @@
+import type { ExURL } from '@d-zero/shared/parse-url';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+
+import { protocolAgnosticKey } from './protocol-agnostic-key.js';
+
+/**
+ * Computes the protocol-agnostic dedup key for the final destination a request
+ * lands on after following its redirect chain.
+ *
+ * Used by the redirect-convergence optimisation (#73): the crawler remembers
+ * which final destinations have already been rendered, keyed by this value, so
+ * that many source URLs all redirecting to one destination render it only once.
+ * When there is no redirect, the destination is the requested URL itself.
+ *
+ * The key matches the form used elsewhere in the crawler (`protocolAgnosticKey`
+ * over the normalised URL without hash/auth) so HTTP and HTTPS variants of the
+ * same destination collapse to one entry.
+ * @param url - The originally requested URL.
+ * @param redirectPaths - The redirect hop URLs captured during the HEAD
+ *   pre-flight, in order. The last entry is the final destination.
+ * @returns The protocol-agnostic key of the final destination.
+ */
+export function redirectDestKey(url: ExURL, redirectPaths: readonly string[]): string {
+	const last = redirectPaths.at(-1);
+	if (last === undefined) {
+		return protocolAgnosticKey(url.withoutHashAndAuth);
+	}
+	const parsed = parseUrl(last);
+	return protocolAgnosticKey(parsed ? parsed.withoutHashAndAuth : last);
+}

--- a/packages/@nitpicker/crawler/src/crawler/types.ts
+++ b/packages/@nitpicker/crawler/src/crawler/types.ts
@@ -1,6 +1,25 @@
 import type { PageData, CrawlerError, Resource } from '../utils/types/types.js';
-import type { ChangePhaseEvent } from '@d-zero/beholder';
+import type { ChangePhaseEvent, ScrapeResult } from '@d-zero/beholder';
 import type { ParseURLOptions } from '@d-zero/shared/parse-url';
+
+/**
+ * Result of resolving a URL that redirects to a destination already rendered
+ * during this crawl (#73). The crawler records the redirect edge only and skips
+ * launching the browser, so the destination is never re-rendered.
+ */
+export interface RedirectEdgeResult {
+	/** Discriminant marking this as a redirect-edge-only outcome. */
+	type: 'redirect-edge';
+	/** HEAD-resolved page data carrying the redirect chain (source → destination). */
+	pageData: PageData;
+}
+
+/**
+ * The outcome of {@link Crawler.#scrapePage}: either a normal scrape result from
+ * the browser/HEAD pipeline, or a {@link RedirectEdgeResult} when the URL's
+ * redirect destination was already rendered and only the edge needs recording.
+ */
+export type ScrapeOutcome = ScrapeResult | RedirectEdgeResult;
 
 /**
  * Configuration options that control crawler behavior.
@@ -206,5 +225,17 @@ export interface CrawlerEventTypes {
 		message: string;
 		/** Whether the URL is external to the crawl scope. */
 		isExternal: boolean;
+	};
+
+	/**
+	 * Emitted when a URL redirects to a destination that has already been
+	 * rendered during this crawl, so only the redirect edge is recorded and the
+	 * destination is not re-rendered (#73). The orchestrator persists this via
+	 * `Archive.setRedirect`, which writes the edge without overwriting the
+	 * destination's content.
+	 */
+	redirect: {
+		/** HEAD-resolved page data carrying the redirect chain (source → destination). */
+		result: PageData;
 	};
 }

--- a/packages/@nitpicker/crawler/src/types.ts
+++ b/packages/@nitpicker/crawler/src/types.ts
@@ -1,4 +1,4 @@
-import type { CrawlerError } from './utils/types/types.js';
+import type { CrawlerError, PageData } from './utils/types/types.js';
 
 /**
  * Event map for the `CrawlerOrchestrator` class.
@@ -27,4 +27,15 @@ export interface CrawlEvent {
 	 * Emitted when an error occurs during crawling or archiving.
 	 */
 	error: CrawlerError;
+
+	/**
+	 * Emitted when a URL redirects to a destination already rendered during this
+	 * crawl, so only the redirect edge is recorded and the destination is not
+	 * re-rendered (#73). Mirrors the crawler's `redirect` event; useful for
+	 * observing how much redirect-convergence work was skipped.
+	 */
+	redirect: {
+		/** HEAD-resolved page data carrying the redirect chain (source → destination). */
+		result: PageData;
+	};
 }

--- a/packages/test-server/src/__tests__/e2e/helpers.ts
+++ b/packages/test-server/src/__tests__/e2e/helpers.ts
@@ -25,11 +25,15 @@ export interface CrawlResult {
  * Runs a crawl session against the given URLs and returns an accessor to the archive.
  * @param urls - One or more URLs to crawl.
  * @param options - Optional overrides merged into the default crawl configuration.
+ * @param tap - Optional callback receiving the orchestrator before crawling
+ *   begins, so a test can subscribe to events (e.g. `redirect`) emitted during
+ *   the crawl. The default error logger is always attached regardless.
  * @returns A {@link CrawlResult} containing the archive accessor and temp paths.
  */
 export async function crawl(
 	urls: string[],
 	options?: Record<string, unknown>,
+	tap?: (orchestrator: CrawlerOrchestrator) => void,
 ): Promise<CrawlResult> {
 	const cwd = path.join(os.tmpdir(), `nitpicker-e2e-${crypto.randomUUID()}`);
 	await fs.mkdir(cwd, { recursive: true });
@@ -47,6 +51,7 @@ export async function crawl(
 			q.on('error', (e) => {
 				console.error('[nitpicker:e2e] error:', e); // eslint-disable-line no-console
 			});
+			tap?.(q);
 		},
 	);
 

--- a/packages/test-server/src/__tests__/e2e/redirect.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/redirect.e2e.ts
@@ -49,3 +49,134 @@ describe('Redirect handling', () => {
 		expect(anchorUrls.some((u) => u.includes('/redirect/start'))).toBe(true);
 	});
 });
+
+describe('Redirect convergence (#73): 多対一リダイレクト先を1回だけ描画する', () => {
+	let result: CrawlResult;
+	let redirectEvents = 0;
+
+	beforeAll(async () => {
+		result = await crawl(['http://localhost:8010/converge/'], undefined, (q) => {
+			q.on('redirect', () => {
+				redirectEvents++;
+			});
+		});
+	}, 60_000);
+
+	afterAll(async () => {
+		await cleanup(result);
+	});
+
+	it('3 ソース中、宛先描画後の 2 ソースは描画されず redirect 辺だけ記録される', () => {
+		// legacy-1 が canonical をレンダリングして claim、legacy-2 / legacy-3 は
+		// 既知の宛先なので redirect-edge（描画スキップ）になる。#73 が無いと
+		// legacy-2 / legacy-3 も canonical を再描画し、redirect イベントは 0 になる。
+		expect(redirectEvents).toBe(2);
+	});
+
+	it('宛先 canonical は 1 ページとして正しく記録される', async () => {
+		const pages = await result.accessor.getPages('internal-page');
+		const dest = pages.find((p) => p.url.pathname === '/converge/canonical');
+		expect(dest).toBeDefined();
+		expect(dest!.title).toBe('Converge Canonical');
+		expect(dest!.status).toBe(200);
+	});
+
+	it('3 つの legacy URL すべてが canonical へのリダイレクト元として記録される', async () => {
+		const pages = await result.accessor.getPages('internal-page');
+		const dest = pages.find((p) => p.url.pathname === '/converge/canonical');
+		expect(dest).toBeDefined();
+
+		const fromPaths = dest!.redirectFrom.map((r) => new URL(r.url).pathname).toSorted();
+		expect(fromPaths).toEqual([
+			'/converge/legacy-1',
+			'/converge/legacy-2',
+			'/converge/legacy-3',
+		]);
+	});
+
+	it('宛先のアンカーは集約で多重化しない（1セットだけ）', async () => {
+		const pages = await result.accessor.getPages('internal-page');
+		const dest = pages.find((p) => p.url.pathname === '/converge/canonical');
+		expect(dest).toBeDefined();
+
+		const anchors = await dest!.getAnchors();
+		// canonical は /converge/ への1リンクのみ。3ソース集約でも多重化しない。
+		const backLinks = anchors.filter((a) => new URL(a.url).pathname === '/converge/');
+		expect(backLinks).toHaveLength(1);
+	});
+});
+
+describe('Redirect convergence dedup はクエリ違いの別ページを潰さない（#73 回帰）', () => {
+	let result: CrawlResult;
+
+	beforeAll(async () => {
+		result = await crawl(['http://localhost:8010/query-distinct/']);
+	}, 60_000);
+
+	afterAll(async () => {
+		await cleanup(result);
+	});
+
+	it('パスが同じでクエリだけ違う2ページが両方とも描画・記録される', async () => {
+		const pages = await result.accessor.getPages('internal-page');
+		const items = pages
+			.filter((p) => p.url.pathname === '/query-distinct/item')
+			.map((p) => p.title)
+			.toSorted();
+		// #73 の dedup キーがクエリを落とすと kind=beta が kind=alpha の宛先として
+		// 弾かれ、Item beta が描画されず 1 ページに潰れる。両方の固有タイトルが残ること。
+		expect(items).toEqual(['Item alpha', 'Item beta']);
+	});
+});
+
+describe('HEAD と GET で到達先が違っても描画した宛先で claim する（#73 #5 回帰）', () => {
+	let result: CrawlResult;
+
+	beforeAll(async () => {
+		result = await crawl(['http://localhost:8010/diverge/']);
+	}, 60_000);
+
+	afterAll(async () => {
+		await cleanup(result);
+	});
+
+	it('ブラウザが描画した browser-dest が記録される', async () => {
+		const pages = await result.accessor.getPages();
+		const browserDest = pages.find((p) => p.url.pathname === '/diverge/browser-dest');
+		expect(browserDest).toBeDefined();
+		expect(browserDest!.title).toBe('Diverge Browser dest');
+	});
+
+	it('HEAD だけが到達する head-dest の幽霊ページが作られない', async () => {
+		const pages = await result.accessor.getPages();
+		const headDest = pages.find((p) => p.url.pathname === '/diverge/head-dest');
+		// claim を HEAD 由来キーで行うと、2本目のソースが head-dest への辺になり
+		// recordRedirect が content-less な head-dest 行を生成してしまう。描画した
+		// browser-dest で claim していれば head-dest は一度も生成されない。
+		expect(headDest).toBeUndefined();
+	});
+});
+
+describe('metadataOnly のリダイレクト元が描画済み宛先を上書きしない（#73 #2 回帰）', () => {
+	let result: CrawlResult;
+
+	beforeAll(async () => {
+		result = await crawl(['http://localhost:8010/clobber/']);
+	}, 60_000);
+
+	afterAll(async () => {
+		await cleanup(result);
+	});
+
+	it('外部 metadataOnly リダイレクト元が internal 宛先を external/title-only に潰さない', async () => {
+		// canonical は自分自身に貼られた external リンク経由で ext を発見するため、
+		// 必ず先に描画・claim される。CHECK が metadataOnly ブランチより下にあると、
+		// ext の薄い title-GET 結果が updatePage 経由で canonical を isExternal=true /
+		// isTarget=false に上書きし、internal-page から消える。
+		const pages = await result.accessor.getPages('internal-page');
+		const canonical = pages.find((p) => p.url.pathname === '/clobber/canonical');
+		expect(canonical).toBeDefined();
+		expect(canonical!.title).toBe('Clobber Canonical');
+		expect(canonical!.isTarget).toBe(true);
+	});
+});

--- a/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
@@ -69,12 +69,18 @@ describe('Resource reuse', () => {
 		expect(redirected.map((r) => r.method)).toEqual(['GET', 'HEAD']);
 	});
 
-	it('リダイレクト画像の pages 行はリダイレクト追跡済みの最終ステータスを持つ', async () => {
+	it('リダイレクトするサブリソースは source→dest の辺として記録され、最終URLが 200 を持つ', async () => {
 		const pages = await result.accessor.getPages();
-		const page = pages.find((p) => p.url.pathname === '/resource-reuse/redirected.png');
-		expect(page).toBeDefined();
-		expect(page!.status).toBe(200);
-		expect(page!.contentType).toBe('image/png');
+		// HEAD プリフライト（trackRedirects）が redirected.png → actual.png を解決し、
+		// 最終到達先 actual.png が 200 / image/png として記録される。
+		const actual = pages.find((p) => p.url.pathname === '/resource-reuse/actual.png');
+		expect(actual).toBeDefined();
+		expect(actual!.status).toBe(200);
+		expect(actual!.contentType).toBe('image/png');
+		// redirected.png は最終 URL を上書きせず、リダイレクト元として記録される。
+		expect(
+			actual!.redirectFrom.some((r) => r.url.includes('/resource-reuse/redirected.png')),
+		).toBe(true);
 	});
 
 	it('external サブリソース（127.0.0.1）への直リンクも再利用され HEAD が飛ばない', () => {

--- a/packages/test-server/src/routes/redirect.ts
+++ b/packages/test-server/src/routes/redirect.ts
@@ -1,4 +1,4 @@
-import type { Hono } from 'hono';
+import type { Context, Hono } from 'hono';
 
 /**
  * Registers routes for testing HTTP redirect chains (301 and 302).
@@ -23,5 +23,115 @@ export function redirectRoutes(app: Hono) {
 				'<a href="/redirect/start">Back to start</a>' +
 				'</body></html>',
 		),
+	);
+
+	// Many-to-one redirect convergence: three distinct legacy URLs all 301 to a
+	// single canonical destination. Used to verify #73 — the destination is
+	// rendered only once and the remaining sources record a redirect edge only.
+	app.get('/converge/', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Converge Top</title></head><body>' +
+				'<a href="/converge/legacy-1">Legacy 1</a>' +
+				'<a href="/converge/legacy-2">Legacy 2</a>' +
+				'<a href="/converge/legacy-3">Legacy 3</a>' +
+				'</body></html>',
+		),
+	);
+
+	app.get('/converge/legacy-1', (c) => c.redirect('/converge/canonical', 301));
+	app.get('/converge/legacy-2', (c) => c.redirect('/converge/canonical', 301));
+	app.get('/converge/legacy-3', (c) => c.redirect('/converge/canonical', 301));
+
+	app.get('/converge/canonical', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Converge Canonical</title></head><body>' +
+				'<a href="/converge/">Back to top</a>' +
+				'</body></html>',
+		),
+	);
+
+	// Query-distinguished pages that do NOT redirect: two URLs share a path but
+	// differ only by query string. The redirect-convergence dedup (#73) must keep
+	// them distinct (the dedup key must not collapse them), so both are rendered.
+	// Non-numeric query values are used so the predicted-pagination heuristic does
+	// not speculatively fetch extra pages and muddy the assertion.
+	app.get('/query-distinct/', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Q Top</title></head><body>' +
+				'<a href="/query-distinct/item?kind=alpha">Item alpha</a>' +
+				'<a href="/query-distinct/item?kind=beta">Item beta</a>' +
+				'</body></html>',
+		),
+	);
+
+	app.get('/query-distinct/item', (c) => {
+		const kind = c.req.query('kind') ?? 'none';
+		return c.html(
+			`<!doctype html><html lang="en"><head><title>Item ${kind}</title></head><body>` +
+				`<p>item ${kind}</p>` +
+				'</body></html>',
+		);
+	});
+
+	// HEAD and GET resolve to DIFFERENT destinations: the HEAD pre-flight lands on
+	// /diverge/head-dest, but the browser (GET) follows to /diverge/browser-dest.
+	// The redirect-dedup must claim the destination the browser actually rendered
+	// (#73), not the HEAD guess — otherwise a sibling source is short-circuited to
+	// an edge pointing at the never-rendered /diverge/head-dest phantom row.
+	app.get('/diverge/', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Diverge Top</title></head><body>' +
+				'<a href="/diverge/src1">Source 1</a>' +
+				'<a href="/diverge/src2">Source 2</a>' +
+				'</body></html>',
+		),
+	);
+
+	const divergeSource = (c: Context) =>
+		c.redirect(
+			c.req.method === 'HEAD' ? '/diverge/head-dest' : '/diverge/browser-dest',
+			301,
+		);
+	app.on(['GET', 'HEAD'], '/diverge/src1', divergeSource);
+	app.on(['GET', 'HEAD'], '/diverge/src2', divergeSource);
+
+	app.get('/diverge/head-dest', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Diverge HEAD dest</title></head><body>' +
+				'<p>head dest</p></body></html>',
+		),
+	);
+	app.get('/diverge/browser-dest', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Diverge Browser dest</title></head><body>' +
+				'<p>browser dest</p></body></html>',
+		),
+	);
+
+	// A metadata-only (external) redirect source must NOT overwrite an
+	// already-rendered internal destination with its thin title-GET result (#73).
+	// The external link is placed ON the canonical page itself, so the canonical is
+	// always rendered (and claimed) before the external source is discovered — the
+	// destination is never re-rendered afterwards, so a clobber would be permanent.
+	// `127.0.0.1` is treated as a different host (external scope); it 301s back to
+	// the internal `localhost` canonical.
+	app.get('/clobber/', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Clobber Top</title></head><body>' +
+				'<a href="/clobber/canonical">Canonical</a>' +
+				'</body></html>',
+		),
+	);
+
+	app.get('/clobber/canonical', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Clobber Canonical</title></head><body>' +
+				'<a href="http://127.0.0.1:8010/clobber/ext">External tracker link</a>' +
+				'</body></html>',
+		),
+	);
+
+	app.on(['GET', 'HEAD'], '/clobber/ext', (c) =>
+		c.redirect('http://localhost:8010/clobber/canonical', 301),
 	);
 }


### PR DESCRIPTION
## 概要

多対一リダイレクト（N 個の旧 URL → 1 つの宛先 D）で、クローラがリダイレクト元ごとに D をフルレンダリング・再保存していた問題（#73）を、HEAD プリフライトで到達先を解決し「D が描画済みなら辺だけ記録して描画をスキップ」することで解消する。#70（storage 層の置き換え）の根本対応。

## 変更内容

- **`fetch-destination`**: HEAD に `trackRedirects: true` を付与し、follow-redirects のリダイレクトチェーンを取得。follow-redirects は `res.redirects[0]` に必ず**元の要求 URL（HEAD は `url.pathname` 送信なのでクエリ落ち）**を積むため、`slice(1)` で先頭を捨てて `redirectPaths` の契約（リダイレクト無し＝空 / 先頭は含めない / 先のクエリは保持）に戻す。
- **`crawler`**: `#scrapedDestinations` claim 集合と、`#scrapePage` の描画前 CHECK（metadata-only / 非 HTML ブランチより**上**に配置 — 薄い HEAD 結果で描画済み宛先を上書きしないため）。claim は **browser が実際に描画した宛先キー**で行い、HEAD と GET の到達先が食い違っても幽霊行を作らない。
- **`archive`**: `Database.recordRedirect` / `Archive.setRedirect` が**宛先本文を上書きせず**辺だけ記録（`#insertPage` を通さない）。`resolveRedirectChain` / `#linkRedirectSources` を `updatePage` と共有。空チェーン・解析不能 URL はクロールを止めずスキップ。

## ⚠️ 保守上の注意

- **`fetch-destination` の `slice(1)` を外さない**。外すとリダイレクト無しのページまで自己リダイレクト扱いになり、`?id=1`/`?id=2` のようなクエリ違いの別ページが同一視されて**2 件目が消える**。ガード: `/query-distinct/` E2E。
- **既知の制約**: HEAD と GET の到達先が食い違う稀なケース（method 条件付き / JS / meta-refresh）では重複排除が空振りして再描画するだけ（データは正しい・幽霊行は作らない）。
- 詳細は `ARCHITECTURE.md` の「リダイレクト先の再レンダリング抑止（#73）」を参照。

## テスト

- ユニット: `resolveRedirectChain` / `redirectDestKey` / `recordRedirect`（本文非上書き・空チェーン・解析不能 dest ガード）
- E2E: `/converge/`（描画1回・辺記録）/ `/query-distinct/`（クエリ別ページ消えない）/ `/diverge/`（HEAD≠GET で幽霊行なし）/ `/clobber/`（metadata-only が描画済み宛先を潰さない）
- レビュー3種（code-review / qa-engineer / product-manager）の指摘を全反映。build / test / lint・#73 関連 E2E すべて緑。

## 互換性

v0.x のため migration ガイドなし。挙動変化（非 HTML / metadata-only のリダイレクトが辺として記録される・`redirectPaths` が実際に埋まる）あり。本修正前のアーカイブの水増しは再クロールで解消（#70 セクション記載）。

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)