### PR TITLE
feat: add crawl --retry-failed to re-fetch failed pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ packages/
 ```sh
 npx @nitpicker/cli crawl <URL> [<URL>...] [options]     # Web サイトをクロールして .nitpicker ファイルを生成（複数 URL で multi-root）
 npx @nitpicker/cli crawl <archive> --append <URL> [--append <URL>...]  # 既存アーカイブに新しい起点 URL を追加クロール
+npx @nitpicker/cli crawl <archive> --retry-failed [--no-recursive]  # 既存アーカイブの失敗ページ（status -1/NULL・content-type NULL・5xx）を再取得
 npx @nitpicker/cli analyze <file> [options]             # .nitpicker ファイルに対して analyze プラグインを実行
 npx @nitpicker/cli report <file> [options]              # .nitpicker ファイルから Google Sheets レポートを生成
 npx @nitpicker/cli pipeline <URL> [options]             # crawl → analyze → report を直列実行
@@ -65,6 +66,10 @@ npx @nitpicker/cli -v | --version                       # `@nitpicker/cli` の�
 > **Multi-root クロール**: 位置引数で複数 URL を渡すと、それぞれが「再帰クロールの起点」かつ「scope エントリ」として扱われ、1 つの `.nitpicker` に集約される。例: `crawl https://www.example.com/blog/ https://www.example.com/news/` → 両配下が internal として記録される。`(hostname, port, path)` トリプルで scope 一致を判定するため、`localhost:3000` と `localhost:8080` は別 scope として分離される（auth が混入しない）。
 
 > **`--append <URL>`**: 位置引数で指定された既存 `.nitpicker` を開き、`--append` の URL を新しい起点として追加クロールする（`--append` は繰り返し指定で複数 URL 可）。新スコープに該当する旧 external ページは internal として再スクレイプされる。失敗時は `<archive>.bak` から自動復元、成功時は `.bak` 削除。`--resume` / `--diff` / `--output` / `--list` / `--list-file` / `--single` との同時指定は不可。
+
+> **`--retry-failed`**: 位置引数で指定された既存 `.nitpicker` を開き、前回クロールで失敗したページだけを pending に戻して再取得する。失敗の定義は `status = -1`（ハード失敗 sentinel）/ `status IS NULL` / `contentType IS NULL` / `status` が 5xx（4xx は確定応答なので対象外）。internal/external 両方が対象で、external は scope 判定により metadata-only として再取得される。実装は append と同じ「再オープン+`.bak`+`Crawler.resume()`+`crawling()`」フローだが、新起点を足す代わりに `Archive.resetFailedPages()`（→ `Database.resetFailedPages`）で失敗ページを `scraped=0` に戻し、archived roots を seed にして失敗ページを resumedPending 経由で処理する（external 失敗ページを scope へ誤登録しないため）。**recursive はフラグ値（デフォルト true）が優先され、アーカイブ作成時の recursive 設定は継承しない**（`crawling(list, { recursive })` で明示注入）。それ以外の設定（scope/excludes/userAgent 等）は archived 設定を流用し、明示指定したフラグのみ上書き。`--resume` / `--append` / `--diff` / `--output` / `--list` / `--list-file` / `--single` との同時指定は不可。
+>
+> **Note**: 全ページが失敗していた（reset 後に `scraped=1` が 0 件になる）アーカイブでも取りこぼさないよう、`Crawler.start()` の resume 判定は `#resumedScraped` だけでなく `#resumedPending` も見る。`#resumedScraped` のみを見ると「全ページ失敗 retry」や「1ページもスクレイプせず中断した resume」を fresh crawl と誤判定し、pending を全部捨ててしまう。
 
 > **Stub mode viewer**: `viewer` は `.nitpicker` ファイルだけでなく、`crawl` を強制停止した時に残る `._nitpicker-*` ディレクトリ（"stub"）も直接受け付ける。`crawl --resume` と同じ mental model で同じパスを渡せる。stub オープンは `Archive.connect(tmpDir)` 経由の **read-only** 接続で、`Database.connect({readOnly: true})` により `initSchema` / `migrateInfoRoots` は **走らない**（user の tmpDir を絶対に書き換えない）。`getHtmlOfPage` も読み取り専用なら zip を tmpDir 内に展開しない（single-entry 抽出）。close 時には `db.destroy()` だけが呼ばれ、tar 化も tmpDir 削除も発生しないため、その後の `crawl --resume` が安全に走る。viewer footer は `/api/info.crawlerPid` に応じて "Live crawl in progress (PID xxx)" / "Interrupted crawl stub" のバッジを出し分ける（`peekArchiveLockHolder` で `<tmpDir>.lock/pid.txt` を probe）。`Archive.releaseHandle()` は writer の DB ハンドルと lock を解放するが tmpDir は残す書き戻し無しの exit hatch — fixture スクリプトと一部テストが使う。
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Web サイトをクロールして `.nitpicker` アーカイブを生成。
 ```sh
 npx @nitpicker/cli crawl <URL> [<URL>...]
 npx @nitpicker/cli crawl existing.nitpicker --append <URL>
+npx @nitpicker/cli crawl existing.nitpicker --retry-failed
 ```
 
 ### スコープと multi-root
@@ -33,6 +34,18 @@ npx @nitpicker/cli crawl existing.nitpicker --append <URL>
 - クロール開始前に `<archive>.bak` を作成。失敗時は自動復元、成功時は `.bak` を削除
 - list-mode archive（`--list` / `--list-file` で作成）への append は不可
 - `--resume` / `--diff` / `--output` / `--list` / `--list-file` / `--single` と同時指定不可
+
+### `--retry-failed`: 失敗ページの再取得
+
+前回クロールで失敗したページだけを再取得する。「サーバ側の一時障害やタイムアウトで取りこぼしたページを、フルクロールし直さずに回収する」ためのモード。
+
+- 再取得対象は **status が `-1`（ネットワークエラー/タイムアウト/ブラウザクラッシュの sentinel）/ `NULL`、content-type が `NULL`、または status が 5xx** のページ。確定応答である 4xx は再取得しても結果が変わらないため対象外
+- `internal` / `external` 両方を対象にする（external はメタデータのみ再取得）
+- 再取得したページが HTML なら新リンクを辿り、未取得の新 URL があればそこから再帰クロールする（デフォルト ON）。`--no-recursive` で「失敗ページの再取得のみ」に限定できる。**この recursive 設定はフラグ値が優先され、アーカイブ作成時の recursive 設定は継承しない**
+- スコープ・除外（`--exclude` 系）・User-Agent などは **アーカイブに保存された設定値を流用**する。明示的にフラグ指定したものだけ上書きされる
+- クロール開始前に `<archive>.bak` を作成。失敗時は自動復元、成功時は `.bak` を削除
+- list-mode archive への retry は不可
+- `--resume` / `--append` / `--diff` / `--output` / `--list` / `--list-file` / `--single` と同時指定不可
 
 ### Basic 認証
 
