### PR TITLE
feat: classify crawl failures by cause (query error-kinds + viewer Errors view)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ npx @nitpicker/cli -v | --version                       # `@nitpicker/cli` の�
 
 > **Note**: `-v` / `--version` は `argv[0]` の位置でのみ判定する。`crawl -v` のようにサブコマンドの後ろに置いた場合はそのコマンドのフラグとして解釈される（`@d-zero/roar` の仕様）。
 
+> **エラー原因分類（`query error-kinds` / viewer Errors ビュー）**: クロール失敗を 8 種（dns / connection-refused / connection-reset / connection-timeout / tls / timeout / protocol / unknown）に分類する。**kind は保存せず読み取り時に `classifyErrorKind(message)`（`@nitpicker/query`）で導出**するため、この機能より前のアーカイブもそのまま分類できる（分類ロジックが 1 箇所に集約され、capture 時と read 時で必ず一致する）。失敗は 2 系統: スクレイプ経路は `page_errors`、crawler レベルの `error` チャネル（DNS/接続/TLS）は構造化テーブル **`crawl_errors`**（`Archive.addError` が `error.log` と両方へ記録、`migrateCrawlErrors` で既存アーカイブに後付け）。`getErrorKinds` は `crawl_errors` に行があればそれを、無ければ（テーブル不在 **または空**）`error.log` をパースしてフォールバックする（空フォールバックが無いと、migration で空テーブルだけ作られた legacy アーカイブのエラーが読まれず消える）。`crawl_errors` は read-only 接続では `migrateCrawlErrors` が走らないため作られない（stub viewer は error.log フォールバックで分類）。
+
 ## 主要アーキテクチャ
 
 ### データフロー（crawl）

