### PR TITLE
fix(crawler): stop treating non-HTML resources as HTML pages (#72)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -707,7 +707,7 @@ metadata-only（title のみ）と非 HTML は `headCheckResult` を `updatePage
 
 **`isTarget` は「ページか」ではなく「in-scope なクロール対象か」を表す。** `fetch-destination` が `isTarget = !isExternal` で設定するため、in-scope な **非HTMLリソース（PDF / zip / 画像）も `isTarget = 1`** になる。したがって「これはページか」は **content-type で判定する**（`isTarget` で判定してはいけない）。
 
-- **書き込み時に content-type を正規化**: `Database.#insertPage` が `normalizeContentType`（trim + 小文字化、空→null）を通して保存する。レスポンスは `header.split(';')[0]` で verbatim に記録されるため `Text/HTML` / `text/html ` が来うるが、正規化により **SQL の完全一致述語（`WHERE contentType = 'text/html'`）と コード側の `isHtmlContentType()`（trim+小文字）が一致**する。
+- **書き込み時に content-type を正規化**: `Database.#insertPage`（`pages`）と `Database.insertResource`（`resources`）が `normalizeContentType`（trim + 小文字化、空→null）を通して保存する。レスポンスは `header.split(';')[0]` で verbatim に記録されるため `Text/HTML` / `text/html ` が来うるが、正規化により **SQL の完全一致述語（`WHERE contentType = 'text/html'`）と コード側の `isHtmlContentType()`（trim+小文字）が一致**し、pages / resources 両テーブルの content-type 表現も揃う。
 - **読み出し時のページ性述語は 2 種類**:
   - **strict（`= 'text/html'`）**: 「描画済みHTMLページ」を数える/見る所。`getPages('page')`、`getScrapedHtmlPageCount`（resume カウンタ＝ライブの描画カウンタと一致させる）、`getSummary` の metadata 充足率の分母（非HTML/エラー行はメタを持てず率を希釈するため）。
   - **loose（`contentType IS NULL OR = 'text/html'`）**: ユーザー向けのページ一覧/件数。`listPages`、`getSummary` の total/internal/external/statusDistribution。**エラー/到達不能ページ（`contentType = null`・`scraped = 1`）を残す**ため（壊れたページは監査で見えるべき）。除外されるのは **既知の非HTMLリソースだけ**で、それらは Resources ビューに出る。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -713,6 +713,11 @@ metadata-only（title のみ）と非 HTML は `headCheckResult` を `updatePage
   - **loose（`contentType IS NULL OR = 'text/html'`）**: ユーザー向けのページ一覧/件数。`listPages`、`getSummary` の total/internal/external/statusDistribution。**エラー/到達不能ページ（`contentType = null`・`scraped = 1`）を残す**ため（壊れたページは監査で見えるべき）。除外されるのは **既知の非HTMLリソースだけ**で、それらは Resources ビューに出る。
 - **スナップショット**: `updatePage` は **`page.html.length > 0` のときだけ** HTML スナップショットを書く（非HTMLは `html=''` なので 0 バイトファイルを作らない）。URL が HTML→非HTML に差し替わった再スクレイプでは古い `pages.html` をクリア、劣化スクレイプ（text/html だが html 空）は据え置く。
 
+**既知の制約**（将来の保守者向け）:
+
+- **正規化は書き込み時のみ・backfill 無し**: 上記の正規化は新規 write にだけ適用される。本修正より前に作られたアーカイブの mixed-case content-type（`Text/HTML` 等）は残るため、完全一致述語が拾えないことがある。`#init` のマイグレーションは pages を backfill しない（v0.x、再クロールで解消）。
+- **非正規 casing のページは snapshot 無しになりうる**: `@d-zero/beholder`（外部）は描画判定を exact `contentType === 'text/html'` で行う。サーバが `Text/HTML` を返すと beholder は描画せず `html=''` を返す。`#insertPage` で content-type は `text/html` に正規化されるため**ページとして計上されるが本文（snapshot）は無い**という行になる。nitpicker 側では根治できず（beholder の判定を case-insensitive にする必要がある）、別途 beholder 側の課題。
+
 > **検索キーワード**: 「isTarget 意味」「ページ 非HTML 除外」「normalizeContentType」「listPages contentType」。
 > **更新責任**: ページ性の定義（strict/loose の使い分け）を変える場合、`list-pages.ts` / `get-summary.ts`（query）と `getScrapedHtmlPageCount` / `#insertPage`（crawler）を同時に見直し、各 spec の「PDF 除外 / エラーページ保持 / メタ分母」テストを更新する。content-type は exact 文字列で多数の SQL に inline されている（共有述語は未導入）ため、HTML 判定規則を変える際は全 inline 箇所を確認すること。
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -363,7 +363,7 @@ Crawling: 130(85) done / 250 found URLs (+12/20 ext) (56%) [108 remaining] [10 p
 **`--resume` / `--append` 時の挙動:**
 
 - `X`（internalDone）と `Z`（internalTotal）には `resumeOffset = #resumedScraped.length` が加算される
-- `Y`（pagesScraped）には `Archive.getScrapedHtmlPageCount()` の戻り値（`pages` テーブルの `isTarget=1 AND scraped=1` 件数）が初期値として加算される
+- `Y`（pagesScraped）には `Archive.getScrapedHtmlPageCount()` の戻り値（`pages` テーブルの `isTarget=1 AND scraped=1 AND contentType='text/html'` 件数）が初期値として加算される。`contentType='text/html'` で絞るのは、in-scope な非HTMLリソース（PDF 等は `isTarget=1`）を「描画済みHTMLページ」として数えないため（→「ページ性の判定」参照）
 - そのため通算値で表示され、resume 跨ぎでも `Y` と `X` の意味的整合が保たれる
 
 > **更新手順（フォーマット変更）**: 表示文字列を変える場合は `format-crawl-progress.ts` の return 文を編集し、`format-crawl-progress.spec.ts` の「完成形のフォーマット文字列を 1 文字ズレなく組み立てる」テスト（`expect(result).toBe(...)` のリテラル）を併せて更新する。`pagesScraped` のセマンティクスを変える場合（例: launch エラーを含める）は `crawler.ts:#scrapePage` の `markBrowserScrape()` 呼び出し位置と worker 側の `renderedInBrowser` 判定の両方を編集し、`should-discard-predicted.spec.ts` と新規 worker レベルテストの追加を検討する。
@@ -564,34 +564,34 @@ scrapeStart(url, page, options)
 
 ### pages テーブル
 
-| カラム                                                            | 型                    | 説明                            |
-| ----------------------------------------------------------------- | --------------------- | ------------------------------- |
-| id                                                                | INTEGER PK            | 自動採番                        |
-| url                                                               | VARCHAR(8190) UNIQUE  | URL 文字列                      |
-| redirectDestId                                                    | INTEGER FK → pages.id | リダイレクト先ページID          |
-| scraped                                                           | BOOLEAN               | スクレイプ済みか                |
-| isTarget                                                          | BOOLEAN               | ターゲットページか              |
-| isExternal                                                        | BOOLEAN               | 外部ページか                    |
-| status                                                            | INTEGER               | HTTP ステータスコード           |
-| statusText                                                        | TEXT                  |                                 |
-| contentType                                                       | TEXT                  |                                 |
-| contentLength                                                     | INTEGER               |                                 |
-| responseHeaders                                                   | TEXT (JSON)           |                                 |
-| lang                                                              | TEXT                  | `<html lang>`                   |
-| title                                                             | TEXT                  | `<title>`                       |
-| description                                                       | TEXT                  | meta description                |
-| keywords                                                          | TEXT                  | meta keywords                   |
-| noindex                                                           | BOOLEAN               | robots noindex                  |
-| nofollow                                                          | BOOLEAN               | robots nofollow                 |
-| noarchive                                                         | BOOLEAN               | robots noarchive                |
-| canonical                                                         | TEXT                  | link canonical                  |
-| alternate                                                         | TEXT                  | link alternate                  |
-| og_type, og_title, og_site_name, og_description, og_url, og_image | TEXT                  | Open Graph                      |
-| twitter_card                                                      | TEXT                  | Twitter Card                    |
-| html                                                              | TEXT                  | HTML スナップショットの相対パス |
-| isSkipped                                                         | BOOLEAN               | スキップされたか                |
-| skipReason                                                        | TEXT                  | スキップ理由                    |
-| order                                                             | INTEGER               | Natural URL Sort 順序           |
+| カラム                                                            | 型                    | 説明                                                                             |
+| ----------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------- |
+| id                                                                | INTEGER PK            | 自動採番                                                                         |
+| url                                                               | VARCHAR(8190) UNIQUE  | URL 文字列                                                                       |
+| redirectDestId                                                    | INTEGER FK → pages.id | リダイレクト先ページID                                                           |
+| scraped                                                           | BOOLEAN               | スクレイプ済みか                                                                 |
+| isTarget                                                          | BOOLEAN               | in-scope なクロール対象か（≠ ページ性。非HTMLリソースも 1。→「ページ性の判定」） |
+| isExternal                                                        | BOOLEAN               | 外部ページか                                                                     |
+| status                                                            | INTEGER               | HTTP ステータスコード                                                            |
+| statusText                                                        | TEXT                  |                                                                                  |
+| contentType                                                       | TEXT                  | 正規化（trim+小文字）して保存                                                    |
+| contentLength                                                     | INTEGER               |                                                                                  |
+| responseHeaders                                                   | TEXT (JSON)           |                                                                                  |
+| lang                                                              | TEXT                  | `<html lang>`                                                                    |
+| title                                                             | TEXT                  | `<title>`                                                                        |
+| description                                                       | TEXT                  | meta description                                                                 |
+| keywords                                                          | TEXT                  | meta keywords                                                                    |
+| noindex                                                           | BOOLEAN               | robots noindex                                                                   |
+| nofollow                                                          | BOOLEAN               | robots nofollow                                                                  |
+| noarchive                                                         | BOOLEAN               | robots noarchive                                                                 |
+| canonical                                                         | TEXT                  | link canonical                                                                   |
+| alternate                                                         | TEXT                  | link alternate                                                                   |
+| og_type, og_title, og_site_name, og_description, og_url, og_image | TEXT                  | Open Graph                                                                       |
+| twitter_card                                                      | TEXT                  | Twitter Card                                                                     |
+| html                                                              | TEXT                  | HTML スナップショットの相対パス                                                  |
+| isSkipped                                                         | BOOLEAN               | スキップされたか                                                                 |
+| skipReason                                                        | TEXT                  | スキップ理由                                                                     |
+| order                                                             | INTEGER               | Natural URL Sort 順序                                                            |
 
 ### anchors テーブル
 
@@ -702,6 +702,19 @@ metadata-only（title のみ）と非 HTML は `headCheckResult` を `updatePage
 | `'internal-no-page'`        | (contentType IS NULL OR != 'text/html') AND isExternal=0 |
 | `'external-no-page'`        | (contentType IS NULL OR != 'text/html') AND isExternal=1 |
 | なし                        | 全件                                                     |
+
+### ページ性の判定（content-type vs isTarget）（#72）
+
+**`isTarget` は「ページか」ではなく「in-scope なクロール対象か」を表す。** `fetch-destination` が `isTarget = !isExternal` で設定するため、in-scope な **非HTMLリソース（PDF / zip / 画像）も `isTarget = 1`** になる。したがって「これはページか」は **content-type で判定する**（`isTarget` で判定してはいけない）。
+
+- **書き込み時に content-type を正規化**: `Database.#insertPage` が `normalizeContentType`（trim + 小文字化、空→null）を通して保存する。レスポンスは `header.split(';')[0]` で verbatim に記録されるため `Text/HTML` / `text/html ` が来うるが、正規化により **SQL の完全一致述語（`WHERE contentType = 'text/html'`）と コード側の `isHtmlContentType()`（trim+小文字）が一致**する。
+- **読み出し時のページ性述語は 2 種類**:
+  - **strict（`= 'text/html'`）**: 「描画済みHTMLページ」を数える/見る所。`getPages('page')`、`getScrapedHtmlPageCount`（resume カウンタ＝ライブの描画カウンタと一致させる）、`getSummary` の metadata 充足率の分母（非HTML/エラー行はメタを持てず率を希釈するため）。
+  - **loose（`contentType IS NULL OR = 'text/html'`）**: ユーザー向けのページ一覧/件数。`listPages`、`getSummary` の total/internal/external/statusDistribution。**エラー/到達不能ページ（`contentType = null`・`scraped = 1`）を残す**ため（壊れたページは監査で見えるべき）。除外されるのは **既知の非HTMLリソースだけ**で、それらは Resources ビューに出る。
+- **スナップショット**: `updatePage` は **`page.html.length > 0` のときだけ** HTML スナップショットを書く（非HTMLは `html=''` なので 0 バイトファイルを作らない）。URL が HTML→非HTML に差し替わった再スクレイプでは古い `pages.html` をクリア、劣化スクレイプ（text/html だが html 空）は据え置く。
+
+> **検索キーワード**: 「isTarget 意味」「ページ 非HTML 除外」「normalizeContentType」「listPages contentType」。
+> **更新責任**: ページ性の定義（strict/loose の使い分け）を変える場合、`list-pages.ts` / `get-summary.ts`（query）と `getScrapedHtmlPageCount` / `#insertPage`（crawler）を同時に見直し、各 spec の「PDF 除外 / エラーページ保持 / メタ分母」テストを更新する。content-type は exact 文字列で多数の SQL に inline されている（共有述語は未導入）ため、HTML 判定規則を変える際は全 inline 箇所を確認すること。
 
 ---
 

--- a/packages/@nitpicker/crawler/src/archive/archive.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.spec.ts
@@ -190,6 +190,43 @@ describe('setPage', () => {
 			await remove(filePath).catch(() => {});
 		}
 	});
+
+	it('非HTML（PDF）の setPage は 0 バイトのスナップショットファイルを作らない（#72）', async () => {
+		// 結合境界: html パスの付与は updatePage、ファイル書き込みは setPage。PDF は
+		// internal で isTarget=true だが html が空なので、スナップショットファイルを
+		// 一切作ってはならない（実体 0 バイトのファイル量産バグ #72）。
+		const filePath = path.resolve(workingDir, 'setpage-pdf-test.nitpicker');
+		const archive = await Archive.create({ filePath, cwd: workingDir });
+		const pageData = {
+			url: parseUrl('http://localhost/document.pdf')!,
+			redirectPaths: [] as string[],
+			isExternal: false,
+			status: 200,
+			statusText: 'OK',
+			contentLength: 1024,
+			contentType: 'application/pdf',
+			responseHeaders: {},
+			meta: { title: '' },
+			anchorList: [] as never[],
+			imageList: [] as never[],
+			html: '',
+			isSkipped: false,
+			isTarget: true,
+		};
+
+		try {
+			const pageId = await archive.setPage(pageData);
+			const snapshotPath = path.resolve(
+				archive.tmpDir,
+				Archive.SNAPSHOT_HTML_DIR,
+				`${pageId}.html`,
+			);
+			expect(existsSync(snapshotPath)).toBe(false);
+		} finally {
+			await archive.close();
+			await remove(filePath).catch(() => {});
+		}
+	});
 });
 
 describe('write: スナップショットzipキャッシュの無効化', () => {

--- a/packages/@nitpicker/crawler/src/archive/database.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.spec.ts
@@ -385,6 +385,50 @@ describe('snapshot 付与: 非HTML / 空html にスナップショットを作�
 	});
 });
 