@@ -184,13 +197,13 @@ LLM が data の鮮度を判定できるよう **`mode` と `crawlerPid` を常�
 
 別プロセスが同じ archive を開いている。`.lock/pid.txt` の PID を `ps -p <PID>` で確認し、稼働中なら終了を待つ。既に終了していれば次回 open 時に stale 検出で自動回復。それでも残れば `rm -rf <path>.lock` で手動削除可能。
 
-### `Cannot append to a list-mode archive`
+### `Cannot append to a list-mode archive` / `Cannot retry a list-mode archive`
 
-`--list` / `--list-file` で作成された archive（`info.fromList=true`）は再帰クロールの土台にならないため append 経路は閉じている。新規 archive を作るかフルクロールで作り直すこと。
+`--list` / `--list-file` で作成された archive（`info.fromList=true`）は再帰クロールの土台にならないため append / retry 経路は閉じている。新規 archive を作るかフルクロールで作り直すこと。
 
 ### `<archive>.bak` が残っている
 
-`--append` の失敗時復元自体が失敗した状態。`AggregateError` がログに残るはず。`mv <archive>.bak <archive>` で原本を復元できる。
+`--append` / `--retry-failed` の失敗時復元自体が失敗した状態。`AggregateError` がログに残るはず。`mv <archive>.bak <archive>` で原本を復元できる。
 
 ### `[migrate] info table upgraded (...)`
 

--- a/packages/@nitpicker/cli/src/commands/crawl.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/crawl.spec.ts
@@ -12,12 +12,14 @@ import { ExitCode } from '../exit-code.js';
 const mockCrawling = vi.fn();
 const mockResume = vi.fn();
 const mockAppend = vi.fn();
+const mockRetryFailed = vi.fn();
 
 vi.mock('@nitpicker/crawler', () => ({
 	CrawlerOrchestrator: {
 		crawling: mockCrawling,
 		resume: mockResume,
 		append: mockAppend,
+		retryFailed: mockRetryFailed,
 	},
 }));
 