--- a/README.md
+++ b/README.md
@@ -120,11 +120,17 @@ npx @nitpicker/cli pipeline <URL> --sheet <URL> --all
 npx @nitpicker/cli query <file> <sub-command> [options]
 ```
 
-サブコマンド: `summary` / `pages` / `page-detail` / `html` / `links` / `resources` / `images` / `violations` / `duplicates` / `mismatches` / `headers` / `resource-referrers`。詳細は `--help`。
+サブコマンド: `summary` / `pages` / `page-detail` / `html` / `links` / `resources` / `images` / `violations` / `duplicates` / `mismatches` / `headers` / `resource-referrers` / `error-kinds`。詳細は `--help`。
 
 ### `--contentTypeCategory`
 
 `pages` のみで使える。**指定時は既定の HTML-or-null ベースフィルタを外し、PDF など非 HTML 行も列挙する**。カテゴリ判定は `@nitpicker/query` の `classifyContentType` ルール表に集約され、Summary チャートと Pages フィルタが同じ行を同じカテゴリに数える。
+
+### `error-kinds`: クロール失敗の原因分類
+
+クロール失敗を原因別（`dns` / `connection-refused` / `connection-reset` / `connection-timeout` / `tls` / `timeout` / `protocol` / `unknown`）に集計する。DNS 解決失敗や接続拒否が、ただの「タイムアウト/不明」に埋もれず区別できる。kind 別件数 + ホスト別内訳 + サンプル URL を JSON で返す。
+
+原因の判定（`classifyErrorKind`）は **保存された値ではなく `message` から読み取り時に行う**ため、この機能より前に作成した既存アーカイブもそのまま分類できる。失敗の取得元は 2 系統: スクレイプ経路の失敗は `page_errors`、DNS/接続/TLS など crawler レベルの失敗は構造化テーブル `crawl_errors`（無い古いアーカイブでは `error.log` を読んでフォールバック）。応答しないページが per-property の累積タイムアウトで `timeout` に倒れる現象は beholder 側の既知課題（`getMeta` の逐次取得）。
 
 ## Viewer
 
@@ -141,6 +147,10 @@ npx @nitpicker/cli viewer <file-or-stub-dir> [--port 9000] [--no-open]
 ### 仮想スクロール
 
 ページ一覧は サーバ側ページネーション（`limit`/`offset`）+ TanStack Query infinite query + TanStack Virtual の組み合わせで、**10 万行規模をクライアント全件ロードせず一定メモリで表示**する。
+
+### Errors ビュー
+
+`query error-kinds` と同じ集計をブラウザで表示する。kind 別のバーを選ぶと、その原因で失敗したホスト内訳とサンプル URL にドリルダウンできる。サンプル URL は（解決失敗・接続拒否など本来開けない URL なので）リンクではなく診断用のテキストとして表示する。
 
 ### HTML スナップショットプレビュー
 

--- a/packages/@nitpicker/cli/src/query/dispatch-query.ts
+++ b/packages/@nitpicker/cli/src/query/dispatch-query.ts
@@ -23,6 +23,7 @@ import {
 	findMismatches,
 	checkHeaders,
 	getResourceReferrers,
+	getErrorKinds,
 } from '@nitpicker/query';
 
 import { mapFlagsToQueryOptions } from './map-flags-to-query-options.js';
@@ -112,6 +113,9 @@ export async function dispatchQuery(
 				throw new Error(`Resource not found: ${url}`);
 			}
 			return result;
+		}
+		case 'error-kinds': {
+			return getErrorKinds(accessor);
 		}
 		default: {
 			const _exhaustive: never = subCommand;

--- a/packages/@nitpicker/cli/src/query/map-flags-to-query-options.ts
+++ b/packages/@nitpicker/cli/src/query/map-flags-to-query-options.ts
@@ -174,6 +174,10 @@ export function mapFlagsToQueryOptions(
 			}
 			return { url: flags.url };
 		}
+		case 'error-kinds': {
+			// No options: the aggregation always covers the whole archive.
+			return {};
+		}
 		default: {
 			const _exhaustive: never = subCommand;
 			throw new Error(`Unknown sub-command: ${String(_exhaustive)}`);

--- a/packages/@nitpicker/cli/src/query/types.ts
+++ b/packages/@nitpicker/cli/src/query/types.ts
@@ -13,7 +13,8 @@ export type QuerySubCommand =
 	| 'duplicates'
 	| 'mismatches'
 	| 'headers'
-	| 'resource-referrers';
+	| 'resource-referrers'
+	| 'error-kinds';
 
 /**
  * List of all valid query sub-command names.
@@ -31,4 +32,5 @@ export const VALID_SUB_COMMANDS = [
 	'mismatches',
 	'headers',
 	'resource-referrers',
+	'error-kinds',
 ] as const satisfies readonly QuerySubCommand[];

--- a/packages/@nitpicker/crawler/src/archive/archive.ts
+++ b/packages/@nitpicker/crawler/src/archive/archive.ts
@@ -101,7 +101,13 @@ export default class Archive extends ArchiveAccessor {
 	abort() {}
 
 	/**
-	 * Appends an error entry to the archive's error log file.
+	 * Records a crawler-level error to both the human-readable `error.log` (full
+	 * stack, for debugging) and the structured `crawl_errors` table (queryable,
+	 * for the `error-kinds` analysis). The cause is not classified here — it is
+	 * derived on read. `error.log` keeps the full stack while `crawl_errors`
+	 * stores `error.message`; both normally carry the same cause token (e.g.
+	 * `ENOTFOUND`), so classification agrees across the two — only an error whose
+	 * cause lives solely in deeper stack frames could differ.
 	 * @param error - The crawler error object containing process and URL information.
 	 */
 	async addError(error: CrawlerError) {
@@ -110,6 +116,7 @@ export default class Archive extends ArchiveAccessor {
 			logFile,
 			`[${error.pid}(${error.isMainProcess ? 'main' : 'sub'})] ${error.url} ${error.error.stack ?? error.error}`,
 		);
+		await this.#db.insertCrawlError(error.url, error.error.message, error.isExternal);
 	}
 
 	/**

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -35,6 +35,7 @@ import { getJSON } from './get-json.js';
 import { initSchema } from './init-schema.js';
 import { LibsqlDialect } from './libsql-dialect.js';
 import { limitedPageIds } from './limited-page-ids.js';
+import { migrateCrawlErrors } from './migrate-crawl-errors.js';
 import { migrateInfoRoots } from './migrate-info-roots.js';
 import { migratePageErrors } from './migrate-page-errors.js';
 import { redirectTable } from './redirect-table.js';
@@ -617,6 +618,28 @@ export class Database extends EventEmitter<DatabaseEvent> {
 	}
 
 	/**
+	 * Records a crawler-level (`error` channel) failure into `crawl_errors`.
+	 *
+	 * Unlike {@link insertPageError} this is not tied to a scraped page: `url`
+	 * may be an external link that never became a page row, or `null` for a
+	 * process-level error. The cause is intentionally not stored — it is derived
+	 * on read so that older archives (which only have `error.log`) and freshly
+	 * captured rows classify identically.
+	 * @param url - The URL the error is about, or `null` for a process-level error.
+	 * @param message - The error message (one line is enough for classification).
+	 * @param isExternal - Whether the URL is external to the crawl scope.
+	 */
+	@ErrorEmitter()
+	@retry(retrySetting)
+	async insertCrawlError(url: string | null, message: string, isExternal = false) {
+		await this.#instance('crawl_errors').insert({
+			url,
+			isExternal: isExternal ? 1 : 0,
+			message,
+			createdAt: Date.now(),
+		});
+	}
+	/**
 	 * Records a partial scrape failure against the page identified by `url`.
 	 *
 	 * The page row is resolved (or inserted as a stub) via
@@ -643,6 +666,7 @@ export class Database extends EventEmitter<DatabaseEvent> {
 			createdAt: Date.now(),
 		});
 	}
+
 	/**
 	 * Inserts a sub-resource into the `resources` table.
 	 * Ignores duplicate URLs (uses `ON CONFLICT IGNORE`).
@@ -1140,6 +1164,7 @@ export class Database extends EventEmitter<DatabaseEvent> {
 		await initSchema(this.#instance);
 		await migrateInfoRoots(this.#instance);
 		await migratePageErrors(this.#instance);
+		await migrateCrawlErrors(this.#instance);
 	}
 	/**
 	 * Upserts page data into the `pages` table (inserts if new, updates if existing).

--- a/packages/@nitpicker/crawler/src/archive/init-schema.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.ts
@@ -138,5 +138,19 @@ export async function initSchema(instance: Knex) {
 			t.integer('createdAt').notNullable();
 
 			t.index('pageId');
+		})
+		.createTable('crawl_errors', (t) => {
+			// Structured form of the crawler-level `error` channel that otherwise
+			// only lands in `error.log`. Unlike `page_errors` these are not tied to
+			// a scraped page (the URL may be an external link that failed DNS, or
+			// null for a process-level error), so there is no `pageId` FK and `url`
+			// is nullable. The cause is NOT stored — it is classified on read from
+			// `message` so older archives (which only have `error.log`) classify the
+			// same way.
+			t.increments('id');
+			t.string('url', 8190).nullable();
+			t.boolean('isExternal');
+			t.text('message').notNullable();
+			t.integer('createdAt').notNullable();
 		});
 }

--- a/packages/@nitpicker/crawler/src/archive/migrate-crawl-errors.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-crawl-errors.ts
@@ -1,0 +1,40 @@
+import type { Knex } from 'knex';
+
+/**
+ * Adds the `crawl_errors` table to archives created before structured capture
+ * of the crawler-level `error` channel landed.
+ *
+ * `crawl_errors` records errors that previously only reached `error.log` (DNS
+ * failures, connection resets, TLS problems, process-level errors), in a
+ * queryable form so the `error-kinds` analysis can classify them without
+ * parsing the text log. Older `.nitpicker` files predate this table; this
+ * migration creates it idempotently. Existing archives stay empty until they
+ * are crawled again (resume / append / retry), at which point new errors are
+ * written here — analysis of pre-existing data falls back to parsing
+ * `error.log`.
+ *
+ * Idempotent: when the table already exists, the function exits without
+ * touching the schema or writing to stderr. It also skips empty archives (no
+ * `pages` table), which the regular initSchema path will fully provision.
+ * @param instance - The Knex query builder instance connected to the database.
+ */
+export async function migrateCrawlErrors(instance: Knex): Promise<void> {
+	const hasTable = await instance.schema.hasTable('crawl_errors');
+	if (hasTable) {
+		return;
+	}
+	const hasPages = await instance.schema.hasTable('pages');
+	if (!hasPages) {
+		// Empty archive; the regular initSchema path will create the table.
+		return;
+	}
+	await instance.schema.createTable('crawl_errors', (t) => {
+		t.increments('id');
+		t.string('url', 8190).nullable();
+		t.boolean('isExternal');
+		t.text('message').notNullable();
+		t.integer('createdAt').notNullable();
+	});
+	// eslint-disable-next-line no-console
+	console.error('[migrate] crawl_errors table created');
+}

--- a/packages/@nitpicker/query/src/classify-error-kind.spec.ts
+++ b/packages/@nitpicker/query/src/classify-error-kind.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+
+import { classifyErrorKind } from './classify-error-kind.js';
+
+describe('classifyErrorKind', () => {
+	it('classifies DNS resolution failures as dns', () => {
+		expect(classifyErrorKind('getaddrinfo ENOTFOUND www.example.com')).toBe('dns');
+		expect(classifyErrorKind('Error: getaddrinfo EAI_AGAIN example.com')).toBe('dns');
+		expect(classifyErrorKind('net::ERR_NAME_NOT_RESOLVED at https://example.com')).toBe(
+			'dns',
+		);
+	});
+
+	it('classifies TLS/certificate failures as tls', () => {
+		expect(classifyErrorKind('net::ERR_CERT_DATE_INVALID')).toBe('tls');
+		expect(classifyErrorKind('Error: unable to verify the first certificate')).toBe(
+			'tls',
+		);
+		expect(classifyErrorKind('net::ERR_SSL_PROTOCOL_ERROR')).toBe('tls');
+	});
+
+	it('classifies connection-refused as connection-refused', () => {
+		expect(classifyErrorKind('connect ECONNREFUSED 127.0.0.1:443')).toBe(
+			'connection-refused',
+		);
+		expect(classifyErrorKind('net::ERR_CONNECTION_REFUSED')).toBe('connection-refused');
+	});
+
+	it('classifies connection resets and empty responses as connection-reset', () => {
+		expect(classifyErrorKind('read ECONNRESET')).toBe('connection-reset');
+		expect(classifyErrorKind('Error: socket hang up')).toBe('connection-reset');
+		expect(classifyErrorKind('net::ERR_EMPTY_RESPONSE')).toBe('connection-reset');
+	});
+
+	it('classifies transport-level timeouts as connection-timeout (not page timeout)', () => {
+		expect(classifyErrorKind('connect ETIMEDOUT 93.184.216.34:443')).toBe(
+			'connection-timeout',
+		);
+		expect(classifyErrorKind('net::ERR_CONNECTION_TIMED_OUT')).toBe('connection-timeout');
+	});
+
+	it('classifies puppeteer/page timeouts as timeout', () => {
+		expect(
+			classifyErrorKind(
+				'Scraper.#fetchData: gave up after 3 retries — Race 180,000ms vs Scraper.#fetchData',
+			),
+		).toBe('timeout');
+		expect(classifyErrorKind('Navigation timeout of 60000 ms exceeded')).toBe('timeout');
+		expect(
+			classifyErrorKind('TimeoutError: waiting failed: timeout 30000ms exceeded'),
+		).toBe('timeout');
+	});
+
+	it('classifies puppeteer protocol/lifecycle failures as protocol', () => {
+		expect(
+			classifyErrorKind('Protocol error (DOM.describeNode): Cannot find context'),
+		).toBe('protocol');
+		expect(classifyErrorKind('Execution context was destroyed')).toBe('protocol');
+		expect(classifyErrorKind('Protocol error (Page.reload): Target closed')).toBe(
+			'protocol',
+		);
+		expect(classifyErrorKind('Navigating frame was detached')).toBe('protocol');
+		expect(classifyErrorKind('The method Page.goto returned null')).toBe('protocol');
+	});
+
+	it('falls back to unknown when no matcher applies', () => {
+		expect(classifyErrorKind('something completely unexpected happened')).toBe('unknown');
+		expect(classifyErrorKind('')).toBe('unknown');
+	});
+
+	it('prefers the transport cause over the page-timeout bucket', () => {
+		// A message carrying ETIMEDOUT must not be mislabelled as a page timeout.
+		expect(classifyErrorKind('net::ERR_CONNECTION_TIMED_OUT, timeout exceeded')).toBe(
+			'connection-timeout',
+		);
+	});
+});

--- a/packages/@nitpicker/query/src/classify-error-kind.ts
+++ b/packages/@nitpicker/query/src/classify-error-kind.ts
@@ -1,0 +1,67 @@
+import type { ErrorKind } from './types.js';
+
+/**
+ * Ordered message matchers. The first pattern that matches wins, so more
+ * specific transport causes (DNS, TLS, connection-*) are tested before the
+ * broader `protocol` / `timeout` buckets — e.g. `ETIMEDOUT` must classify as
+ * `connection-timeout`, not the page-level `timeout`, and a puppeteer
+ * `Protocol error` must not be swallowed by the `timeout` matcher.
+ */
+const MATCHERS: readonly { readonly kind: ErrorKind; readonly pattern: RegExp }[] = [
+	{
+		kind: 'dns',
+		pattern:
+			/ENOTFOUND|EAI_AGAIN|getaddrinfo|ERR_NAME_NOT_RESOLVED|ERR_NAME_RESOLUTION_FAILED/i,
+	},
+	{
+		kind: 'tls',
+		pattern:
+			/ERR_CERT|ERR_SSL|\bCERT_|SSL routines|ERR_BAD_SSL|UNABLE_TO_VERIFY|unable to verify|self.signed certificate|\bERR_TLS/i,
+	},
+	{ kind: 'connection-refused', pattern: /ECONNREFUSED|ERR_CONNECTION_REFUSED/i },
+	{
+		kind: 'connection-reset',
+		pattern:
+			/ECONNRESET|socket hang up|ERR_CONNECTION_RESET|ERR_CONNECTION_CLOSED|ERR_EMPTY_RESPONSE/i,
+	},
+	{
+		kind: 'connection-timeout',
+		pattern: /ETIMEDOUT|ERR_CONNECTION_TIMED_OUT|ERR_TIMED_OUT/i,
+	},
+	{
+		kind: 'protocol',
+		pattern:
+			/Protocol error|Target closed|Session closed|Execution context was destroyed|frame (?:was |got )?detached|Navigating frame was detached|Cannot find context|Node with given id|Page\.\w+ returned/i,
+	},
+	{
+		kind: 'timeout',
+		pattern:
+			/Race \d|Navigation timeout|timeout of \d+\s*ms exceeded|TimeoutError|Timed out/i,
+	},
+];
+
+/**
+ * Classify a raw crawler/scraper error message into a coarse {@link ErrorKind}.
+ *
+ * Pure and deterministic: the same message always yields the same kind, which
+ * is why the kind is derived on read rather than persisted — it can be applied
+ * uniformly to freshly captured `crawl_errors`, legacy `error.log` lines, and
+ * `page_errors` alike.
+ * @param message - The raw error message (a single line is sufficient; the
+ *   cause token such as `ENOTFOUND` or `Navigation timeout` lives there).
+ * @returns The matched kind, or `unknown` when no matcher applies.
+ * @example
+ * ```ts
+ * classifyErrorKind('getaddrinfo ENOTFOUND www.example.com'); // 'dns'
+ * classifyErrorKind('gave up after 3 retries — Race 180,000ms'); // 'timeout'
+ * classifyErrorKind('Protocol error (Page.reload): Target closed'); // 'protocol'
+ * ```
+ */
+export function classifyErrorKind(message: string): ErrorKind {
+	for (const { kind, pattern } of MATCHERS) {
+		if (pattern.test(message)) {
+			return kind;
+		}
+	}
+	return 'unknown';
+}

--- a/packages/@nitpicker/query/src/get-error-kinds.spec.ts
+++ b/packages/@nitpicker/query/src/get-error-kinds.spec.ts
@@ -1,0 +1,211 @@
+import type { CrawlerError } from '@nitpicker/crawler';
+
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { Archive } from '@nitpicker/crawler';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getErrorKinds } from './get-error-kinds.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_error_kinds__');
+
+/**
+ * Minimal config so {@link Archive.create} has a valid `info` row.
+ * @returns A config object accepted by `Archive.setConfig`.
+ */
+function baseConfig() {
+	return {
+		baseUrl: 'https://example.com',
+		name: 'test',
+		version: '0.0.0',
+		recursive: true,
+		interval: 0,
+		image: false,
+		fetchExternal: true,
+		parallels: 1,
+		roots: ['https://example.com'],
+		excludes: [],
+		excludeKeywords: [],
+		excludeUrls: [],
+		maxExcludedDepth: 0,
+		retry: 3,
+		fromList: false,
+		disableQueries: false,
+		userAgent: 'test',
+		ignoreRobots: false,
+	};
+}
+
+/**
+ * Build a `CrawlerError` for the crawler-level `error` channel.
+ * @param url - The URL the error is about, or `null` for a process-level error.
+ * @param message - The raw error message.
+ * @param isExternal - Whether the URL is external.
+ * @returns A `CrawlerError` accepted by `Archive.addError`.
+ */
+function crawlerError(
+	url: string | null,
+	message: string,
+	isExternal = false,
+): CrawlerError {
+	return { pid: 1, isMainProcess: true, url, isExternal, error: new Error(message) };
+}
+
+describe('getErrorKinds', () => {
+	let archive: InstanceType<typeof Archive> | undefined;
+
+	afterEach(async () => {
+		if (archive) {
+			await archive.close();
+			archive = undefined;
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('classifies and aggregates page_errors + crawl_errors, sourced from crawl_errors', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'capture.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		// Scrape-path failure → page_errors (timeout).
+		await archive.addPageError(
+			'https://example.com/slow',
+			'retryExhausted',
+			'gave up after 3 retries — Race 180,000ms vs Scraper.#fetchData',
+			false,
+		);
+		// Crawler-level failures → crawl_errors (dns + connection-refused).
+		await archive.addError(
+			crawlerError(
+				'http://ext.example.net/x',
+				'getaddrinfo ENOTFOUND ext.example.net',
+				true,
+			),
+		);
+		await archive.addError(
+			crawlerError('https://api.example.org/', 'connect ECONNREFUSED 10.0.0.1:443', true),
+		);
+
+		const result = await getErrorKinds(archive);
+
+		expect(result.channelSource).toBe('crawl_errors');
+		expect(result.total).toBe(3);
+
+		const byKind = new Map(result.groups.map((g) => [g.kind, g]));
+		expect(byKind.get('timeout')?.count).toBe(1);
+		expect(byKind.get('timeout')?.hosts).toEqual([{ host: 'example.com', count: 1 }]);
+		expect(byKind.get('dns')?.count).toBe(1);
+		expect(byKind.get('dns')?.hosts).toEqual([{ host: 'ext.example.net', count: 1 }]);
+		expect(byKind.get('dns')?.sampleUrls).toEqual(['http://ext.example.net/x']);
+		expect(byKind.get('connection-refused')?.count).toBe(1);
+	});
+
+	it('groups are sorted by count, most failures first', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'sorted.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		await archive.addError(crawlerError('https://a.example.com/', 'Race 180,000ms'));
+		await archive.addError(
+			crawlerError('https://b.example.com/', 'Navigation timeout of 60000 ms exceeded'),
+		);
+		await archive.addError(
+			crawlerError('https://c.example.net/', 'getaddrinfo ENOTFOUND c.example.net'),
+		);
+
+		const result = await getErrorKinds(archive);
+
+		expect(result.groups[0]!.kind).toBe('timeout');
+		expect(result.groups[0]!.count).toBe(2);
+		expect(result.groups[1]!.kind).toBe('dns');
+	});
+
+	it('falls back to parsing error.log when the crawl_errors table is absent', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'legacy.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		// Simulate an archive crawled before structured capture: drop the table
+		// and leave only a text error.log (the format addError writes).
+		await archive.getKnex().schema.dropTable('crawl_errors');
+		await writeFile(
+			path.join(archive.tmpDir, 'error.log'),
+			[
+				'[123(main)] http://dead.example.net/ Error: getaddrinfo ENOTFOUND dead.example.net',
+				'    at node:dns:122:26',
+				'[123(main)] null Error: socket hang up',
+				'    at node:_http_client:526:25',
+			].join('\n'),
+			'utf8',
+		);
+
+		const result = await getErrorKinds(archive);
+
+		expect(result.channelSource).toBe('error.log');
+		const byKind = new Map(result.groups.map((g) => [g.kind, g]));
+		expect(byKind.get('dns')?.count).toBe(1);
+		expect(byKind.get('dns')?.hosts).toEqual([{ host: 'dead.example.net', count: 1 }]);
+		// A process-level error logged with a `null` URL buckets under (unknown).
+		expect(byKind.get('connection-reset')?.count).toBe(1);
+		expect(byKind.get('connection-reset')?.hosts).toEqual([
+			{ host: '(unknown)', count: 1 },
+		]);
+	});
+
+	it('falls back to error.log when crawl_errors exists but is empty (migrated legacy archive)', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'migrated.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		// The table exists (as a migration would leave it) but holds no rows,
+		// while the legacy errors still live only in error.log.
+		expect(await archive.getKnex().schema.hasTable('crawl_errors')).toBe(true);
+		await writeFile(
+			path.join(archive.tmpDir, 'error.log'),
+			'[1(main)] http://dead.example.net/ Error: getaddrinfo ENOTFOUND dead.example.net\n',
+			'utf8',
+		);
+
+		const result = await getErrorKinds(archive);
+
+		expect(result.channelSource).toBe('error.log');
+		expect(result.total).toBe(1);
+		expect(result.groups[0]!.kind).toBe('dns');
+	});
+
+	it('reports channelSource none and empty groups for a clean archive', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'clean.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		const result = await getErrorKinds(archive);
+
+		expect(result.total).toBe(0);
+		expect(result.channelSource).toBe('none');
+		expect(result.groups).toEqual([]);
+	});
+});

--- a/packages/@nitpicker/query/src/get-error-kinds.ts
+++ b/packages/@nitpicker/query/src/get-error-kinds.ts
@@ -1,0 +1,201 @@
+import type { ErrorKind, ErrorKindGroup, ErrorKindsResult } from './types.js';
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { classifyErrorKind } from './classify-error-kind.js';
+
+/** Upper bound on representative URLs kept per {@link ErrorKindGroup}. */
+const MAX_SAMPLE_URLS = 50;
+
+/** One failure record before aggregation. */
+interface ErrorRecord {
+	/** URL the failure is about, or `null` when unknown / process-level. */
+	url: string | null;
+	/** Raw message used to classify the cause. */
+	message: string;
+}
+
+/** Mutable accumulator for a single {@link ErrorKind} while aggregating. */
+interface KindAccumulator {
+	/** Total records classified into this kind. */
+	count: number;
+	/** host → count. */
+	hosts: Map<string, number>;
+	/** Capped representative URLs. */
+	sampleUrls: string[];
+}
+
+/**
+ * Extract the hostname from a URL string, or a sentinel when it is absent or
+ * unparsable — keeps host aggregation total without throwing on odd inputs.
+ * @param url - The URL string, possibly `null`.
+ * @returns The hostname, `(unknown)` for `null`, or `(invalid)` when parsing fails.
+ */
+function hostOf(url: string | null): string {
+	if (!url) {
+		return '(unknown)';
+	}
+	try {
+		return new URL(url).host || '(invalid)';
+	} catch {
+		return '(invalid)';
+	}
+}
+
+/**
+ * Read scrape-path failures from `page_errors`, joined to `pages` for the URL.
+ * Older archives may predate the table, so existence is checked first.
+ * @param accessor - The opened archive accessor.
+ * @returns Failure records (possibly empty).
+ */
+async function readPageErrors(accessor: ArchiveAccessor): Promise<ErrorRecord[]> {
+	const knex = accessor.getKnex();
+	if (!(await knex.schema.hasTable('page_errors'))) {
+		return [];
+	}
+	const rows = await knex('page_errors as e')
+		.leftJoin('pages as p', 'p.id', 'e.pageId')
+		.select('p.url as url', 'e.message as message');
+	return rows.map((r: { url: string | null; message: string }) => ({
+		url: r.url ?? null,
+		message: r.message,
+	}));
+}
+
+/**
+ * Parse `error.log` entries (`[pid(main)] <url> <message…>`) for archives that
+ * predate the `crawl_errors` table. Only the first line of each entry is read —
+ * the cause token lives there; stack-trace continuation lines are ignored.
+ * @param tmpDir - The accessor's working directory holding `error.log`.
+ * @returns Failure records, or empty when the log is missing.
+ */
+async function readErrorLog(tmpDir: string): Promise<ErrorRecord[]> {
+	let text: string;
+	try {
+		text = await readFile(path.join(tmpDir, 'error.log'), 'utf8');
+	} catch {
+		return [];
+	}
+	const records: ErrorRecord[] = [];
+	// Match only the `[pid(main|sub)] ` header, then split the remainder by hand:
+	// a single regex with two greedy trailing groups (`(\S+)\s*(.*)`) is flagged
+	// for super-linear backtracking, and slicing is both linear and clearer.
+	const header = /^\[\d+\((?:main|sub)\)\]\s+/;
+	for (const line of text.split('\n')) {
+		const match = header.exec(line);
+		if (!match) {
+			continue;
+		}
+		const rest = line.slice(match[0].length);
+		const spaceIndex = rest.indexOf(' ');
+		const rawUrl = spaceIndex === -1 ? rest : rest.slice(0, spaceIndex);
+		records.push({
+			url: rawUrl === 'null' || rawUrl === '' ? null : rawUrl,
+			message: spaceIndex === -1 ? '' : rest.slice(spaceIndex + 1),
+		});
+	}
+	return records;
+}
+
+/**
+ * Read structured crawler-level failures from `crawl_errors`.
+ * @param accessor - The opened archive accessor.
+ * @returns Failure records.
+ */
+async function readCrawlErrors(accessor: ArchiveAccessor): Promise<ErrorRecord[]> {
+	const knex = accessor.getKnex();
+	const rows = await knex('crawl_errors').select('url', 'message');
+	return rows.map((r: { url: string | null; message: string }) => ({
+		url: r.url ?? null,
+		message: r.message,
+	}));
+}
+
+/**
+ * Classify and aggregate every recorded crawl failure by cause.
+ *
+ * Merges two sources: scrape-path failures (`page_errors`), and the
+ * crawler-level `error` channel taken from `crawl_errors` when it has rows, or
+ * parsed from `error.log` when it does not (so archives crawled before
+ * structured capture — including ones a migration left with an empty
+ * `crawl_errors` table — still classify). Each record's cause is derived with
+ * {@link classifyErrorKind} — nothing is read from a stored `kind`, so the same
+ * archive always classifies the same way regardless of when it was crawled.
+ *
+ * Known limitation: re-crawling a pre-capture archive (resume / append) writes
+ * the new run's errors into `crawl_errors`, which then shadows `error.log`; the
+ * original run's `error`-channel entries (still only in `error.log`) are not
+ * merged. Scrape-path (`page_errors`) history is unaffected.
+ *
+ * Counts are per failure record (a URL that failed on several presets or phases
+ * contributes multiple records); use the per-host breakdown and sample URLs to
+ * drill into a kind.
+ * @param accessor - The opened archive accessor.
+ * @returns Per-kind counts, host breakdown, and sample URLs, sorted by count.
+ * @example
+ * ```ts
+ * const { groups } = await getErrorKinds(accessor);
+ * const dns = groups.find((g) => g.kind === 'dns');
+ * console.log(dns?.count, dns?.hosts);
+ * ```
+ */
+export async function getErrorKinds(
+	accessor: ArchiveAccessor,
+): Promise<ErrorKindsResult> {
+	const knex = accessor.getKnex();
+	const hasCrawlErrors = await knex.schema.hasTable('crawl_errors');
+
+	const pageRecords = await readPageErrors(accessor);
+
+	// Prefer the structured table, but fall back to error.log whenever it yields
+	// nothing — not just when the table is absent. A legacy (pre-capture) archive
+	// opened in write mode (resume / append / a read-write query) gets an EMPTY
+	// crawl_errors table created by migration; gating the fallback on table
+	// absence alone would then read zero rows and silently drop every error that
+	// still lives only in error.log. (Once the table has rows it is authoritative
+	// and error.log is not re-read, so freshly captured errors are never
+	// double-counted against their own error.log entries.)
+	let channelRecords = hasCrawlErrors ? await readCrawlErrors(accessor) : [];
+	let channelSource: ErrorKindsResult['channelSource'] =
+		channelRecords.length > 0 ? 'crawl_errors' : 'none';
+	if (channelRecords.length === 0) {
+		const logRecords = await readErrorLog(accessor.tmpDir);
+		if (logRecords.length > 0) {
+			channelRecords = logRecords;
+			channelSource = 'error.log';
+		}
+	}
+
+	const accumulators = new Map<ErrorKind, KindAccumulator>();
+	let total = 0;
+	for (const { url, message } of [...pageRecords, ...channelRecords]) {
+		const kind = classifyErrorKind(message);
+		let acc = accumulators.get(kind);
+		if (!acc) {
+			acc = { count: 0, hosts: new Map(), sampleUrls: [] };
+			accumulators.set(kind, acc);
+		}
+		acc.count++;
+		total++;
+		const host = hostOf(url);
+		acc.hosts.set(host, (acc.hosts.get(host) ?? 0) + 1);
+		if (url && acc.sampleUrls.length < MAX_SAMPLE_URLS) {
+			acc.sampleUrls.push(url);
+		}
+	}
+
+	const groups: ErrorKindGroup[] = [...accumulators.entries()]
+		.map(([kind, acc]) => ({
+			kind,
+			count: acc.count,
+			hosts: [...acc.hosts.entries()]
+				.map(([host, count]) => ({ host, count }))
+				.toSorted((a, b) => b.count - a.count),
+			sampleUrls: acc.sampleUrls,
+		}))
+		.toSorted((a, b) => b.count - a.count);
+
+	return { total, channelSource, groups };
+}

--- a/packages/@nitpicker/query/src/query.ts
+++ b/packages/@nitpicker/query/src/query.ts
@@ -9,11 +9,13 @@
 export { ArchiveManager } from './archive-manager.js';
 export type { OpenResult } from './archive-manager.js';
 export { checkHeaders } from './check-headers.js';
+export { classifyErrorKind } from './classify-error-kind.js';
 export { classifyContentType, CONTENT_TYPE_CATEGORIES } from './classify-content-type.js';
 export { CONTENT_TYPE_RULES } from './content-type-rules.js';
 export type { ContentTypeRule, MimeMatcher } from './content-type-rules.js';
 export { findDuplicates } from './find-duplicates.js';
 export { findMismatches } from './find-mismatches.js';
+export { getErrorKinds } from './get-error-kinds.js';
 export { getLinkGraph } from './get-link-graph.js';
 export { getPageDetail } from './get-page-detail.js';
 export { getPageHtml } from './get-page-html.js';

--- a/packages/@nitpicker/query/src/types.ts
+++ b/packages/@nitpicker/query/src/types.ts
@@ -671,3 +671,59 @@ export interface ListPageLinksOptions {
 	/** Number of results to skip. */
 	offset?: number;
 }
+
+/**
+ * Coarse cause of a crawl/scrape failure.
+ *
+ * The crawler stores only the raw error message (in `crawl_errors`,
+ * `page_errors`, or `error.log`); the cause is derived on read by
+ * {@link classifyErrorKind}, so existing archives gain classification without a
+ * re-crawl. `timeout` is a puppeteer/page-level timeout (e.g. navigation or the
+ * scraper's overall race), whereas `connection-timeout` is a transport-level
+ * `ETIMEDOUT`; keeping them apart lets a slow-but-reachable host be told from an
+ * unreachable one.
+ */
+export type ErrorKind =
+	| 'dns'
+	| 'connection-refused'
+	| 'connection-reset'
+	| 'connection-timeout'
+	| 'tls'
+	| 'timeout'
+	| 'protocol'
+	| 'unknown';
+
+/** A single host's failure count within an {@link ErrorKindGroup}. */
+export interface ErrorKindHost {
+	/** Hostname extracted from the failing URL, or `(unknown)` when the URL is absent/unparsable. */
+	host: string;
+	/** Number of failures of the group's kind on this host. */
+	count: number;
+}
+
+/** Aggregated failures sharing one {@link ErrorKind}. */
+export interface ErrorKindGroup {
+	/** The classified cause. */
+	kind: ErrorKind;
+	/** Total failure records classified into this kind. */
+	count: number;
+	/** Per-host breakdown, most failures first. */
+	hosts: ErrorKindHost[];
+	/** Up to a capped number of representative failing URLs. */
+	sampleUrls: string[];
+}
+
+/** Result of {@link getErrorKinds}. */
+export interface ErrorKindsResult {
+	/** Total failure records across all kinds. */
+	total: number;
+	/**
+	 * Where the error-channel (DNS/connection/TLS) records came from:
+	 * `crawl_errors` for archives crawled after structured capture landed,
+	 * `error.log` for older archives parsed on read, or `none` when neither
+	 * yielded rows. `page_errors` (scrape-path) is always merged in regardless.
+	 */
+	channelSource: 'crawl_errors' | 'error.log' | 'none';
+	/** Groups sorted by `count`, most failures first. */
+	groups: ErrorKindGroup[];
+}

--- a/packages/@nitpicker/viewer/e2e/viewer.spec.ts
+++ b/packages/@nitpicker/viewer/e2e/viewer.spec.ts
@@ -78,6 +78,16 @@ test.describe('Nitpicker Viewer', () => {
 		).toBeVisible();
 		await expect(page.locator('.vt-row').first()).toBeVisible();
 	});
+
+	test('Errors ビューに遷移して見出しと解説が表示される', async ({ page }) => {
+		await page.goto('/');
+		await page.getByRole('link', { name: 'Errors' }).click();
+		await expect(page.getByRole('heading', { name: 'Errors', level: 1 })).toBeVisible();
+		// The fixture crawls a healthy local site, so the view renders its empty
+		// state rather than failure groups — asserting it confirms the route,
+		// nav link, API wiring, and render path all resolve.
+		await expect(page.locator('.view-header .view-description')).toBeVisible();
+	});
 });
 
 test.describe('アクセシビリティ', () => {

--- a/packages/@nitpicker/viewer/src/create-app.ts
+++ b/packages/@nitpicker/viewer/src/create-app.ts
@@ -5,6 +5,7 @@ import { Hono } from 'hono';
 
 import { registerArchiveInfoRoute } from './routes/register-archive-info-route.js';
 import { registerDuplicatesRoute } from './routes/register-duplicates-route.js';
+import { registerErrorKindsRoute } from './routes/register-error-kinds-route.js';
 import { registerGraphRoute } from './routes/register-graph-route.js';
 import { registerHeadersRoute } from './routes/register-headers-route.js';
 import { registerImagesRoute } from './routes/register-images-route.js';
@@ -48,6 +49,7 @@ export function createApp(options: CreateAppOptions): Hono {
 	registerGraphRoute(app, context);
 	registerPageLinksRoute(app, context);
 	registerArchiveInfoRoute(app, context);
+	registerErrorKindsRoute(app, context);
 
 	app.onError((error, c) => {
 		const raw = error instanceof Error ? error.message : String(error);

--- a/packages/@nitpicker/viewer/src/routes/register-error-kinds-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-error-kinds-route.ts
@@ -1,0 +1,18 @@
+import type { ArchiveContext } from '../types.js';
+import type { Hono } from 'hono';
+
+import { getErrorKinds } from '@nitpicker/query';
+
+/**
+ * Registers `GET /api/error-kinds` — crawl failures classified by cause
+ * (DNS, connection, TLS, timeout, protocol, …) with per-host breakdown and
+ * sample URLs. See {@link getErrorKinds} for how the cause is derived.
+ * @param app - The Hono application.
+ * @param context - The opened archive context.
+ */
+export function registerErrorKindsRoute(app: Hono, context: ArchiveContext): void {
+	app.get('/api/error-kinds', async (c) => {
+		const accessor = context.manager.get(context.archiveId);
+		return c.json(await getErrorKinds(accessor));
+	});
+}

--- a/packages/@nitpicker/viewer/web/api/use-error-kinds.ts
+++ b/packages/@nitpicker/viewer/web/api/use-error-kinds.ts
@@ -1,0 +1,16 @@
+import type { ErrorKindsResult } from '@nitpicker/query';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { apiGet } from './api-client.js';
+
+/**
+ * Fetches crawl failures classified by cause (DNS, connection, TLS, timeout, …).
+ * @returns The TanStack Query result for the error-kinds aggregation.
+ */
+export function useErrorKinds() {
+	return useQuery({
+		queryKey: ['error-kinds'],
+		queryFn: () => apiGet<ErrorKindsResult>('/api/error-kinds'),
+	});
+}

--- a/packages/@nitpicker/viewer/web/app.tsx
+++ b/packages/@nitpicker/viewer/web/app.tsx
@@ -7,6 +7,7 @@ import { MAIN_CONTENT_ID, SkipLink } from './components/skip-link.js';
 import { TopBar } from './components/top-bar.js';
 import { I18nProvider } from './i18n/i18n-provider.js';
 import { DuplicatesView } from './routes/duplicates-view.js';
+import { ErrorsView } from './routes/errors-view.js';
 import { GraphView } from './routes/graph-view.js';
 import { HeadersView } from './routes/headers-view.js';
 import { ImagesView } from './routes/images-view.js';
@@ -62,6 +63,7 @@ export function App() {
 									<Route path="/duplicates" element={<DuplicatesView />} />
 									<Route path="/mismatches" element={<MismatchesView />} />
 									<Route path="/headers" element={<HeadersView />} />
+									<Route path="/errors" element={<ErrorsView />} />
 									<Route path="*" element={<Navigate to="/" replace />} />
 								</Routes>
 							</main>

--- a/packages/@nitpicker/viewer/web/components/nav-sidebar.tsx
+++ b/packages/@nitpicker/viewer/web/components/nav-sidebar.tsx
@@ -17,6 +17,7 @@ const NAV_ITEMS: NavItem[] = [
 	{ path: '/duplicates', labelKey: 'nav.duplicates' },
 	{ path: '/mismatches', labelKey: 'nav.mismatches' },
 	{ path: '/headers', labelKey: 'nav.headers' },
+	{ path: '/errors', labelKey: 'nav.errors' },
 ];
 
 /**

--- a/packages/@nitpicker/viewer/web/i18n/translations.ts
+++ b/packages/@nitpicker/viewer/web/i18n/translations.ts
@@ -31,6 +31,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 			headers: 'Headers',
 			graph: 'Graph',
 			pageLinks: 'Page Links',
+			errors: 'Errors',
 		},
 		common: {
 			loading: 'Loading…',
@@ -220,6 +221,16 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				colRemarks: 'Remarks',
 				filterUrlPattern: 'URL pattern (%foo%)',
 			},
+			errors: {
+				title: 'Errors',
+				description:
+					'Crawl failures grouped by cause (DNS, connection, TLS, timeout, protocol). Select a kind to see which hosts and URLs failed.',
+				total: '{total} failure records',
+				channelSource: 'DNS / connection / TLS source: {source}',
+				empty: 'No crawl errors recorded.',
+				hosts: 'Hosts',
+				sampleUrls: 'Sample URLs',
+			},
 		},
 	},
 	ja: {
@@ -246,6 +257,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 			headers: 'ヘッダー',
 			graph: 'グラフ',
 			pageLinks: 'ページリンク',
+			errors: 'エラー',
 		},
 		common: {
 			loading: '読み込み中…',
@@ -434,6 +446,16 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				colHeaders: 'ヘッダー',
 				colRemarks: '備考',
 				filterUrlPattern: 'URL パターン（%foo%）',
+			},
+			errors: {
+				title: 'エラー',
+				description:
+					'クロール失敗を原因別（DNS・接続・TLS・タイムアウト・プロトコル）に分類。種別を選ぶと、失敗したホストと URL を確認できます。',
+				total: '失敗レコード {total} 件',
+				channelSource: 'DNS / 接続 / TLS の取得元: {source}',
+				empty: 'クロールエラーは記録されていません。',
+				hosts: 'ホスト',
+				sampleUrls: 'サンプル URL',
 			},
 		},
 	},

--- a/packages/@nitpicker/viewer/web/routes/errors-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/errors-view.tsx
@@ -1,0 +1,123 @@
+import type { ErrorKind } from '@nitpicker/query';
+
+import { useState } from 'react';
+
+import { useErrorKinds } from '../api/use-error-kinds.js';
+import { ViewHeader } from '../components/view-header.js';
+import { useI18n } from '../i18n/use-i18n.js';
+import { computeRatio } from '../utils/compute-ratio.js';
+import { formatPercent } from '../utils/format-percent.js';
+
+/**
+ * Errors dashboard: crawl failures grouped by classified cause.
+ *
+ * Each kind renders as a selectable bar (share of all failure records). The
+ * selected kind expands into a per-host breakdown and a list of sample URLs so
+ * the user can tell, say, a handful of DNS failures apart from a flood of slow
+ * pages that merely timed out — the distinction the raw archive blurs into one
+ * "timeout / unknown" bucket. The cause is derived on read, so this works on
+ * archives crawled before structured error capture existed.
+ * @returns The errors view element.
+ */
+export function ErrorsView() {
+	const { t } = useI18n();
+	const { data, isLoading, error } = useErrorKinds();
+	const [selected, setSelected] = useState<ErrorKind | null>(null);
+
+	if (isLoading) {
+		return <div className="state">{t('common.loading')}</div>;
+	}
+	if (error) {
+		return <div className="state state-error">{error.message}</div>;
+	}
+	if (!data) {
+		return null;
+	}
+
+	if (data.total === 0) {
+		return (
+			<div>
+				<ViewHeader
+					titleKey="views.errors.title"
+					descriptionKey="views.errors.description"
+				/>
+				<div className="state">{t('views.errors.empty')}</div>
+			</div>
+		);
+	}
+
+	// Default the drill-down to the largest kind so the view is never empty, and
+	// fall back to it if a previously-selected kind is absent from the current
+	// data (e.g. after a refetch) so the detail panel never silently disappears.
+	const activeGroup = data.groups.find((g) => g.kind === selected) ?? data.groups[0];
+	const activeKind = activeGroup?.kind ?? null;
+
+	return (
+		<div>
+			<ViewHeader
+				titleKey="views.errors.title"
+				descriptionKey="views.errors.description"
+			/>
+			<p className="state">
+				{t('views.errors.total', { total: data.total })}
+				{data.channelSource !== 'none' && (
+					<>
+						{' · '}
+						{t('views.errors.channelSource', { source: data.channelSource })}
+					</>
+				)}
+			</p>
+
+			<div className="bars">
+				{data.groups.map((group) => {
+					const ratio = computeRatio(group.count, data.total);
+					const isActive = group.kind === activeKind;
+					return (
+						<button
+							type="button"
+							key={group.kind}
+							className={isActive ? 'bar-row bar-row-active' : 'bar-row'}
+							aria-pressed={isActive}
+							onClick={() => setSelected(group.kind)}>
+							<span style={{ width: 160, textAlign: 'left' }}>{group.kind}</span>
+							<span className="bar-track">
+								<span className="bar-fill" style={{ width: `${ratio * 100}%` }} />
+							</span>
+							<span>
+								{group.count.toLocaleString()} <small>({formatPercent(ratio)})</small>
+							</span>
+						</button>
+					);
+				})}
+			</div>
+
+			{activeGroup && (
+				<div className="error-detail">
+					<h2>
+						{activeGroup.kind} — {t('views.errors.hosts')}
+					</h2>
+					<div className="bars">
+						{activeGroup.hosts.map((host) => (
+							<div key={host.host} className="bar-row">
+								<span style={{ width: 240, textAlign: 'left' }}>{host.host}</span>
+								<span>{host.count.toLocaleString()}</span>
+							</div>
+						))}
+					</div>
+
+					<h2>{t('views.errors.sampleUrls')}</h2>
+					{/* Plain, selectable text rather than links: these URLs failed to
+					    crawl (DNS failure, refused, cert error, …), so a link would just
+					    open a dead tab. They exist to be read and copied for diagnosis. */}
+					<ul className="url-list">
+						{activeGroup.sampleUrls.map((url, index) => (
+							<li key={`${url}-${index}`}>
+								<code>{url}</code>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/@nitpicker/viewer/web/styles.css
+++ b/packages/@nitpicker/viewer/web/styles.css
@@ -502,6 +502,47 @@ h2 {
 }
 
 /*
+ * A `.bar-row` rendered as a <button> for the Errors view drill-down. Strip the
+ * native button chrome so it visually matches the static bar rows, but keep it
+ * a real button for keyboard / screen-reader operability.
+ */
+button.bar-row {
+	inline-size: 100%;
+	padding-block: 2px;
+	padding-inline: 4px;
+	font: inherit;
+	color: inherit;
+	text-align: start;
+	cursor: pointer;
+	background: none;
+	border: 1px solid transparent;
+	border-radius: 4px;
+}
+
+button.bar-row:hover {
+	background: var(--border);
+}
+
+.bar-row-active {
+	border-color: var(--accent);
+}
+
+.error-detail {
+	margin-block-start: 24px;
+}
+
+.url-list {
+	padding-inline-start: 18px;
+	margin: 0;
+	font-size: var(--font-size-base);
+	word-break: break-all;
+}
+
+.url-list li {
+	margin-block: 2px;
+}
+
+/*
  * Content-Type stacked bar — macOS / iOS storage-style breakdown.
  *
  * The bar itself is a flex row of `.bar-segment-<category>` spans, each given


### PR DESCRIPTION
## 概要

クロール失敗を**原因別に分類**して分析できるようにする。これまで DNS 解決失敗・接続拒否・TLS エラーなどが、構造化データ上はただの「タイムアウト/不明」に埋もれて区別できなかった。`query error-kinds` と viewer の **Errors ビュー**で、原因別の件数・ホスト内訳・サンプル URL を確認できる。

## ErrorKind（8 分類）

`dns` / `connection-refused` / `connection-reset` / `connection-timeout` / `tls` / `timeout` / `protocol` / `unknown`

判定 `classifyErrorKind(message)` は純粋関数で、**kind は保存せず読み取り時に message から導出**する。これにより**この機能より前に作成した既存アーカイブもそのまま分類**でき、capture 時と read 時で必ず一致する。

## データソース（2 系統）

- **スクレイプ経路の失敗** → `page_errors`（既存テーブル）
- **crawler レベルの `error` チャネル**（DNS/接続/TLS）→ 新テーブル **`crawl_errors`**。`Archive.addError` が `error.log` と両方へ記録。`migrateCrawlErrors` で既存アーカイブに後付け。
- `getErrorKinds` は `crawl_errors` に行があればそれを、**無い／空なら `error.log` をパースしてフォールバック**（read-only の stub viewer や、migration で空テーブルだけ作られた legacy アーカイブも分類可能）。

## 変更点

- `@nitpicker/crawler`: `crawl_errors` テーブル + `migrateCrawlErrors` + `insertCrawlError`、`addError` を構造化記録に拡張。
- `@nitpicker/query`: `classifyErrorKind` + `getErrorKinds`（kind 別件数 + ホスト内訳 + サンプル URL）。
- `@nitpicker/cli`: `query <file> error-kinds` サブコマンド。
- `@nitpicker/viewer`: `/api/error-kinds` + Errors ビュー（kind バー → ホスト/URL ドリルダウン）。サンプル URL は死リンク回避のためプレーンテキスト表示。

## テスト

- `classify-error-kind.spec.ts`（9）: 8 分類の判定と優先順位。
- `get-error-kinds.spec.ts`（5）: crawl_errors / error.log fallback / 空テーブル fallback / clean / ソート。
- viewer Playwright e2e に Errors ビュー smoke テスト追加。
- 実データ（既存アーカイブ）で `query error-kinds` を検証し、timeout に埋もれていた DNS 失敗を分離できることを確認。
- lint 0 errors・unit 1593・viewer e2e 26・test-server e2e 96 すべて green。

## 関連

- 応答しないページが per-property の累積タイムアウトで `timeout` に倒れる現象（`video_uuid` ページ等）は beholder 側の既知課題: d-zero-dev/tools#874。本機能はそれを `timeout` kind + ホスト別で可視化し、除外対象の特定を助ける。

## 既知の制約

- pre-capture アーカイブを resume/append で再クロールすると、新 run のエラーが `crawl_errors` に入り `error.log` を shadow するため、元 run の `error` チャネル分は集計に含まれない（`page_errors` 履歴は影響なし）。JSDoc に明記済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)