+describe('content-type の正規化（#72）', () => {
+	it('contentType は小文字化・trim して保存され、ページとして分類される', async () => {
+		const dbPath = path.resolve(workingDir, 'content-type-normalize.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/cased';
+		try {
+			// サーバが `Content-Type: Text/HTML ` のような非正規形を返しても、保存時に
+			// 正規化されるので、完全一致の page フィルタ（contentType='text/html'）が拾える。
+			await db.updatePage(
+				{
+					url: parseUrl(url)!,
+					redirectPaths: [],
+					isExternal: false,
+					status: 200,
+					statusText: 'OK',
+					contentLength: 100,
+					contentType: 'Text/HTML ',
+					responseHeaders: {},
+					meta: { title: 'Cased' },
+					anchorList: [],
+					imageList: [],
+					html: '<html></html>',
+					isSkipped: false,
+				},
+				workingDir,
+				true,
+			);
+
+			const [row] = await db
+				.getKnex()
+				.from('pages')
+				.select('contentType')
+				.where('url', url);
+			expect(row.contentType).toBe('text/html');
+
+			const pages = await db.getPages('page');
+			expect(pages.some((p) => p.url === url)).toBe(true);
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+});
+
 describe('re-scrape: 同一ページの再 updatePage', () => {
 	const rescrapeDbPath = path.resolve(workingDir, 'rescrape-dup.sqlite');
 

--- a/packages/@nitpicker/crawler/src/archive/database.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.spec.ts
@@ -1958,4 +1958,32 @@ describe('getResourceByUrl', () => {
 
 		await db.destroy();
 	});
+
+	it('resources の content-type も正規化して保存される（pages と揃える）', async () => {
+		const dbPath2 = path.resolve(workingDir, 'resource-normalize-test.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath2 });
+		try {
+			await db.insertResource({
+				url: parseUrl('https://example.com/asset.PNG')!,
+				isExternal: false,
+				isError: false,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'IMAGE/PNG ',
+				contentLength: 100,
+				compress: false,
+				cdn: false,
+				headers: {},
+			});
+			const [row] = await db
+				.getKnex()
+				.from('resources')
+				.select('contentType')
+				.where('url', 'https://example.com/asset.PNG');
+			expect(row.contentType).toBe('image/png');
+		} finally {
+			await db.destroy();
+			await remove(dbPath2);
+		}
+	});
 });

--- a/packages/@nitpicker/crawler/src/archive/database.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.spec.ts
@@ -32,7 +32,7 @@ describe('Pages', () => {
 				status: 200,
 				statusText: 'OK',
 				contentLength: 1000,
-				contentType: 'html/text',
+				contentType: 'text/html',
 				responseHeaders: {},
 				meta: {
 					title: 'LOCAL_SERVER',
@@ -177,7 +177,7 @@ describe('Pages', () => {
 		expect(count).toEqual(14);
 	});
 
-	it('getScrapedHtmlPageCount は isTarget=1 かつ scraped=1 のページのみカウントする', async () => {
+	it('getScrapedHtmlPageCount は isTarget=1 かつ scraped=1 かつ text/html のページのみカウントする', async () => {
 		const dbPath = path.resolve(workingDir, 'html-count-test.sqlite');
 		const db = await Database.connect({
 			workingDir,
@@ -237,11 +237,149 @@ describe('Pages', () => {
 				.getKnex()
 				.from('pages')
 				.insert({ url: 'http://localhost/pending-asset', scraped: 0, isTarget: 0 });
+			// scraped=1, isTarget=1, だが非HTML（HEAD で捕まえた in-scope な PDF は
+			// isTarget=1 のまま）。isTarget は in-scope の意味なので、ページ数は
+			// content-type で保証する。content-type ガードが無いと 2 になる。
+			await db.getKnex().from('pages').insert({
+				url: 'http://localhost/doc.pdf',
+				scraped: 1,
+				isTarget: 1,
+				contentType: 'application/pdf',
+			});
 
 			const count = await db.getScrapedHtmlPageCount();
 
 			expect(count).toBe(1);
 		} finally {
+			await remove(dbPath);
+		}
+	});
+});
+
+describe('snapshot 付与: 非HTML / 空html にスナップショットを作らない（#72）', () => {
+	/**
+	 * Builds page data for the snapshot-gating tests.
+	 * @param url - The page URL.
+	 * @param contentType - The response content type.
+	 * @param html - The rendered HTML string (empty for non-HTML / degraded scrapes).
+	 * @returns Page data accepted by `Database.updatePage`.
+	 */
+	const makePage = (url: string, contentType: string, html: string) => ({
+		url: parseUrl(url)!,
+		redirectPaths: [] as string[],
+		isExternal: false,
+		status: 200,
+		statusText: 'OK',
+		contentLength: 100,
+		contentType,
+		responseHeaders: {},
+		meta: { title: '' },
+		anchorList: [],
+		imageList: [],
+		html,
+		isSkipped: false,
+	});
+
+	it('非HTML（application/pdf, html 空）は isTarget でも pages.html が null', async () => {
+		const dbPath = path.resolve(workingDir, 'snapshot-pdf.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/doc.pdf';
+		try {
+			// PDF は internal なので isTarget=true だが、本文 HTML が無いので
+			// スナップショットを作ってはならない（0 バイトファイル量産バグ #72）。
+			await db.updatePage(makePage(url, 'application/pdf', ''), workingDir, true);
+			const [page] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(page.html).toBeNull();
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('HTML（text/html, html 非空）は pages.html にスナップショットパスが設定される', async () => {
+		const dbPath = path.resolve(workingDir, 'snapshot-html.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/page';
+		try {
+			await db.updatePage(makePage(url, 'text/html', '<html></html>'), workingDir, true);
+			const [page] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(page.html).not.toBeNull();
+			expect(page.html).toContain('.html');
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('劣化スクレイプ（text/html だが html 空）は pages.html が null', async () => {
+		const dbPath = path.resolve(workingDir, 'snapshot-degraded.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/degraded';
+		try {
+			await db.updatePage(makePage(url, 'text/html', ''), workingDir, true);
+			const [page] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(page.html).toBeNull();
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('snapshot は isTarget ではなく html の有無で決まる（isTarget=false でも html があれば付与）', async () => {
+		// #72 のゲートは isTarget を条件から外し、html 本文の有無だけで判定する。
+		// 実運用では html 非空のページは必ず isTarget=true だが、この不変条件は
+		// crawler 側に分散しているため、ここで「ゲートが isTarget に依存しない」ことを
+		// 明示的に固定する（誰かが isTarget を条件に戻したらこのテストが落ちる）。
+		const dbPath = path.resolve(workingDir, 'snapshot-non-target.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/non-target-html';
+		try {
+			await db.updatePage(makePage(url, 'text/html', '<html></html>'), workingDir, false);
+			const [page] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(page.html).not.toBeNull();
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('HTML→非HTML へ再スクレイプされたら古い pages.html（stale パス）をクリアする', async () => {
+		const dbPath = path.resolve(workingDir, 'snapshot-flip.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/flips';
+		try {
+			// 1) 最初は HTML としてスクレイプ → スナップショットパスが付く。
+			await db.updatePage(makePage(url, 'text/html', '<html></html>'), workingDir, true);
+			const [before] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(before.html).not.toBeNull();
+
+			// 2) 同 URL が PDF に差し替わって再スクレイプ（html 空・content-type 非HTML）。
+			// pages.html が古い HTML パスのまま残ると contentType と矛盾するのでクリアする。
+			await db.updatePage(makePage(url, 'application/pdf', ''), workingDir, true);
+			const [after] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(after.html).toBeNull();
+		} finally {
+			await db.destroy();
+			await remove(dbPath);
+		}
+	});
+
+	it('HTML→劣化（text/html だが html 空）の再スクレイプでは直前のスナップショットを保持する', async () => {
+		const dbPath = path.resolve(workingDir, 'snapshot-degraded-keep.sqlite');
+		const db = await Database.connect({ workingDir, filename: dbPath });
+		const url = 'http://localhost/degrades';
+		try {
+			await db.updatePage(makePage(url, 'text/html', '<html></html>'), workingDir, true);
+			const [before] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(before.html).not.toBeNull();
+
+			// 劣化スクレイプ（content-type は text/html のまま、html だけ空）は
+			// 一時的な失敗と区別できないため、直前の良いスナップショットを据え置く。
+			await db.updatePage(makePage(url, 'text/html', ''), workingDir, true);
+			const [after] = await db.getKnex().from('pages').select('html').where('url', url);
+			expect(after.html).toBe(before.html);
+		} finally {
+			await db.destroy();
 			await remove(dbPath);
 		}
 	});

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -24,6 +24,7 @@ import { TypedAwaitEventEmitter as EventEmitter } from '@d-zero/shared/typed-awa
 import knex from 'knex';
 
 import { findScopeEntry } from '../crawler/find-scope-entry.js';
+import { isHtmlContentType } from '../crawler/is-html-content-type.js';
 import { eachSplitted } from '../utils/array/each-splitted.js';
 import { ErrorEmitter } from '../utils/error/error-emitter.js';
 
@@ -574,7 +575,14 @@ export class Database extends EventEmitter<DatabaseEvent> {
 	 * Used by the crawler to seed its `pagesScraped` counter on resume so the
 	 * progress display reflects all browser-rendered HTML pages across sessions,
 	 * not just the current one.
-	 * @returns The number of rows in `pages` with `isTarget = 1` and `scraped = 1`.
+	 *
+	 * "HTML page" is guaranteed by `contentType = 'text/html'`, NOT by `isTarget`
+	 * alone: `isTarget` means "in-scope crawl target" and is set for in-scope
+	 * non-HTML resources too (e.g. a PDF reached via the HEAD pre-flight is
+	 * `isTarget = 1`). Counting those would over-report the HTML page total, so
+	 * page-ness is asserted at the read layer here rather than by trusting
+	 * `isTarget`.
+	 * @returns The number of `text/html` rows with `isTarget = 1` and `scraped = 1`.
 	 */
 	@ErrorEmitter()
 	@retry(retrySetting)
@@ -583,6 +591,7 @@ export class Database extends EventEmitter<DatabaseEvent> {
 			.from<DB_Page>('pages')
 			.where('isTarget', 1)
 			.andWhere('scraped', 1)
+			.andWhere('contentType', 'text/html')
 			.count<{ count: number }[]>('* as count');
 		return row ? Number(row.count) : 0;
 	}
@@ -967,8 +976,37 @@ export class Database extends EventEmitter<DatabaseEvent> {
 				page.isExternal,
 			);
 			let snapshot: { html?: string; pageId: number } = { pageId };
-			if (isTarget && snapshotDir) {
+			// Only write an HTML snapshot when there is actual HTML to write.
+			// `page.html.length > 0` is the precise signal: the scraper returns
+			// `html: ''` for everything that is not a rendered `text/html` document
+			// (non-HTML responses, metadata-only, external, degraded renders), so a
+			// non-empty `html` is exactly "a rendered HTML body exists". Gating on
+			// `isTarget` alone wrote a 0-byte snapshot (and set `pages.html`) for
+			// every internal non-HTML resource — PDF / zip / images are isTarget=1 —
+			// flooding the archive with empty files pointing at meaningless paths (#72).
+			//
+			// `isTarget` is intentionally NOT part of this condition: it is implied by
+			// `html.length > 0` (only in-scope target pages are browser-rendered into a
+			// non-empty body; metadata-only and external pages carry `html: ''`), so the
+			// content check alone expresses the intent without a redundant term.
+			if (snapshotDir && page.html.length > 0) {
 				snapshot = await this.#updateSnapshotPath(pageId, snapshotDir, trx);
+			} else if (
+				snapshotDir &&
+				page.contentType !== null &&
+				!isHtmlContentType(page.contentType)
+			) {
+				// The page is now a *known* non-HTML type. If a previous scrape stored
+				// an HTML snapshot for this URL (e.g. it served HTML then was replaced
+				// by a PDF across `crawl --resume` / `--append`), clear the stale path
+				// so `pages.html` never contradicts `contentType`. A degraded HTML
+				// re-scrape (text/html or unknown content type with empty html) is NOT
+				// cleared — the last good snapshot is preserved, mirroring the
+				// anchors / images empty-guard below. Gated on `snapshotDir` because a
+				// stale path can only have been written by a snapshot-capable call
+				// (`setPage`); `setExternalPage` passes `snapshotDir = null` and never
+				// sets `html`, so it has nothing to clear.
+				await trx<DB_Page>('pages').where('id', pageId).update({ html: null });
 			}
 			// Re-scrape semantics: the same URL can be scraped more than once
 			// (e.g. `crawl --resume`, re-visits, `--append` re-promotion). The

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -25,6 +25,7 @@ import knex from 'knex';
 
 import { findScopeEntry } from '../crawler/find-scope-entry.js';
 import { isHtmlContentType } from '../crawler/is-html-content-type.js';
+import { normalizeContentType } from '../crawler/normalize-content-type.js';
 import { eachSplitted } from '../utils/array/each-splitted.js';
 import { ErrorEmitter } from '../utils/error/error-emitter.js';
 
@@ -1136,7 +1137,12 @@ export class Database extends EventEmitter<DatabaseEvent> {
 				isExternal: page.isExternal,
 				status: page.status,
 				statusText: page.statusText,
-				contentType: page.contentType,
+				// Canonicalize so the stored value matches the exact-string page-ness
+				// predicate (`WHERE contentType = 'text/html'`) used by the read layer
+				// and the case-insensitive `isHtmlContentType` used in code. Responses
+				// are recorded verbatim upstream, so `Text/HTML` / `text/html ` can
+				// otherwise be stored and silently misclassified.
+				contentType: normalizeContentType(page.contentType),
 				contentLength: page.contentLength,
 				responseHeaders: JSON.stringify(page.responseHeaders),
 				lang: page.meta.lang,

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -639,7 +639,9 @@ export class Database extends EventEmitter<DatabaseEvent> {
 				isExternal: resource.isExternal ? 1 : 0,
 				status: resource.status,
 				statusText: resource.statusText,
-				contentType: resource.contentType,
+				// Canonicalize like `pages.contentType` (see #insertPage) so resource
+				// content-type filters / dedupe keys are case- and whitespace-stable.
+				contentType: normalizeContentType(resource.contentType),
 				contentLength: resource.contentLength,
 				compress: resource.compress || 0,
 				cdn: resource.cdn || 0,

--- a/packages/@nitpicker/crawler/src/crawler/normalize-content-type.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/normalize-content-type.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeContentType } from './normalize-content-type.js';
+
+describe('normalizeContentType', () => {
+	it('null はそのまま null', () => {
+		expect(normalizeContentType(null)).toBeNull();
+	});
+
+	it('既に正規形ならそのまま返す', () => {
+		expect(normalizeContentType('text/html')).toBe('text/html');
+		expect(normalizeContentType('application/pdf')).toBe('application/pdf');
+	});
+
+	it('大文字は小文字化する', () => {
+		expect(normalizeContentType('Text/HTML')).toBe('text/html');
+		expect(normalizeContentType('APPLICATION/PDF')).toBe('application/pdf');
+	});
+
+	it('前後の空白を除去する', () => {
+		expect(normalizeContentType('text/html ')).toBe('text/html');
+		expect(normalizeContentType('  text/html')).toBe('text/html');
+	});
+
+	it('空白のみ・空文字は null にする', () => {
+		expect(normalizeContentType('   ')).toBeNull();
+		expect(normalizeContentType('')).toBeNull();
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/normalize-content-type.ts
+++ b/packages/@nitpicker/crawler/src/crawler/normalize-content-type.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonicalizes a Content-Type media type for storage.
+ *
+ * MIME types are case-insensitive (RFC 2045) and may arrive with surrounding
+ * whitespace (e.g. `text/html ` left after stripping the `; charset=...`
+ * parameter). Responses are recorded verbatim (`header.split(';')[0]`) without
+ * normalization, so `Text/HTML` or `text/html ` can otherwise reach the
+ * database. Storing the canonical (trimmed, lower-cased) form lets the exact
+ * SQL page-ness predicate (`WHERE contentType = 'text/html'`) agree with the
+ * code-level {@link isHtmlContentType} check, which trims and lower-cases.
+ * @param contentType - The raw media type, or `null` when unknown.
+ * @returns The trimmed, lower-cased media type, or `null` when unknown/blank.
+ */
+export function normalizeContentType(contentType: string | null): string | null {
+	if (contentType === null) {
+		return null;
+	}
+	const normalized = contentType.trim().toLowerCase();
+	return normalized === '' ? null : normalized;
+}

--- a/packages/@nitpicker/query/src/get-summary.spec.ts
+++ b/packages/@nitpicker/query/src/get-summary.spec.ts
@@ -145,6 +145,79 @@ describe('getSummary', () => {
 			imageList: [],
 			isSkipped: false,
 		});
+
+		// In-scope non-HTML resource (PDF): isTarget=1 but NOT a page. It must not
+		// inflate totalPages/internalPages and must not dilute the metadata rates.
+		await archive.setPage({
+			url: parseUrl('https://example.com/doc.pdf')!,
+			redirectPaths: [],
+			isExternal: false,
+			isTarget: true,
+			status: 200,
+			statusText: 'OK',
+			contentType: 'application/pdf',
+			contentLength: 2048,
+			responseHeaders: {},
+			html: '',
+			meta: {
+				lang: null,
+				title: null,
+				description: null,
+				keywords: null,
+				noindex: false,
+				nofollow: false,
+				noarchive: false,
+				canonical: null,
+				alternate: null,
+				'og:type': null,
+				'og:title': null,
+				'og:site_name': null,
+				'og:description': null,
+				'og:url': null,
+				'og:image': null,
+				'twitter:card': null,
+			},
+			anchorList: [],
+			imageList: [],
+			isSkipped: false,
+		});
+
+		// Errored / unreachable internal page: scraped=1 but contentType=null. It IS
+		// a page (counted, and its status shows in the histogram) but it can never
+		// carry metadata, so it must NOT be in the metadata-fulfillment denominator.
+		await archive.setPage({
+			url: parseUrl('https://example.com/broken')!,
+			redirectPaths: [],
+			isExternal: false,
+			isTarget: true,
+			status: -1,
+			statusText: 'ERR_NAME_NOT_RESOLVED',
+			contentType: null,
+			contentLength: null,
+			responseHeaders: {},
+			html: '',
+			meta: {
+				lang: null,
+				title: null,
+				description: null,
+				keywords: null,
+				noindex: false,
+				nofollow: false,
+				noarchive: false,
+				canonical: null,
+				alternate: null,
+				'og:type': null,
+				'og:title': null,
+				'og:site_name': null,
+				'og:description': null,
+				'og:url': null,
+				'og:image': null,
+				'twitter:card': null,
+			},
+			anchorList: [],
+			imageList: [],
+			isSkipped: false,
+		});
 	});
 
 	afterAll(async () => {
@@ -160,12 +233,104 @@ describe('getSummary', () => {
 
 		expect(result.baseUrl).toBe('https://example.com');
 		expect(result.roots).toEqual(['https://example.com', 'https://example.com/blog/']);
-		expect(result.totalPages).toBe(3);
-		expect(result.internalPages).toBe(3);
+		// 3 HTML pages + 1 errored page (contentType null) — the in-scope PDF
+		// (application/pdf) is the only thing excluded.
+		expect(result.totalPages).toBe(4);
+		expect(result.internalPages).toBe(4);
 		expect(result.externalPages).toBe(0);
+		// The errored page's status IS in the histogram (broken-link audit needs it).
+		expect(result.statusDistribution).toContainEqual({ status: -1, count: 1 });
+		// The PDF's 200 must not be counted here (would make 200 count 3).
 		expect(result.statusDistribution).toContainEqual({ status: 200, count: 2 });
 		expect(result.statusDistribution).toContainEqual({ status: 404, count: 1 });
+		// Metadata denominator stays 3 (HTML pages only): neither the PDF nor the
+		// errored page dilutes it (otherwise title would be 2/4 or 2/5).
 		expect(result.metadataFulfillment.title).toBeCloseTo(2 / 3);
 		expect(result.metadataFulfillment.description).toBeCloseTo(1 / 3);
+	});
+});
+
+describe('getSummary: HTMLページが1つも無い（全てエラー/到達不能）アーカイブ', () => {
+	let archive: InstanceType<typeof Archive>;
+	const dir = path.resolve(__dirname, '__test_fixtures_summary_no_html__');
+	const archiveFilePath = path.resolve(dir, 'summary-no-html.nitpicker');
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(dir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: dir });
+		await archive.setConfig({
+			baseUrl: 'https://example.com',
+			roots: ['https://example.com'],
+			name: 'test',
+			version: '0.4.4',
+			recursive: true,
+			interval: 0,
+			image: true,
+			fetchExternal: false,
+			parallels: 1,
+			excludes: [],
+			excludeKeywords: [],
+			excludeUrls: [],
+			maxExcludedDepth: 0,
+			retry: 3,
+			fromList: false,
+			disableQueries: false,
+			userAgent: 'test',
+			ignoreRobots: false,
+		});
+		// Only an errored/unreachable internal page — zero text/html rows.
+		await archive.setPage({
+			url: parseUrl('https://example.com/broken')!,
+			redirectPaths: [],
+			isExternal: false,
+			isTarget: true,
+			status: -1,
+			statusText: 'ERR_NAME_NOT_RESOLVED',
+			contentType: null,
+			contentLength: null,
+			responseHeaders: {},
+			html: '',
+			meta: {
+				lang: null,
+				title: null,
+				description: null,
+				keywords: null,
+				noindex: false,
+				nofollow: false,
+				noarchive: false,
+				canonical: null,
+				alternate: null,
+				'og:type': null,
+				'og:title': null,
+				'og:site_name': null,
+				'og:description': null,
+				'og:url': null,
+				'og:image': null,
+				'twitter:card': null,
+			},
+			anchorList: [],
+			imageList: [],
+			isSkipped: false,
+		});
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.close();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('メタ充足率の分母が 0 でも NaN にならず 0 を返す', async () => {
+		const result = await getSummary(archive);
+		// The errored page is still counted as a page...
+		expect(result.totalPages).toBe(1);
+		// ...but with zero text/html rows the metadata denominator is 0; the guard
+		// must yield 0, not NaN (0/0). Removing the `metaTotal > 0` guard makes these NaN.
+		expect(result.metadataFulfillment.title).toBe(0);
+		expect(result.metadataFulfillment.description).toBe(0);
+		expect(result.metadataFulfillment.ogImage).toBe(0);
 	});
 });

--- a/packages/@nitpicker/query/src/get-summary.ts
+++ b/packages/@nitpicker/query/src/get-summary.ts
@@ -15,26 +15,46 @@ export async function getSummary(accessor: ArchiveAccessor): Promise<SummaryResu
 	const baseUrl = config.baseUrl;
 	const roots = config.roots;
 
+	// This is the PAGES summary. A "page" is an HTML page OR a not-yet-classified
+	// row (errored / unreachable, `contentType` null) so broken pages stay counted
+	// and their statuses stay in the histogram (the broken-link audit needs them);
+	// only KNOWN non-HTML resources (PDF / zip / image) are excluded — they have
+	// their own views. `isTarget` is NOT used (an in-scope PDF is `isTarget = 1`).
+	// The metadata-fulfillment rates further below use a STRICT `text/html`
+	// denominator, since only rendered HTML pages can carry title / description /
+	// OGP — counting errored rows there would dilute the rates.
 	const totalResult = (await knex('pages')
 		.count('id as total')
 		.where('scraped', 1)
-		.whereNull('redirectDestId')) as { total: number }[];
+		.whereNull('redirectDestId')
+		.where((qb) => {
+			qb.whereNull('contentType').orWhere('contentType', 'text/html');
+		})) as { total: number }[];
 
 	const internalResult = (await knex('pages')
 		.count('id as internalCount')
 		.where({ scraped: 1, isExternal: 0 })
-		.whereNull('redirectDestId')) as { internalCount: number }[];
+		.whereNull('redirectDestId')
+		.where((qb) => {
+			qb.whereNull('contentType').orWhere('contentType', 'text/html');
+		})) as { internalCount: number }[];
 
 	const externalResult = (await knex('pages')
 		.count('id as externalCount')
 		.where({ scraped: 1, isExternal: 1 })
-		.whereNull('redirectDestId')) as { externalCount: number }[];
+		.whereNull('redirectDestId')
+		.where((qb) => {
+			qb.whereNull('contentType').orWhere('contentType', 'text/html');
+		})) as { externalCount: number }[];
 
 	const statusRows = (await knex('pages')
 		.select('status')
 		.count('id as count')
 		.where('scraped', 1)
 		.whereNull('redirectDestId')
+		.where((qb) => {
+			qb.whereNull('contentType').orWhere('contentType', 'text/html');
+		})
 		.groupBy('status')
 		.orderBy('status')) as { status: number | null; count: number }[];
 
@@ -56,39 +76,46 @@ export async function getSummary(accessor: ArchiveAccessor): Promise<SummaryResu
 		ogImage: 0,
 	};
 
-	if (internalNum > 0) {
-		const metaRows = (await knex('pages')
-			.select(
-				knex.raw(
-					"COUNT(CASE WHEN title IS NOT NULL AND title != '' THEN 1 END) as hasTitle",
-				),
-				knex.raw(
-					"COUNT(CASE WHEN description IS NOT NULL AND description != '' THEN 1 END) as hasDescription",
-				),
-				knex.raw(
-					"COUNT(CASE WHEN keywords IS NOT NULL AND keywords != '' THEN 1 END) as hasKeywords",
-				),
-				knex.raw(
-					"COUNT(CASE WHEN og_title IS NOT NULL AND og_title != '' THEN 1 END) as hasOgTitle",
-				),
-				knex.raw(
-					"COUNT(CASE WHEN og_description IS NOT NULL AND og_description != '' THEN 1 END) as hasOgDescription",
-				),
-				knex.raw(
-					"COUNT(CASE WHEN og_image IS NOT NULL AND og_image != '' THEN 1 END) as hasOgImage",
-				),
-			)
-			.where({ scraped: 1, isExternal: 0 })
-			.whereNull('redirectDestId')) as Record<string, number>[];
+	// Metadata fulfillment is over STRICT internal HTML pages only. The denominator
+	// (`metaTotal`) is computed by the SAME query as the numerators — NOT reused
+	// from `internalNum` (which now includes errored/unreachable rows that can
+	// never carry metadata and would dilute every rate).
+	const metaRows = (await knex('pages')
+		.select(
+			knex.raw('COUNT(*) as total'),
+			knex.raw(
+				"COUNT(CASE WHEN title IS NOT NULL AND title != '' THEN 1 END) as hasTitle",
+			),
+			knex.raw(
+				"COUNT(CASE WHEN description IS NOT NULL AND description != '' THEN 1 END) as hasDescription",
+			),
+			knex.raw(
+				"COUNT(CASE WHEN keywords IS NOT NULL AND keywords != '' THEN 1 END) as hasKeywords",
+			),
+			knex.raw(
+				"COUNT(CASE WHEN og_title IS NOT NULL AND og_title != '' THEN 1 END) as hasOgTitle",
+			),
+			knex.raw(
+				"COUNT(CASE WHEN og_description IS NOT NULL AND og_description != '' THEN 1 END) as hasOgDescription",
+			),
+			knex.raw(
+				"COUNT(CASE WHEN og_image IS NOT NULL AND og_image != '' THEN 1 END) as hasOgImage",
+			),
+		)
+		.where({ scraped: 1, isExternal: 0, contentType: 'text/html' })
+		.whereNull('redirectDestId')) as Record<string, number>[];
 
-		const meta = metaRows[0] ?? ({} as Record<string, number>);
+	const meta = metaRows[0] ?? ({} as Record<string, number>);
+	const metaTotal = Number(meta.total ?? 0);
+
+	if (metaTotal > 0) {
 		metadataFulfillment = {
-			title: Number(meta.hasTitle) / internalNum,
-			description: Number(meta.hasDescription) / internalNum,
-			keywords: Number(meta.hasKeywords) / internalNum,
-			ogTitle: Number(meta.hasOgTitle) / internalNum,
-			ogDescription: Number(meta.hasOgDescription) / internalNum,
-			ogImage: Number(meta.hasOgImage) / internalNum,
+			title: Number(meta.hasTitle) / metaTotal,
+			description: Number(meta.hasDescription) / metaTotal,
+			keywords: Number(meta.hasKeywords) / metaTotal,
+			ogTitle: Number(meta.hasOgTitle) / metaTotal,
+			ogDescription: Number(meta.hasOgDescription) / metaTotal,
+			ogImage: Number(meta.hasOgImage) / metaTotal,
 		};
 	}
 

--- a/packages/@nitpicker/query/src/list-pages.spec.ts
+++ b/packages/@nitpicker/query/src/list-pages.spec.ts
@@ -100,6 +100,42 @@ describe('listPages', () => {
 				isSkipped: false,
 			});
 		}
+
+		// An in-scope non-HTML resource (PDF): isTarget=1 but NOT a page. It must
+		// not appear in the page list (page-ness is content-type, not isTarget).
+		await archive.setPage({
+			url: parseUrl('https://example.com/doc.pdf')!,
+			redirectPaths: [],
+			isExternal: false,
+			isTarget: true,
+			status: 200,
+			statusText: 'OK',
+			contentType: 'application/pdf',
+			contentLength: 1024,
+			responseHeaders: {},
+			html: '',
+			meta: {
+				lang: null,
+				title: null,
+				description: null,
+				keywords: null,
+				noindex: false,
+				nofollow: false,
+				noarchive: false,
+				canonical: null,
+				alternate: null,
+				'og:type': null,
+				'og:title': null,
+				'og:site_name': null,
+				'og:description': null,
+				'og:url': null,
+				'og:image': null,
+				'twitter:card': null,
+			},
+			anchorList: [],
+			imageList: [],
+			isSkipped: false,
+		});
 	});
 
 	afterAll(async () => {
@@ -114,6 +150,14 @@ describe('listPages', () => {
 		const result = await listPages(archive);
 		expect(result.total).toBe(3);
 		expect(result.items).toHaveLength(3);
+	});
+
+	it('非HTMLリソース（PDF, isTarget=1）はページ一覧に含まれない', async () => {
+		const result = await listPages(archive);
+		// PDF も scraped=1 / isTarget=1 で DB にあるが、content-type が text/html
+		// でないのでページ一覧（SEO メタ一覧）には出さない。Resources ビュー側で見る。
+		expect(result.items.some((p) => p.url.endsWith('/doc.pdf'))).toBe(false);
+		expect(result.items.map((p) => p.contentType)).not.toContain('application/pdf');
 	});
 
 	it('ステータスコードでフィルタする', async () => {
@@ -167,5 +211,88 @@ describe('listPages', () => {
 		const result = await listPages(archive, { directory: 'example.com' });
 		// Root URL (https://example.com) doesn't contain 'example.com/' so only subpages match
 		expect(result.total).toBe(2);
+	});
+});
+
+describe('listPages: ページ性は content-type（エラーページは残し、リソースだけ除外）', () => {
+	let archive: InstanceType<typeof Archive>;
+	const dir = path.resolve(__dirname, '__test_fixtures_list_pages_errored__');
+	const archiveFilePath = path.resolve(dir, 'list-pages-errored.nitpicker');
+
+	/**
+	 * Builds page data for this describe's fixtures.
+	 * @param url - The page URL.
+	 * @param status - HTTP status.
+	 * @param contentType - The content type (null for an errored/unreachable page).
+	 * @param html - The rendered HTML (empty for non-HTML / errored).
+	 * @returns Page data accepted by `Archive.setPage`.
+	 */
+	const makePage = (
+		url: string,
+		status: number,
+		contentType: string | null,
+		html: string,
+	) => ({
+		url: parseUrl(url)!,
+		redirectPaths: [] as string[],
+		isExternal: false,
+		isTarget: true,
+		status,
+		statusText: '',
+		contentType,
+		contentLength: 0,
+		responseHeaders: {},
+		html,
+		meta: {
+			lang: null,
+			title: null,
+			description: null,
+			keywords: null,
+			noindex: false,
+			nofollow: false,
+			noarchive: false,
+			canonical: null,
+			alternate: null,
+			'og:type': null,
+			'og:title': null,
+			'og:site_name': null,
+			'og:description': null,
+			'og:url': null,
+			'og:image': null,
+			'twitter:card': null,
+		},
+		anchorList: [] as never[],
+		imageList: [] as never[],
+		isSkipped: false,
+	});
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(dir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: dir });
+		await archive.setPage(
+			makePage('https://example.com/', 200, 'text/html', '<html></html>'),
+		);
+		// In-scope PDF: a resource, excluded.
+		await archive.setPage(
+			makePage('https://example.com/doc.pdf', 200, 'application/pdf', ''),
+		);
+		// Errored / unreachable internal page: contentType null — must STAY listed.
+		await archive.setPage(makePage('https://example.com/broken', -1, null, ''));
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.close();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('エラーページ（contentType null）は一覧に残り、リソース（PDF）だけ除外される', async () => {
+		const result = await listPages(archive);
+		const paths = result.items.map((p) => new URL(p.url).pathname).toSorted();
+		expect(paths).toEqual(['/', '/broken']);
+		expect(paths).not.toContain('/doc.pdf');
 	});
 });

--- a/packages/@nitpicker/query/src/list-pages.ts
+++ b/packages/@nitpicker/query/src/list-pages.ts
@@ -23,7 +23,17 @@ export async function listPages(
 	const limit = options.limit ?? 100;
 	const offset = options.offset ?? 0;
 
-	const baseQuery = knex('pages').where('scraped', 1).whereNull('redirectDestId');
+	// "Pages" = HTML pages PLUS not-yet-classified rows (errored / unreachable,
+	// whose `contentType` is null) so broken pages stay visible to the audit. Only
+	// KNOWN non-HTML resources (PDF / zip / image, `contentType` like
+	// 'application/pdf') are excluded — they live in the Resources view. Page-ness
+	// is content type, NOT `isTarget` (an in-scope PDF is `isTarget = 1`).
+	const baseQuery = knex('pages')
+		.where('scraped', 1)
+		.whereNull('redirectDestId')
+		.where((qb) => {
+			qb.whereNull('contentType').orWhere('contentType', 'text/html');
+		});
 
 	if (options.status != null) {
 		baseQuery.where('status', options.status);

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -14,6 +14,7 @@
 		"@nitpicker/analyze-main-contents": "0.9.0",
 		"@nitpicker/core": "0.9.0",
 		"@nitpicker/crawler": "0.9.0",
+		"@nitpicker/query": "0.9.0",
 		"@nitpicker/types": "0.9.0",
 		"await-event-emitter": "2.0.2",
 		"knex": "3.1.0",

--- a/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
@@ -1,3 +1,4 @@
+import { getSummary, listPages } from '@nitpicker/query';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { type CrawlResult, cleanup, crawl } from './helpers.js';
@@ -44,6 +45,24 @@ describe('Resource reuse', () => {
 		expect(resource).toBeDefined();
 		expect(resource!.status).toBe(200);
 		expect(resource!.contentType).toBe('image/png');
+	});
+
+	it('画像（非HTMLリソース）はページ一覧・サマリのページ数から除外される（end-to-end）', async () => {
+		// クロスパッケージ統合: 実クロール（crawler が image/png として分類）→ query が
+		// ページ性を content-type で判定。画像は pages 行・resources には残るが、
+		// listPages / getSummary のページ集計からは除外される。
+		const { items, total } = await listPages(result.accessor);
+		const paths = items.map((p) => new URL(p.url).pathname);
+		expect(paths).toContain('/resource-reuse/');
+		expect(paths).not.toContain('/resource-reuse/counted.png');
+		expect(paths).not.toContain('/resource-reuse/uncounted.png');
+		// 一覧に出るのは HTML（または content-type 未確定）のみ。
+		for (const item of items) {
+			expect(item.contentType === null || item.contentType === 'text/html').toBe(true);
+		}
+		// listPages と getSummary のページ数は一致する（どちらも画像を除外）。
+		const summary = await getSummary(result.accessor);
+		expect(summary.totalPages).toBe(total);
 	});
 
 	it('サブリソースに無い直リンク画像は従来どおり HEAD でフォールバックする', () => {

--- a/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/resource-reuse.e2e.ts
@@ -60,8 +60,11 @@ describe('Resource reuse', () => {
 		for (const item of items) {
 			expect(item.contentType === null || item.contentType === 'text/html').toBe(true);
 		}
-		// listPages と getSummary のページ数は一致する（どちらも画像を除外）。
+		// 唯一の HTML ページは /resource-reuse/（他リンクは全て画像）。listPages も
+		// getSummary も絶対値 1 で固定する（片側だけ壊れても、両側同時に壊れても落ちる）。
+		expect(total).toBe(1);
 		const summary = await getSummary(result.accessor);
+		expect(summary.totalPages).toBe(1);
 		expect(summary.totalPages).toBe(total);
 	});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18397,6 +18397,7 @@ __metadata:
     "@nitpicker/analyze-main-contents": "npm:0.9.0"
     "@nitpicker/core": "npm:0.9.0"
     "@nitpicker/crawler": "npm:0.9.0"
+    "@nitpicker/query": "npm:0.9.0"
     "@nitpicker/types": "npm:0.9.0"
     await-event-emitter: "npm:2.0.2"
     hono: "npm:4.12.2"


### PR DESCRIPTION
## 概要

非HTMLリソース（PDF / zip / 画像）が「HTMLページ」として扱われていた一連の不具合（#72 起点）を修正する。根は **`isTarget` が「in-scope なクロール対象か」を表すフラグで、ページ性ではない**こと（in-scope な PDF も `isTarget=1`）。ページ性は **content-type** で判定する。

## 修正内容

- **crawler（snapshot）**: `updatePage` の HTML スナップショット付与を `page.html.length > 0` で判定（非HTMLは `html=''` なので **0 バイトファイルを作らない**。実クロールで pdf 134,198 / zip 8,470 件の空ファイルが生成されていた）。HTML→非HTML 再スクレイプ時は古い `pages.html` をクリア、劣化スクレイプは据え置き。
- **crawler（count）**: `getScrapedHtmlPageCount` に `contentType='text/html'` を追加（in-scope な PDF を「HTMLページ」に数えない）。
- **crawler（normalize）**: `#insertPage` で content-type を正規化（trim+小文字、空→null）。`Text/HTML` 等が来ても SQL 完全一致述語と `isHtmlContentType()` が一致する。
- **query（list/summary）**: `listPages` / `getSummary`（total/internal/external/statusDistribution）のページ性述語を「**既知の非HTMLリソースだけ除外**（`contentType IS NULL OR = 'text/html'`）」に。**エラー/到達不能ページ（contentType null）は残す**（壊れたページは監査で見える）。除外されたリソースは Resources ビューに出る。metadata 充足率の分母は strict `text/html`（同一クエリの自前 COUNT、エラー行で希釈しない）。

`isTarget` の意味は**変更していない**（storage は faithful、ページ性は read 層で content-type 判定）。

## ⚠️ 設計判断（レビュー反映）

- ページ性は **read 層で content-type 保証**（`isTarget` を弄らない）。これは #70/#71 で確立した「storage faithful、最適化/分類は read 時」方針に沿う。
- read 述語は2種類：**strict**（`= 'text/html'`：描画済みHTMLページの件数・メタ充足率分母）と **loose**（`IS NULL OR = 'text/html'`：ユーザー向け一覧/件数。エラーページを残す）。
- 既知の保守ポイント：`'text/html'` リテラルが多数の SQL に inline（共有述語未導入）。詳細は `ARCHITECTURE.md`「ページ性の判定（content-type vs isTarget）」。

## テスト

- ユニット: `normalizeContentType` / snapshot ゲート（pdf・空html・劣化・HTML→非HTML クリア・isTarget非依存）/ `getScrapedHtmlPageCount`（非HTML除外）/ `listPages`（PDF除外・エラーページ保持）/ `getSummary`（PDF不算入・エラーページ算入・メタ分母希釈なし・全エラーで NaN にならない）/ content-type 正規化。
- 結合: 非HTML setPage で 0 バイトファイルを作らない（archive）。
- **E2E（クロスパッケージ）**: 実クロール → image/png 分類 → `listPages`/`getSummary` から除外（pages/resources には残る）・両 read 経路のページ数一致。

build / unit 1448 / lint 緑。レビュー3種（code-review / qa-engineer / product-manager）反映済み。

## 互換性

v0.x のため migration ガイドなし。挙動変化（非HTMLが page 一覧/件数から除外・content-type 正規化・非HTMLに空 snapshot を作らない）は `ARCHITECTURE.md` に記載。既存アーカイブの空ファイル等は再クロールで解消。

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)