@@ -58,6 +60,7 @@ function createFlags(overrides: Partial<CrawlFlags> = {}): CrawlFlags {
 	return {
 		resume: undefined,
 		append: undefined,
+		retryFailed: undefined,
 		interval: undefined,
 		image: true,
 		fetchExternal: true,
@@ -103,6 +106,11 @@ function setupFakeOrchestrator() {
 	});
 
 	mockAppend.mockImplementation((_path, _urls, _opts, cb) => {
+		cb?.(fakeOrchestrator, { baseUrl: 'https://example.com' });
+		return Promise.resolve(fakeOrchestrator);
+	});
+
+	mockRetryFailed.mockImplementation((_path, _opts, cb) => {
 		cb?.(fakeOrchestrator, { baseUrl: 'https://example.com' });
 		return Promise.resolve(fakeOrchestrator);
 	});
@@ -467,6 +475,90 @@ describe('crawl', () => {
 				createFlags({ append: ['https://sample-b.example.com/'], single: true }),
 			),
 		).rejects.toThrow('--append cannot be combined with --single');
+	});
+
+	it('crawl <archive> --retry-failed で CrawlerOrchestrator.retryFailed が呼ばれる', async () => {
+		const { crawl } = await import('./crawl.js');
+		await crawl(['/tmp/existing.nitpicker'], createFlags({ retryFailed: true }));
+
+		expect(mockRetryFailed).toHaveBeenCalledOnce();
+		const [archivePath] = mockRetryFailed.mock.calls[0]!;
+		expect(archivePath).toBe('/tmp/existing.nitpicker');
+		expect(mockCrawling).not.toHaveBeenCalled();
+		expect(mockAppend).not.toHaveBeenCalled();
+	});
+
+	it('--retry-failed を指定したのに位置引数が無いとエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(crawl([], createFlags({ retryFailed: true }))).rejects.toThrow(
+			'--retry-failed requires the archive path as the positional argument (usage: crawl <archive> --retry-failed).',
+		);
+	});
+
+	it('--retry-failed を指定したのに位置引数が複数あるとエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(
+			crawl(['/tmp/a.nitpicker', '/tmp/b.nitpicker'], createFlags({ retryFailed: true })),
+		).rejects.toThrow(
+			'--retry-failed takes exactly one positional argument (the archive path).',
+		);
+	});
+
+	it('--retry-failed と --resume の同時指定はエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(
+			crawl(
+				['/tmp/a.nitpicker'],
+				createFlags({ retryFailed: true, resume: '/tmp/stub' }),
+			),
+		).rejects.toThrow('--resume and --retry-failed cannot be used together');
+	});
+
+	it('--retry-failed と --append の同時指定はエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(
+			crawl(
+				['/tmp/a.nitpicker'],
+				createFlags({ retryFailed: true, append: ['https://sample-b.example.com/'] }),
+			),
+		).rejects.toThrow('--append and --retry-failed cannot be used together');
+	});
+
+	it('--retry-failed と --diff の同時指定はエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(
+			crawl(
+				['a.nitpicker', 'b.nitpicker'],
+				createFlags({ retryFailed: true, diff: true }),
+			),
+		).rejects.toThrow('--diff cannot be combined with --retry-failed');
+	});
+
+	it('--retry-failed と --output の同時指定はエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(
+			crawl(
+				['/tmp/a.nitpicker'],
+				createFlags({ retryFailed: true, output: '/tmp/out.nitpicker' }),
+			),
+		).rejects.toThrow('--output flag is not supported with --retry-failed');
+	});
+
+	it('--retry-failed と --list の同時指定はエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(
+			crawl(
+				['/tmp/a.nitpicker'],
+				createFlags({ retryFailed: true, list: ['https://example.com/'] }),
+			),
+		).rejects.toThrow('--retry-failed cannot be combined with --list');
+	});
+
+	it('--retry-failed と --single の同時指定はエラー', async () => {
+		const { crawl } = await import('./crawl.js');
+		await expect(
+			crawl(['/tmp/a.nitpicker'], createFlags({ retryFailed: true, single: true })),
+		).rejects.toThrow('--retry-failed cannot be combined with --single');
 	});
 
 	it('--append × list が空配列 ([]) なら通る', async () => {

--- a/packages/@nitpicker/cli/src/commands/crawl.ts
+++ b/packages/@nitpicker/cli/src/commands/crawl.ts
@@ -33,6 +33,10 @@ export const commandDef = {
 			isMultiple: true,
 			desc: 'Append crawl: register the URL as a new recursive root for the positional archive (repeat for multiple URLs)',
 		},
+		retryFailed: {
+			type: 'boolean',
+			desc: 'Retry crawl: re-fetch failed pages (missing status/content-type or a 5xx status) in the positional archive; use --no-recursive to skip re-crawling newly found URLs',
+		},
 		interval: {
 			type: 'number',
 			shortFlag: 'I',
@@ -333,6 +337,53 @@ async function appendCrawl(archivePath: string, newUrls: string[], flags: CrawlF
 }
 
 /**
+ * Re-fetch failed pages in an existing `.nitpicker` archive and re-crawl.
+ *
+ * Opens the archive at the positional argument, resets every page whose
+ * previous attempt failed (missing status / content type, or a 5xx status)
+ * back to pending, and resumes crawling. Newly-discovered URLs are followed
+ * unless `--no-recursive` was given. The archived crawl configuration
+ * (scopes, excludes, keywords, user agent, …) is reused unless explicitly
+ * overridden. A `<archive>.bak` is taken before any DB mutation; on success it
+ * is removed, on failure it is restored.
+ * @param archivePath - Path to the existing `.nitpicker` archive.
+ * @param flags - Parsed CLI flags from the `crawl` command.
+ */
+async function retryFailedCrawl(archivePath: string, flags: CrawlFlags) {
+	const errStack: (CrawlerError | Error)[] = [];
+
+	const orchestrator = await CrawlerOrchestrator.retryFailed(
+		archivePath,
+		{
+			...mapFlagsToCrawlConfig(flags),
+			list: false,
+		},
+		(orchestrator, config) => {
+			run(
+				`${archivePath} (retry-failed)`,
+				orchestrator,
+				config,
+				flags.verbose ? 'verbose' : flags.silent ? 'silent' : 'normal',
+			).catch((error) => errStack.push(error));
+		},
+	);
+
+	try {
+		await orchestrator.write();
+	} finally {
+		await orchestrator.archive.close();
+		orchestrator.garbageCollect();
+	}
+
+	if (errStack.length > 0) {
+		const error = new CrawlAggregateError(errStack);
+		// eslint-disable-next-line no-console
+		console.error(`\n${error.message}`);
+		throw error;
+	}
+}
+
+/**
  * Validates that all URLs in the list are parseable by the URL constructor.
  * @param urls - Array of URL strings to validate
  * @throws {Error} If any URL is invalid
@@ -374,6 +425,9 @@ export async function crawl(args: string[], flags: CrawlFlags) {
 		if (hasAppendFlag) {
 			throw new Error('--diff cannot be combined with --append.');
 		}
+		if (flags.retryFailed) {
+			throw new Error('--diff cannot be combined with --retry-failed.');
+		}
 		if (args.length !== 2) {
 			throw new Error('--diff takes exactly two file paths to compare');
 		}
@@ -404,11 +458,21 @@ export async function crawl(args: string[], flags: CrawlFlags) {
 					'--resume and --append cannot be used together. Pick the existing-archive mode that fits your task.',
 				);
 			}
+			if (flags.retryFailed) {
+				throw new Error(
+					'--resume and --retry-failed cannot be used together. Pick the existing-archive mode that fits your task.',
+				);
+			}
 			await resumeCrawl(flags.resume, flags);
 			return;
 		}
 
 		if (hasAppendFlag) {
+			if (flags.retryFailed) {
+				throw new Error(
+					'--append and --retry-failed cannot be used together. Pick the existing-archive mode that fits your task.',
+				);
+			}
 			if (flags.output) {
 				throw new Error(
 					'--output flag is not supported with --append. The archive path is the positional argument being appended.',
@@ -434,6 +498,35 @@ export async function crawl(args: string[], flags: CrawlFlags) {
 				);
 			}
 			await appendCrawl(args[0]!, flags.append, flags);
+			return;
+		}
+
+		if (flags.retryFailed) {
+			if (flags.output) {
+				throw new Error(
+					'--output flag is not supported with --retry-failed. The archive path is the positional argument being retried.',
+				);
+			}
+			if (flags.listFile) {
+				throw new Error('--retry-failed cannot be combined with --list-file.');
+			}
+			if (hasListFlag) {
+				throw new Error('--retry-failed cannot be combined with --list.');
+			}
+			if (flags.single) {
+				throw new Error('--retry-failed cannot be combined with --single.');
+			}
+			if (args.length === 0) {
+				throw new Error(
+					'--retry-failed requires the archive path as the positional argument (usage: crawl <archive> --retry-failed).',
+				);
+			}
+			if (args.length > 1) {
+				throw new Error(
+					'--retry-failed takes exactly one positional argument (the archive path).',
+				);
+			}
+			await retryFailedCrawl(args[0]!, flags);
 			return;
 		}
 

--- a/packages/@nitpicker/cli/src/commands/pipeline.ts
+++ b/packages/@nitpicker/cli/src/commands/pipeline.ts
@@ -238,6 +238,7 @@ export async function pipeline(args: string[], flags: PipelineFlags) {
 			silent: flags.silent,
 			resume: undefined,
 			append: [],
+			retryFailed: false,
 			diff: undefined,
 		});
 	} catch (error) {

--- a/packages/@nitpicker/crawler/src/archive/archive.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.ts
@@ -194,6 +194,17 @@ export default class Archive extends ArchiveAccessor {
 		return this.#db.repromoteExternalPages(scopes, options);
 	}
 	/**
+	 * Reset previously-failed pages back to pending so a follow-up crawl re-fetches them.
+	 *
+	 * Delegates to {@link Database.resetFailedPages}. See that method for the
+	 * exact failure criteria (missing status / content type, or a 5xx status).
+	 * @returns The URLs of the pages that were reset to pending.
+	 */
+	async resetFailedPages() {
+		dbLog('Reset failed pages back to pending');
+		return this.#db.resetFailedPages();
+	}
+	/**
 	 * Stores the crawl configuration into the archive database.
 	 * @param config - The configuration object to store.
 	 */

--- a/packages/@nitpicker/crawler/src/archive/database.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.spec.ts
@@ -1651,6 +1651,281 @@ describe('repromoteExternalPages', () => {
 	});
 });
 
+describe('resetFailedPages', () => {
+	const resetDbPath = path.resolve(workingDir, 'reset-failed-test.sqlite');
+
+	/**
+	 * Insert a fully-formed `pages` row with explicit failure-relevant columns so
+	 * each test can assert the SELECT/reset logic against a precise state.
+	 * @param db - The connected database.
+	 * @param row - The page fields to insert. Defaults model a scraped, internal page.
+	 * @param row.url
+	 * @param row.scraped
+	 * @param row.isTarget
+	 * @param row.isExternal
+	 * @param row.status
+	 * @param row.contentType
+	 * @param row.isSkipped
+	 * @param row.redirectDestId
+	 * @returns The inserted row id.
+	 */
+	async function insertPage(
+		db: Database,
+		row: {
+			url: string;
+			scraped?: number;
+			isTarget?: number;
+			isExternal?: number;
+			status?: number | null;
+			contentType?: string | null;
+			isSkipped?: number | null;
+			redirectDestId?: number | null;
+		},
+	): Promise<number> {
+		const knex = db.getKnex();
+		const [inserted] = await knex('pages')
+			.insert({
+				url: row.url,
+				scraped: row.scraped ?? 1,
+				isTarget: row.isTarget ?? 1,
+				isExternal: row.isExternal ?? 0,
+				status: row.status === undefined ? 200 : row.status,
+				statusText: 'OK',
+				contentType: row.contentType === undefined ? 'text/html' : row.contentType,
+				contentLength: 100,
+				responseHeaders: '{}',
+				html: 'snapshot/x.html',
+				isSkipped: row.isSkipped ?? 0,
+				redirectDestId: row.redirectDestId ?? null,
+			})
+			.returning('id');
+		return Number(
+			typeof inserted === 'object' ? (inserted as { id: number }).id : inserted,
+		);
+	}
+
+	afterAll(async () => {
+		await remove(resetDbPath);
+	});
+
+	it('resets pages with missing status, missing content type, or a 5xx status, and returns their URLs', async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(resetDbPath, { force: true });
+		const db = await Database.connect({ workingDir, filename: resetDbPath });
+
+		await insertPage(db, { url: 'https://example.com/null-status', status: null });
+		await insertPage(db, { url: 'https://example.com/null-ctype', contentType: null });
+		await insertPage(db, { url: 'https://example.com/server-error', status: 500 });
+		await insertPage(db, { url: 'https://example.com/unavailable', status: 503 });
+		// Hard scrape failures are stored as status=-1 with a content type still
+		// present, so the -1 sentinel branch (not the null-contentType branch)
+		// is what must catch them.
+		await insertPage(db, {
+			url: 'https://example.com/hard-error',
+			status: -1,
+			contentType: 'text/html',
+		});
+
+		const reset = await db.resetFailedPages();
+		expect(reset.toSorted()).toEqual([
+			'https://example.com/hard-error',
+			'https://example.com/null-ctype',
+			'https://example.com/null-status',
+			'https://example.com/server-error',
+			'https://example.com/unavailable',
+		]);
+
+		// Every reset row is demoted to pending and stripped of scrape metadata.
+		const all = await db.getPages();
+		for (const url of reset) {
+			const page = all.find((p) => p.url === url)!;
+			expect(page.scraped).toBe(0);
+			expect(page.status).toBeNull();
+			expect(page.statusText).toBeNull();
+			expect(page.contentType).toBeNull();
+			expect(page.contentLength).toBeNull();
+			expect(page.html).toBeNull();
+		}
+
+		await db.destroy();
+	});
+
+	it('leaves definitive responses (2xx/4xx), skipped, redirect-source, and pending pages untouched', async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(resetDbPath, { force: true });
+		const db = await Database.connect({ workingDir, filename: resetDbPath });
+
+		await insertPage(db, { url: 'https://example.com/ok', status: 200 });
+		await insertPage(db, { url: 'https://example.com/not-found', status: 404 });
+		await insertPage(db, { url: 'https://example.com/gone', status: 410 });
+		// status NULL but intentionally skipped → not a failure.
+		await insertPage(db, {
+			url: 'https://example.com/skipped',
+			status: null,
+			isSkipped: 1,
+		});
+		// status NULL but a redirect source → not a failure.
+		const dest = await insertPage(db, { url: 'https://example.com/dest', status: 200 });
+		await insertPage(db, {
+			url: 'https://example.com/redirect-src',
+			status: null,
+			redirectDestId: dest,
+		});
+		// Already pending (scraped=0) → outside the "previously attempted" set.
+		await insertPage(db, {
+			url: 'https://example.com/pending',
+			scraped: 0,
+			status: null,
+		});
+
+		const reset = await db.resetFailedPages();
+		expect(reset).toEqual([]);
+
+		await db.destroy();
+	});
+
+	it('resets internal and external failures alike while preserving isExternal', async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(resetDbPath, { force: true });
+		const db = await Database.connect({ workingDir, filename: resetDbPath });
+
+		await insertPage(db, {
+			url: 'https://example.com/internal-fail',
+			isExternal: 0,
+			status: null,
+		});
+		await insertPage(db, {
+			url: 'https://other.example.com/external-fail',
+			isExternal: 1,
+			status: 500,
+		});
+
+		const reset = await db.resetFailedPages();
+		expect(reset).toHaveLength(2);
+
+		const all = await db.getPages();
+		const internal = all.find((p) => p.url === 'https://example.com/internal-fail')!;
+		const external = all.find(
+			(p) => p.url === 'https://other.example.com/external-fail',
+		)!;
+		expect(internal.isExternal).toBe(0);
+		expect(external.isExternal).toBe(1);
+		expect(internal.scraped).toBe(0);
+		expect(external.scraped).toBe(0);
+
+		await db.destroy();
+	});
+
+	it('clears anchors / images / resources-referrers / page_errors only for reset pages', async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(resetDbPath, { force: true });
+		const db = await Database.connect({ workingDir, filename: resetDbPath });
+
+		const failId = await insertPage(db, {
+			url: 'https://example.com/fail',
+			status: null,
+		});
+		const keepId = await insertPage(db, { url: 'https://example.com/keep', status: 200 });
+
+		const knex = db.getKnex();
+		await knex('anchors').insert([
+			{ pageId: failId, hrefId: keepId, hash: null, textContent: 'to keep' },
+			{ pageId: keepId, hrefId: failId, hash: null, textContent: 'to fail' },
+		]);
+		await knex('images').insert([
+			{
+				pageId: failId,
+				src: 'https://example.com/fail.png',
+				currentSrc: null,
+				alt: null,
+				width: 1,
+				height: 1,
+				naturalWidth: 1,
+				naturalHeight: 1,
+				isLazy: 0,
+				viewportWidth: 1024,
+				sourceCode: null,
+			},
+			{
+				pageId: keepId,
+				src: 'https://example.com/keep.png',
+				currentSrc: null,
+				alt: null,
+				width: 1,
+				height: 1,
+				naturalWidth: 1,
+				naturalHeight: 1,
+				isLazy: 0,
+				viewportWidth: 1024,
+				sourceCode: null,
+			},
+		]);
+		const [resourceId] = await knex('resources')
+			.insert({ url: 'https://cdn.example.com/x.css', isExternal: 1 })
+			.returning('id');
+		const rid = Number(
+			typeof resourceId === 'object' ? (resourceId as { id: number }).id : resourceId,
+		);
+		await knex('resources-referrers').insert([
+			{ resourceId: rid, pageId: failId },
+			{ resourceId: rid, pageId: keepId },
+		]);
+		await knex('page_errors').insert([
+			{ pageId: failId, phase: 'render', message: 'boom', createdAt: 1_700_000_000_000 },
+			{ pageId: keepId, phase: 'render', message: 'kept', createdAt: 1_700_000_000_000 },
+		]);
+
+		await db.resetFailedPages();
+
+		expect(await knex('anchors').where('pageId', failId)).toEqual([]);
+		expect(await knex('images').where('pageId', failId)).toEqual([]);
+		expect(await knex('resources-referrers').where('pageId', failId)).toEqual([]);
+		expect(await knex('page_errors').where('pageId', failId)).toEqual([]);
+
+		// The non-failed page keeps all of its related rows.
+		expect(await knex('anchors').where('pageId', keepId)).toHaveLength(1);
+		expect(await knex('images').where('pageId', keepId)).toHaveLength(1);
+		expect(await knex('resources-referrers').where('pageId', keepId)).toHaveLength(1);
+		expect(await knex('page_errors').where('pageId', keepId)).toHaveLength(1);
+
+		await db.destroy();
+	});
+
+	it('returns an empty list when there are no failed pages', async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(resetDbPath, { force: true });
+		const db = await Database.connect({ workingDir, filename: resetDbPath });
+
+		await insertPage(db, { url: 'https://example.com/ok', status: 200 });
+		expect(await db.resetFailedPages()).toEqual([]);
+
+		await db.destroy();
+	});
+
+	it('resets every match across the 500-row chunk boundary', async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(resetDbPath, { force: true });
+		const db = await Database.connect({ workingDir, filename: resetDbPath });
+
+		const total = 501;
+		for (let i = 0; i < total; i++) {
+			await insertPage(db, { url: `https://example.com/fail-${i}`, status: null });
+		}
+
+		const reset = await db.resetFailedPages();
+		expect(reset).toHaveLength(total);
+
+		const remainingScraped = await db
+			.getKnex()
+			.from('pages')
+			.where('scraped', 1)
+			.count<{ c: number }[]>({ c: '*' });
+		expect(Number(remainingScraped[0]!.c)).toBe(0);
+
+		await db.destroy();
+	});
+});
+
 describe('self-redirect', () => {
 	const selfRedirectDbPath = path.resolve(workingDir, 'self-redirect-test.sqlite');
 

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -837,6 +837,85 @@ export class Database extends EventEmitter<DatabaseEvent> {
 		dbLog('Repromoted %d external pages back to pending', promotedUrls.length);
 		return promotedUrls;
 	}
+
+	/**
+	 * Reset previously-attempted pages that ended in a recoverable failure so a
+	 * follow-up crawl can re-fetch them from scratch.
+	 *
+	 * A page qualifies as a recoverable failure when it was already scraped
+	 * (`scraped = 1`), is not a redirect source (`redirectDestId IS NULL`), was
+	 * not intentionally skipped (`isSkipped` is not `1`), and one of the
+	 * following holds:
+	 *
+	 * - `status = -1` — the sentinel a hard scrape failure (network error,
+	 *   timeout, browser crash) is recorded with (see `handle-scrape-error.ts`);
+	 * - `status IS NULL` — no status was ever stored for the row;
+	 * - `contentType IS NULL` — the content type could not be determined;
+	 * - `status` is in the `5xx` range — a (frequently transient) server error.
+	 *
+	 * Definitive `4xx` responses are intentionally excluded: re-fetching a 404
+	 * almost always yields the same answer. Matching rows — internal and
+	 * external alike — are demoted back to pending (`scraped = 0`) and have their
+	 * stale scrape metadata cleared. The page row itself is kept (id preserved)
+	 * so existing `anchors.hrefId` referrers stay valid, and `isExternal` is left
+	 * untouched so the next pass re-classifies each page from the crawl scope.
+	 * Related `anchors`, `images`, `resources-referrers`, and `page_errors` rows
+	 * are deleted so the re-scrape can re-insert fresh data without duplicates.
+	 *
+	 * SELECT and UPDATE/DELETE statements are chunked to stay below SQLite's
+	 * `SQLITE_LIMIT_VARIABLE_NUMBER`.
+	 * @returns The URLs of the pages that were reset to pending.
+	 */
+	@ErrorEmitter()
+	@retry(retrySetting)
+	async resetFailedPages(): Promise<string[]> {
+		const candidates = await this.#instance
+			.select('id', 'url')
+			.from<DB_Page>('pages')
+			.where('scraped', 1)
+			.whereNull('redirectDestId')
+			.where((qb) => {
+				qb.where('isSkipped', 0).orWhereNull('isSkipped');
+			})
+			.where((qb) => {
+				qb.whereNull('status')
+					.orWhere('status', -1)
+					.orWhereNull('contentType')
+					.orWhereBetween('status', [500, 599]);
+			});
+
+		if (candidates.length === 0) {
+			return [];
+		}
+
+		const ids = candidates.map((row) => row.id);
+		const urls = candidates.map((row) => row.url);
+
+		const chunkSize = 500;
+		for (let i = 0; i < ids.length; i += chunkSize) {
+			const chunk = ids.slice(i, i + chunkSize);
+			await this.#instance<DB_Page>('pages').whereIn('id', chunk).update({
+				scraped: 0,
+				html: null,
+				status: null,
+				statusText: null,
+				contentType: null,
+				contentLength: null,
+				responseHeaders: '{}',
+			});
+			// Clear the prior crawl's per-page data so the re-scrape starts clean.
+			// `updatePage` only replaces anchors/images when the new scrape is
+			// non-empty, so this pre-clear is load-bearing for pages that reset but
+			// then fail again (or are never reached), and it is the only place
+			// `resources-referrers` and `page_errors` are cleared.
+			await this.#instance('anchors').whereIn('pageId', chunk).delete();
+			await this.#instance('images').whereIn('pageId', chunk).delete();
+			await this.#instance('resources-referrers').whereIn('pageId', chunk).delete();
+			await this.#instance('page_errors').whereIn('pageId', chunk).delete();
+		}
+		dbLog('Reset %d failed pages back to pending', urls.length);
+		return urls;
+	}
 	/**
 	 * Stores the crawl configuration in the `info` table.
 	 * Only fields in {@link INFO_COLUMN_ALLOWLIST} are forwarded — any extra

--- a/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
+++ b/packages/@nitpicker/crawler/src/crawler-orchestrator.ts
@@ -201,10 +201,14 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 	 * when the crawl completes. Discovered pages, external pages, skipped pages,
 	 * and resources are forwarded to the archive for storage.
 	 * @param list - The list of parsed URLs to crawl. The first URL is used as the root.
+	 * @param opts - Optional crawl overrides.
+	 * @param opts.recursive - Whether discovered URLs are followed. Defaults to
+	 *   `!fromList` (recursive unless the archive was created from a URL list), so
+	 *   existing callers keep their behaviour; the retry flow passes it explicitly.
 	 * @returns A promise that resolves when crawling is complete.
 	 * @throws {Error} If the URL list is empty.
 	 */
-	async crawling(list: ExURL[]) {
+	async crawling(list: ExURL[], opts?: { recursive?: boolean }) {
 		const root = list[0];
 
 		if (!root) {
@@ -272,7 +276,7 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 					.catch((error) => reject(error));
 			});
 
-			this.#crawler.start(list, { recursive: !this.#fromList });
+			this.#crawler.start(list, { recursive: opts?.recursive ?? !this.#fromList });
 		});
 	}
 
@@ -516,6 +520,117 @@ export class CrawlerOrchestrator extends EventEmitter<CrawlEvent> {
 					throw new AggregateError(
 						[error, restoreError],
 						`append failed AND restore from backup failed. Original archive backup is left at: ${backupPath}`,
+					);
+				}
+				throw error;
+			}
+		} catch (error) {
+			await archive.close().catch(() => {});
+			throw error;
+		}
+	}
+
+	/**
+	 * Re-fetch previously-failed pages in an existing `.nitpicker` archive.
+	 *
+	 * Opens the archive, resets every page whose previous attempt ended in a
+	 * recoverable failure (missing status / content type, or a 5xx status — see
+	 * {@link Archive.resetFailedPages}) back to pending, and resumes crawling.
+	 * The archived crawl configuration is reused — scopes, excludes, keywords,
+	 * user agent, etc. — so the retry honours the original crawl boundaries
+	 * unless a field is explicitly overridden via `options`. The exception is
+	 * `recursive`: it is taken from `options` (the CLI flag defaults it to
+	 * `true`) rather than inherited from the archive, so a retry decides afresh
+	 * whether to follow newly-discovered URLs regardless of how the original
+	 * crawl was run.
+	 *
+	 * When `recursive` is enabled (the default), newly-discovered URLs from the
+	 * re-fetched pages are followed and crawled from scratch; when disabled, only
+	 * the failed pages themselves are re-fetched. The archived roots seed the
+	 * crawl scope while the reset pages are picked up through the resumed pending
+	 * set, so failed external pages stay external (metadata-only) instead of being
+	 * promoted into scope, and a failed root is re-fetched in place.
+	 *
+	 * A `<archive>.bak` is created before any DB mutation and removed on success;
+	 * if the crawl throws, the backup is restored to keep the original archive
+	 * intact.
+	 *
+	 * List-mode archives (`info.fromList === true`) are rejected for the same
+	 * reason as {@link CrawlerOrchestrator.append}: their pages are metadata-only.
+	 * @param archivePath - Absolute or relative path to the existing `.nitpicker`.
+	 * @param options - Optional config overrides applied on top of the archived config.
+	 * @param initializedCallback - Optional callback invoked after initialization but before crawling resumes.
+	 * @returns The orchestrator instance after the retry crawl completes.
+	 * @throws {Error} When the archive is in list mode or has no parseable roots.
+	 */
+	static async retryFailed(
+		archivePath: string,
+		options?: Partial<CrawlConfig>,
+		initializedCallback?: CrawlInitializedCallback,
+	) {
+		const cwd = options?.cwd ?? process.cwd();
+		const absFilePath = path.isAbsolute(archivePath)
+			? archivePath
+			: path.resolve(cwd, archivePath);
+
+		const archive = await Archive.open({ filePath: absFilePath, cwd });
+		// Any throw between here and the successful return must release the
+		// archive lock and clean up tmpDir; the caller's `close()` only runs on
+		// the happy path.
+		try {
+			const archived = await archive.getConfig();
+			if (archived.fromList) {
+				throw new Error(
+					'Cannot retry a list-mode archive: this archive was created with --list/--list-file and contains metadata-only pages. Create a fresh archive instead.',
+				);
+			}
+
+			const rootsParsed = sortUrl(archived.roots, archived);
+			if (rootsParsed.length === 0) {
+				throw new Error('retry: archive has no parseable root URLs');
+			}
+
+			const config: Config = {
+				...archived,
+				...cleanObject(options),
+				roots: archived.roots,
+				fromList: false,
+				baseUrl: archived.baseUrl,
+			};
+
+			const backupPath = absFilePath + '.bak';
+			await copyFile(absFilePath, backupPath);
+
+			try {
+				const resetUrls = await archive.resetFailedPages();
+				log('Start retrying failed pages');
+				log('Archive %s', absFilePath);
+				log('Reset %d failed page(s)', resetUrls.length);
+
+				const orchestrator = new CrawlerOrchestrator(archive, config);
+				const { scraped, pending } = await archive.getCrawlingState();
+				const resources = await archive.getResourceUrlList();
+				const pagesScrapedOffset = await archive.getScrapedHtmlPageCount();
+				orchestrator.#crawler.resume(pending, scraped, resources, pagesScrapedOffset);
+				if (initializedCallback) {
+					await initializedCallback(orchestrator, config);
+				}
+				await orchestrator.crawling(rootsParsed, { recursive: config.recursive });
+				clearDestinationCache();
+				await archive.setUrlOrder();
+				await ignoreEnoent(unlinkFile(backupPath));
+				return orchestrator;
+			} catch (error) {
+				try {
+					await copyFile(backupPath, absFilePath);
+					await ignoreEnoent(unlinkFile(backupPath));
+				} catch (restoreError) {
+					// Restore itself failed — surface both so the operator knows
+					// the .bak still exists and the original archive may be
+					// corrupt. The outer `catch` still releases the lock.
+					throw new AggregateError(
+						[error, restoreError],
+						`retry failed AND restore from backup failed. Original archive backup is left at: ${backupPath}`,
 					);
 				}
 				throw error;

--- a/packages/@nitpicker/crawler/src/crawler/crawler.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.spec.ts
@@ -287,6 +287,32 @@ describe('Crawler', () => {
 		});
 	});
 
+	describe('start() resume merge', () => {
+		it('scraped が空でも resumedPending を初期キューに含める（全ページ失敗 retry）', async () => {
+			const { deal } = await import('@d-zero/dealer');
+			const { default: Crawler } = await import('./crawler.js');
+
+			let captured: { href: string }[] = [];
+			vi.mocked(deal).mockImplementation((items) => {
+				captured = items as { href: string }[];
+				return Promise.resolve();
+			});
+
+			const crawler = new Crawler(defaultOptions);
+			// Every page in the archive was a failure: resume with an empty
+			// scraped set but a pending (reset) child. Keying isResuming on
+			// scraped alone would drop this child entirely.
+			crawler.resume(['https://example.com/failed-child'], [], []);
+			crawler.start([parseUrl('https://example.com/')!]);
+
+			await vi.waitFor(() => expect(captured.length).toBeGreaterThan(0));
+
+			const hrefs = captured.map((u) => u.href);
+			expect(hrefs).toContain('https://example.com/failed-child');
+			expect(hrefs).toContain('https://example.com');
+		});
+	});
+
 	describe('worker-level error handling', () => {
 		it('ワーカー内の例外が error イベントとして emit され処理が継続する', async () => {
 			const { default: Crawler } = await import('./crawler.js');

--- a/packages/@nitpicker/crawler/src/crawler/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler/crawler.ts
@@ -241,7 +241,12 @@ export default class Crawler extends EventEmitter<CrawlerEventTypes> {
 			this.#options.fromList = true;
 		}
 
-		const isResuming = this.#resumedScraped.length > 0;
+		// A resume can have an empty scraped set — e.g. a crawl interrupted before
+		// any page finished, or a `--retry-failed` run where every page in the
+		// archive was a failure and got reset to pending. Keying purely on
+		// `#resumedScraped` would then mistake the session for a fresh crawl and
+		// drop every resumed pending URL, so honour the pending set too.
+		const isResuming = this.#resumedScraped.length > 0 || this.#resumedPending.length > 0;
 		// Dedupe by the same protocol-agnostic key the dealer uses internally.
 		// Append-mode in particular can put the same URL into both
 		// `#resumedPending` (via `repromoteExternalPages`) and `urls` (the

--- a/packages/test-server/src/__tests__/e2e/retry-failed.e2e.ts
+++ b/packages/test-server/src/__tests__/e2e/retry-failed.e2e.ts
@@ -1,0 +1,170 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Archive, CrawlerOrchestrator } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Run a baseline crawl that creates a `.nitpicker` archive on disk, then close
+ * it so the caller can re-open it via `Archive.open`.
+ * @param urls - One or more URLs to crawl.
+ * @param options - Optional crawl configuration overrides.
+ * @returns Paths to the produced archive and its cwd.
+ */
+async function crawlAndPersist(
+	urls: string[],
+	options: Record<string, unknown> = {},
+): Promise<{ filePath: string; cwd: string }> {
+	const cwd = path.join(os.tmpdir(), `nitpicker-retry-${crypto.randomUUID()}`);
+	await fs.mkdir(cwd, { recursive: true });
+
+	const orchestrator = await CrawlerOrchestrator.crawling(urls, {
+		cwd,
+		interval: 0,
+		parallels: 1,
+		image: false,
+		...options,
+	});
+	const filePath = orchestrator.archive.filePath;
+	await orchestrator.write();
+	await orchestrator.archive.close();
+	orchestrator.garbageCollect();
+
+	return { filePath, cwd };
+}
+
+/**
+ * Toggle the `/flaky/recoverable` route between failing (500) and healed (200).
+ * @param state - `'heal'` to serve 200, `'reset'` to serve 500.
+ */
+async function setFlakyState(state: 'heal' | 'reset'): Promise<void> {
+	const res = await fetch(`http://localhost:8010/flaky/control/${state}`);
+	await res.text();
+}
+
+describe('Retry failed crawl (recursive, default)', () => {
+	let filePath: string;
+	let cwd: string;
+	let accessor: Archive;
+
+	beforeAll(async () => {
+		// 1) Baseline crawl while /flaky/recoverable returns 500. The page is
+		//    recorded with status 500 and its (healed-only) child stays unseen.
+		await setFlakyState('reset');
+		const baseline = await crawlAndPersist(['http://localhost:8010/flaky/']);
+		filePath = baseline.filePath;
+		cwd = baseline.cwd;
+
+		// 2) Heal the endpoint, then retry the failed pages. The 5xx page is
+		//    reset, re-fetched as a 200, and its newly-exposed child is crawled.
+		await setFlakyState('heal');
+		const orchestrator = await CrawlerOrchestrator.retryFailed(filePath, { cwd });
+		await orchestrator.write();
+		await orchestrator.archive.close();
+		orchestrator.garbageCollect();
+
+		accessor = await Archive.open({ filePath, cwd });
+	}, 240_000);
+
+	afterAll(async () => {
+		await accessor?.close();
+		await fs.rm(cwd, { recursive: true, force: true });
+		await setFlakyState('reset');
+	});
+
+	it('the recoverable 5xx page is re-fetched and now records status 200', async () => {
+		const pages = await accessor.getPages('page');
+		const recoverable = pages.find((p) => p.url.pathname === '/flaky/recoverable');
+		expect(recoverable).toBeDefined();
+		expect(recoverable!.status).toBe(200);
+	});
+
+	it('a URL discovered only after recovery is crawled as a full internal page', async () => {
+		const pages = await accessor.getPages('page');
+		const child = pages.find((p) => p.url.pathname === '/flaky/healed-child');
+		expect(child).toBeDefined();
+		expect(child!.isExternal).toBe(false);
+		expect(child!.isTarget).toBe(true);
+	});
+
+	it('removes the .bak backup file once the retry succeeds', async () => {
+		const exists = await fs
+			.stat(filePath + '.bak')
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
+});
+
+describe('Retry failed crawl (--no-recursive)', () => {
+	let filePath: string;
+	let cwd: string;
+	let accessor: Archive;
+
+	beforeAll(async () => {
+		await setFlakyState('reset');
+		const baseline = await crawlAndPersist(['http://localhost:8010/flaky/']);
+		filePath = baseline.filePath;
+		cwd = baseline.cwd;
+
+		await setFlakyState('heal');
+		const orchestrator = await CrawlerOrchestrator.retryFailed(filePath, {
+			cwd,
+			recursive: false,
+		});
+		await orchestrator.write();
+		await orchestrator.archive.close();
+		orchestrator.garbageCollect();
+
+		accessor = await Archive.open({ filePath, cwd });
+	}, 240_000);
+
+	afterAll(async () => {
+		await accessor?.close();
+		await fs.rm(cwd, { recursive: true, force: true });
+		await setFlakyState('reset');
+	});
+
+	it('still re-fetches the failed page itself (status 200)', async () => {
+		const pages = await accessor.getPages('page');
+		const recoverable = pages.find((p) => p.url.pathname === '/flaky/recoverable');
+		expect(recoverable).toBeDefined();
+		expect(recoverable!.status).toBe(200);
+	});
+
+	it('does not crawl newly-discovered URLs as full pages', async () => {
+		const pages = await accessor.getPages('page');
+		const child = pages.find((p) => p.url.pathname === '/flaky/healed-child');
+		expect(child).toBeUndefined();
+	});
+});
+
+describe('Retry failed crawl: list-mode rejection', () => {
+	let filePath: string;
+	let cwd: string;
+
+	beforeAll(async () => {
+		await setFlakyState('reset');
+		const baseline = await crawlAndPersist(['http://localhost:8010/flaky/']);
+		filePath = baseline.filePath;
+		cwd = baseline.cwd;
+
+		const archive = await Archive.open({ filePath, cwd });
+		await archive.updateConfig({ fromList: true });
+		await archive.write();
+		await archive.close();
+	}, 120_000);
+
+	afterAll(async () => {
+		await fs.rm(cwd, { recursive: true, force: true });
+		await setFlakyState('reset');
+	});
+
+	it('throws a helpful error when retrying a list-mode archive', async () => {
+		await expect(CrawlerOrchestrator.retryFailed(filePath, { cwd })).rejects.toThrow(
+			'Cannot retry a list-mode archive: this archive was created with --list/--list-file and contains metadata-only pages. Create a fresh archive instead.',
+		);
+	}, 120_000);
+});

--- a/packages/test-server/src/routes/flaky.ts
+++ b/packages/test-server/src/routes/flaky.ts
@@ -1,0 +1,58 @@
+import type { Hono } from 'hono';
+
+/** Whether `/flaky/recoverable` is currently healed (serves 200) or failing (500). */
+let healed = false;
+
+/**
+ * Registers routes that simulate a transient (recoverable) crawl failure for
+ * exercising `crawl --retry-failed`.
+ *
+ * `/flaky/recoverable` returns `500` until `/flaky/control/heal` is hit, after
+ * which it returns `200` and exposes a child link (`/flaky/healed-child`) that
+ * is undiscoverable while the page is failing. The healed/failing state lives
+ * in a module variable so an E2E test can flip it over HTTP between the
+ * baseline crawl and the retry, independent of process boundaries.
+ * @param app - The Hono application instance to register routes on.
+ */
+export function flakyRoutes(app: Hono) {
+	app.get('/flaky/control/heal', (c) => {
+		healed = true;
+		return c.text('healed');
+	});
+
+	app.get('/flaky/control/reset', (c) => {
+		healed = false;
+		return c.text('reset');
+	});
+
+	app.get('/flaky/', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Flaky Top</title></head><body>' +
+				'<a href="/flaky/recoverable">Recoverable</a>' +
+				'</body></html>',
+		),
+	);
+
+	app.get('/flaky/recoverable', (c) =>
+		healed
+			? c.html(
+					'<!doctype html><html lang="en"><head><title>Recovered</title></head><body>' +
+						'<a href="/flaky/healed-child">Healed Child</a>' +
+						'</body></html>',
+				)
+			: c.html(
+					'<!doctype html><html lang="en"><head><title>Server Error</title></head><body>' +
+						'<p>temporary failure</p>' +
+						'</body></html>',
+					500,
+				),
+	);
+
+	app.get('/flaky/healed-child', (c) =>
+		c.html(
+			'<!doctype html><html lang="en"><head><title>Healed Child</title></head><body>' +
+				'<p>only reachable after the recoverable page heals</p>' +
+				'</body></html>',
+		),
+	);
+}

--- a/packages/test-server/src/server.ts
+++ b/packages/test-server/src/server.ts
@@ -6,6 +6,7 @@ import { Hono } from 'hono';
 import { basicRoutes } from './routes/basic.js';
 import { errorStatusRoutes } from './routes/error-status.js';
 import { excludeRoutes } from './routes/exclude.js';
+import { flakyRoutes } from './routes/flaky.js';
 import { metaRoutes } from './routes/meta.js';
 import { optionsRoutes } from './routes/options.js';
 import { paginationRoutes } from './routes/pagination.js';
@@ -33,6 +34,7 @@ export function createApp() {
 	paginationRoutes(app);
 	scrollJackRoutes(app);
 	resourceReuseRoutes(app);
+	flakyRoutes(app);
 	return app;
 }
 


### PR DESCRIPTION
## 概要

`crawl <archive> --retry-failed` を追加。前回クロールで失敗したページだけを再取得するモード。「サーバ側の一時障害やタイムアウトで取りこぼしたページを、フルクロールし直さずに回収する」ためのもの。

## 振る舞い

- **再取得対象**: `status = -1`（ネットワークエラー/タイムアウト/ブラウザクラッシュの sentinel）/ `status IS NULL` / `contentType IS NULL` / `status` が 5xx のページ。確定応答の 4xx は対象外。internal / external 両方（external は metadata-only 再取得）。
- **再クロール**: 再取得したページが HTML なら新リンクを辿り、未取得の新 URL があればそこから再帰クロール（デフォルト ON）。`--no-recursive` で「失敗ページの再取得のみ」に限定。recursive はフラグ値が優先され、アーカイブ作成時の設定は継承しない（grill-me で合意）。
- **設定流用**: scope・除外（`--exclude` 系）・User-Agent などはアーカイブ保存値を流用し、明示指定したフラグのみ上書き（既存 resume/append と同じ仕組み）。
- **安全性**: クロール開始前に `<archive>.bak` を作成、失敗時は自動復元・成功時は削除。list-mode archive への retry は不可。`--resume`/`--append`/`--diff`/`--output`/`--list`/`--list-file`/`--single` と同時指定不可。

## 実装

- `Database.resetFailedPages` / `Archive.resetFailedPages`: 失敗ページを `scraped=0` に戻し、`anchors`/`images`/`resources-referrers`/`page_errors` を削除。
- `CrawlerOrchestrator.retryFailed`: append と同じ再オープン + `.bak` + `Crawler.resume()` + `crawling()` フロー。archived roots を seed にし、失敗ページは resumedPending 経由で処理（external を scope に誤登録しない）。
- `Crawler.start` の resume 判定を `#resumedScraped` だけでなく `#resumedPending` も見るよう修正。全ページ失敗 retry（reset 後に scraped が空）や「1ページもスクレイプせず中断した resume」を fresh crawl と誤判定して pending を全部捨てるバグを修正。
- `crawling(list, { recursive })`: recursive を明示注入できるオプションを追加。

## テスト

- `database.spec.ts`: `resetFailedPages` の判定（-1/NULL/5xx、4xx・skipped・redirect-source・pending の除外、internal/external、関連行削除、500行チャンク境界）。
- `crawler.spec.ts`: 全ページ失敗時に resumedPending を取りこぼさない回帰テスト。
- `crawl.spec.ts`: dispatch と相互排他バリデーション。
- `retry-failed.e2e.ts`: flaky ルートで 500→治癒→200 の recovery、recursive/非recursive の差、list-mode 拒否。
- lint / build / unit(1579) / e2e(102) すべて green。

## 既知の制約（フォローアップ候補・本 PR スコープ外）

- external 失敗ページを retry すると `LinkList.resume` が metadata-only フラグを復元しないためフルレンダリングされる（resume/append と共通の既存挙動）。
- `append` / `retryFailed` の再オープン + `.bak` 復元ロジック、`resetFailedPages` / `repromoteExternalPages` のチャンク更新ループに重複あり。共通ヘルパー抽出は既存コードへの波及を避けるため別 PR に分離。

🤖 Generated with [Claude Code](https://claude.com/claude-code)