### PR TITLE
perf: SQL-first viewer queries (find-duplicates 112x, listUnusedResources 21x, listPages COUNT 264x)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -694,13 +694,15 @@ beholder 3.0.0 アップグレードで pages のメタカラムは ~47 列の f
 
 **追加 INDEX 群 (viewer 高速化)**: `init-schema.ts` 末尾で 3 つの perf index を raw SQL で追加。428k 行 / フィルタ後 168k 行の実 archive 計測:
 
-| Index                                                                                                           | 対象 query            | Before | After       |
-| --------------------------------------------------------------------------------------------------------------- | --------------------- | ------ | ----------- |
-| `idx_pages_listfilter` (PR #96) — `pages(scraped, redirectDestId, url, contentType)`                            | `listPages`           | 15s    | 45ms (368x) |
-| `idx_resources_internal_url` — `resources(isExternal, url)` covering                                            | `listUnusedResources` | 66s    | 7.5s (8.8x) |
-| `idx_images_covering` — `images(pageId, src, alt, width, height, naturalWidth, naturalHeight, isLazy)` covering | `listImages`          | 32s    | 16s (2.0x)  |
+| Index                                                                                                                                                    | 対象 query            | Before | After       |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ------ | ----------- |
+| `idx_pages_listfilter` — `pages(isExternal, scraped, redirectDestId, url, contentType)` (PR #96 では 4 列、本 PR で先頭に `isExternal` を追加。詳細下記) | `listPages`           | 15s    | 45ms (368x) |
+| `idx_resources_internal_url` — `resources(isExternal, url)` covering                                                                                     | `listUnusedResources` | 66s    | 7.5s (8.8x) |
+| `idx_images_covering` — `images(pageId, src, alt, width, height, naturalWidth, naturalHeight, isLazy)` covering                                          | `listImages`          | 32s    | 16s (2.0x)  |
 
 加えて `find-duplicates` を N+1 SQL (代表値ごとに別 `SELECT url` ループ) から `GROUP_CONCAT(url, X'1F')` の単発 query に書換 (414s → 8s, 49.6x、`scripts/bench-find-duplicates.mjs`)。`get-link-graph` の `pageRows` + `edgeRows` を `Promise.all` に統合 (sequential 38s → parallel 30s ish、JS aggregation はそのまま — SQL push-down を試した結果 10x 悪化したため不採用、根拠は `get-link-graph.ts` の JSDoc)。
+
+> **設計注意（`idx_pages_listfilter` の column 順は `isExternal` 先頭）:** PR #96 では 4 列 `(scraped, redirectDestId, url, contentType)` だったが、本 PR で先頭に `isExternal` を追加した。Pages view のデフォルト「Include external 無し」フィルタは WHERE に `isExternal=0` を入れ、これは paginate-query の COUNT と SELECT の両方に効く。**SELECT は `ORDER BY url` のおかげで listfilter index が選ばれていたが、COUNT には ORDER BY が無いので planner が単一列 `pages_isexternal_index` を選んで scan + per-row filter に倒れ、165k internal page archive で COUNT だけで ~8.7 秒消費していた**。`isExternal` を先頭に置くと COUNT も SELECT も同じ covering 構成で完結し、COUNT は ~33ms に短縮 (264x)。確認スクリプト: `scripts/try-isexternal-first-index.mjs`。**Include external を ON にした場合は依然 8s 級** (`pages_scraped_index` への fallback、partial index で別途解決可能)。既存 archive 側は `scripts/add-perf-indexes.mjs` が `DROP INDEX IF EXISTS` 経由で 4 列版を 5 列版に張り替える。
 
 > **設計注意（.nitpicker archive に `ANALYZE` を絶対に走らせない）:** `idx_pages_listfilter` は SQLite の planner heuristics に依存して動作する。`ANALYZE` で per-index 統計が生成されると、planner は同 index を `listLinks` / `getLinkGraph` / `listPageLinks` の JOIN paths でも source/dest seek に流用しはじめ、これらが ~15s → ~500s (33x worse) に回帰する。実証: `scripts/bench-partial-listfilter.mjs` の no-ANALYZE / +ANALYZE pass 比較。crawler / viewer / MCP / migration の**いかなる経路でも** `ANALYZE` / `PRAGMA optimize` を実行しないこと。既存 archive への手動適用は `scripts/add-perf-indexes.mjs` で行う (このスクリプトも ANALYZE しない、3 index 一括追加)。
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -692,11 +692,19 @@ beholder 3.0.0 アップグレードで pages のメタカラムは ~47 列の f
 
 **追加 INDEX**: `pages(robots_noindex)`, `pages(og_type)`。`lang` はモノリンガルサイトで cardinality 低く無効なので skip。
 
-**追加 INDEX (listPages 高速化)**: `idx_pages_listfilter` (`scraped, redirectDestId, url, contentType`) を `init-schema.ts` の末尾で raw SQL 経由で追加。listPages の default WHERE (`scraped=1 AND redirectDestId IS NULL AND (contentType IS NULL OR contentType='text/html')`) + `ORDER BY url ASC` を index-ordered scan で完結させる covering 構成。**428k 行 / フィルタ後 168k 行の実 archive で 15s → 45ms (368x speedup)** を確認。
+**追加 INDEX 群 (viewer 高速化)**: `init-schema.ts` 末尾で 3 つの perf index を raw SQL で追加。428k 行 / フィルタ後 168k 行の実 archive 計測:
 
-> **設計注意（.nitpicker archive に `ANALYZE` を絶対に走らせない）:** `idx_pages_listfilter` は SQLite の planner heuristics に依存して動作する。`ANALYZE` で per-index 統計が生成されると、planner は同 index を `listLinks` / `getLinkGraph` / `listPageLinks` の JOIN paths でも source/dest seek に流用しはじめ、これらが ~15s → ~500s (33x worse) に回帰する。実証: `scripts/bench-partial-listfilter.mjs` の no-ANALYZE / +ANALYZE pass 比較。crawler / viewer / MCP / migration の**いかなる経路でも** `ANALYZE` / `PRAGMA optimize` を実行しないこと。既存 archive への手動適用は `scripts/add-pages-listfilter-index.mjs` で行う (このスクリプトも ANALYZE しない)。
+| Index                                                                                                           | 対象 query            | Before | After       |
+| --------------------------------------------------------------------------------------------------------------- | --------------------- | ------ | ----------- |
+| `idx_pages_listfilter` (PR #96) — `pages(scraped, redirectDestId, url, contentType)`                            | `listPages`           | 15s    | 45ms (368x) |
+| `idx_resources_internal_url` — `resources(isExternal, url)` covering                                            | `listUnusedResources` | 66s    | 7.5s (8.8x) |
+| `idx_images_covering` — `images(pageId, src, alt, width, height, naturalWidth, naturalHeight, isLazy)` covering | `listImages`          | 32s    | 16s (2.0x)  |
 
-> **既知の遅い query (本 PR スコープ外)**: `idx_pages_listfilter` 追加で listPages 系は解消されたが、Viewer の他ビューは依然遅い (実 archive 計測値): `findDuplicates` 474s, `listUnusedResources` 60s, `getLinkGraph` 33s, `listPageLinks` 22s, `getSummary` 22s, `listLinks` 13-16s, `listIsolated*` 15-17s, `listImages` 8-12s。次フェーズで「JS 側のデータ加工を SQL 側に押し下げる」方針で個別に最適化する予定。
+加えて `find-duplicates` を N+1 SQL (代表値ごとに別 `SELECT url` ループ) から `GROUP_CONCAT(url, X'1F')` の単発 query に書換 (414s → 8s, 49.6x、`scripts/bench-find-duplicates.mjs`)。`get-link-graph` の `pageRows` + `edgeRows` を `Promise.all` に統合 (sequential 38s → parallel 30s ish、JS aggregation はそのまま — SQL push-down を試した結果 10x 悪化したため不採用、根拠は `get-link-graph.ts` の JSDoc)。
+
+> **設計注意（.nitpicker archive に `ANALYZE` を絶対に走らせない）:** `idx_pages_listfilter` は SQLite の planner heuristics に依存して動作する。`ANALYZE` で per-index 統計が生成されると、planner は同 index を `listLinks` / `getLinkGraph` / `listPageLinks` の JOIN paths でも source/dest seek に流用しはじめ、これらが ~15s → ~500s (33x worse) に回帰する。実証: `scripts/bench-partial-listfilter.mjs` の no-ANALYZE / +ANALYZE pass 比較。crawler / viewer / MCP / migration の**いかなる経路でも** `ANALYZE` / `PRAGMA optimize` を実行しないこと。既存 archive への手動適用は `scripts/add-perf-indexes.mjs` で行う (このスクリプトも ANALYZE しない、3 index 一括追加)。
+
+> **受容済みの遅い query**: `listLinks` 13-16s (anchor SCAN + 3-way JOIN + COALESCE、SQL-first push-down 不能、`canonicalId` 列の denormalisation 待ち), `listPageLinks` 22s (correlated subquery × 2 per row、`referrer_count` 列の denormalisation 待ち), `getSummary` 22s (4 並列 COUNT、既に SQL-optimal、pre-aggregated summary 待ち), `computeIsolatedClusters` 17s (66k inventory pages + 5M anchors、SQL-side filter 試したが 11.6s で改善なし、`isolated_root` 列の denormalisation 待ち)。各 query.ts の JSDoc に「push-down 不能の根拠」と「次のステップ (schema 変更)」を記載。
 
 **pre-0.10 互換性**: clean-break。`archive/meta/assert-compatible-version.ts` が `info.version` を読んで `REQUIRED_FORMAT_VERSION = "0.10.0"` と semver 比較し、古い archive を `Database.connect` で開いた時点で `IncompatibleArchiveError` を throw する。`v0.x` 系の breaking 容認方針（MEMORY: `v0-x-breaking-changes`）に基づく。移行は `scripts/migrate-to-0.10.mjs`。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,13 @@ packages/
 
 > **Note**: `viewer` は Hono バックエンド（`@nitpicker/query` を再利用）+ React SPA（Vite ビルド）の単一パッケージ。CLI に `viewer` サブコマンドとして統合され、`@nitpicker/cli/package.json` の `dependencies` に含まれる。他コマンドがバッチ型（実行→完了→`process.exit`）なのに対し、viewer だけは常駐サーバなので `cli.ts` 末尾の `process.exit` を回避する例外扱いになる（`startViewer` は SIGINT/SIGTERM まで resolve しない）。ビルドは `tsc`（backend）+ `vite build`（frontend）の 2 段。
 
-> **Note (listPages 高速化用 index)**: `init-schema.ts` 末尾で `CREATE INDEX idx_pages_listfilter ON pages(scraped, redirectDestId, url, contentType)` を貼っている。428k 行 archive で `listPages` を 15s → 45ms (368x) に。**重要: `.nitpicker` archive に `ANALYZE` を絶対に走らせない** — 統計が出ると planner が同 index を JOIN paths にも流用して `listLinks` / `getLinkGraph` / `listPageLinks` を 15s → 500s に回帰させる (33x worse)。既存 archive 適用は `scripts/add-pages-listfilter-index.mjs`。詳細は ARCHITECTURE.md の「設計注意 (ANALYZE を走らせない)」を正とする。なお他 view (Duplicates 474s / Unused 60s / Graph 33s / PageLinks 22s / Summary 22s / Links 13-16s / Isolated 15-17s / Images 8-12s) は次フェーズで「JS 加工を SQL 側に押し下げる」方針で最適化予定。
+> **Note (viewer 高速化用 index 群)**: `init-schema.ts` 末尾で複数の perf index を貼っている。428k 行 archive 計測値:
+>
+> - `idx_pages_listfilter` (PR #96): listPages 15s → 45ms (368x)
+> - `idx_resources_internal_url`: listUnusedResources 66s → 7.5s (8.8x)
+> - `idx_images_covering`: listImages 32s → 16s (2.0x)
+>
+> 加えて `find-duplicates` を N+1 SQL から `GROUP_CONCAT` 一発に書換 (414s → 8s, 49.6x)、`get-link-graph` を Promise.all parallel に。**重要: `.nitpicker` archive に `ANALYZE` を絶対に走らせない** — 統計が出ると planner が `idx_pages_listfilter` を JOIN paths にも流用して `listLinks` / `getLinkGraph` / `listPageLinks` を 15s → 500s に回帰させる (33x worse)。既存 archive 適用は `scripts/add-perf-indexes.mjs` (PR #96 の `add-pages-listfilter-index.mjs` をリネーム + 拡張、3 index 一括)。詳細は ARCHITECTURE.md の「設計注意 (ANALYZE を走らせない)」を正とする。残る重い view (`listLinks`, `listPageLinks`, `getSummary`, `compute-isolated-clusters`) は `canonicalId` / `referrer_count` / `isolated_root` 等の schema denormalisation 無しではこれ以上削れず、当面受容 (各 query.ts の JSDoc に根拠記載)。
 
 > **Note (ページネーションモード)**: リスト系ビューは MPA ページネーション（`PagedTable` + `?page=` + `?pageSize=`、デフォルト）と仮想スクロール（`VirtualTable` + `useInfiniteQuery`、opt-in）の 2 モードを TopBar のトグルで切替えられる。`DataTable` がモードに応じて dispatch し、`usePagedQuery` / `use-*-infinite` を `enabled` フラグで切替えるため backend は無改修。**page と pageSize は URL クエリが正**（deep-link / 共有が成立するため両方が URL に乗らないと意味がない、`?pageSize=` 無しで `?page=5` を共有しても受け手の窓サイズが違うと別の行が見える）。デフォルト値（page=1, pageSize=100）は URL から省略してクリーンに保つ。localStorage は `nitpicker-pagination-mode`（モード本体）と `nitpicker-page-size`（**新規タブ初回の hint**）のみ。MPA がデフォルトな理由は deep-link / URL 共有 / 戻る進むが効くため。仮想スクロールは 10 万行規模の探索性が要るとき opt-in。詳細は ARCHITECTURE.md の `@nitpicker/viewer` 節「設計注意（ページネーション...）」を正とする。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ packages/
 
 > **Note (viewer 高速化用 index 群)**: `init-schema.ts` 末尾で複数の perf index を貼っている。428k 行 archive 計測値:
 >
-> - `idx_pages_listfilter` (PR #96): listPages 15s → 45ms (368x)
+> - `idx_pages_listfilter`: listPages 15s → 45ms (368x)。**column 順は `(isExternal, scraped, redirectDestId, url, contentType)`** — PR #96 で `scraped` 先頭の 4 列で出したら paginate-query の COUNT が `isExternal=0` フィルタで `pages_isexternal_index` に倒れて 8.7s かかる事案が出たので、本 PR で `isExternal` 先頭の 5 列に張り替え (264x for COUNT)
 > - `idx_resources_internal_url`: listUnusedResources 66s → 7.5s (8.8x)
 > - `idx_images_covering`: listImages 32s → 16s (2.0x)
 >

--- a/packages/@nitpicker/crawler/src/archive/init-schema.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.ts
@@ -405,6 +405,18 @@ export async function initSchema(instance: Knex) {
 	// The same index also serves `listIsolatedPages`, `listIsolatedClusters`,
 	// and `getSummary`'s HTML-page counts.
 	//
+	// **Column order: `(isExternal, scraped, redirectDestId, url, contentType)`.**
+	// The leading `isExternal` is critical: the Pages view's default
+	// "external excluded" filter adds `WHERE isExternal = 0` to both the
+	// SELECT and the paginate-query COUNT. A previous version of this index
+	// (`(scraped, redirectDestId, url, contentType)`) shipped without
+	// `isExternal`, and the SELECT picked it up (`ORDER BY url` forced the
+	// match) while the COUNT — having no `ORDER BY` — fell back to the
+	// single-column `pages_isexternal_index` + scan + per-row WHERE filter,
+	// costing ~8.7s for the COUNT alone on a 165k-internal-page archive.
+	// Putting `isExternal` first makes both shapes pick this index as a
+	// covering scan (~33ms COUNT, ~1ms SELECT warm).
+	//
 	// **DO NOT RUN `ANALYZE` ON .nitpicker ARCHIVES.** With ANALYZE statistics
 	// available, the planner switches the JOIN paths in `listLinks`,
 	// `getLinkGraph`, and `listPageLinks` to use this index for source/dest
@@ -412,12 +424,12 @@ export async function initSchema(instance: Knex) {
 	// existing `SCAN anchors → rowid seek` plan. That regression takes those
 	// queries from ~15s to ~500s (33x worse). The unanalyzed-table heuristic
 	// happens to pick the right plan for the joins while still picking the new
-	// index for `listPages` because the column order (`scraped, redirectDestId,
-	// url, contentType`) exactly matches the WHERE+ORDER predicates. If a
-	// future change adds `ANALYZE` anywhere in the crawler / viewer / MCP /
-	// migration paths, this index must be re-evaluated first.
+	// index for `listPages` because the column order exactly matches the
+	// WHERE+ORDER predicates. If a future change adds `ANALYZE` anywhere in
+	// the crawler / viewer / MCP / migration paths, this index must be
+	// re-evaluated first.
 	await instance.raw(
-		'CREATE INDEX idx_pages_listfilter ON pages(scraped, redirectDestId, url, contentType)',
+		'CREATE INDEX idx_pages_listfilter ON pages(isExternal, scraped, redirectDestId, url, contentType)',
 	);
 
 	// Covering index for `listUnusedResources`. Without it the query SCAN s

--- a/packages/@nitpicker/crawler/src/archive/init-schema.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.ts
@@ -419,4 +419,30 @@ export async function initSchema(instance: Knex) {
 	await instance.raw(
 		'CREATE INDEX idx_pages_listfilter ON pages(scraped, redirectDestId, url, contentType)',
 	);
+
+	// Covering index for `listUnusedResources`. Without it the query SCAN s
+	// `resources_url_unique` (every resource, including externals) then
+	// filters `isExternal = 0` row-by-row — ~66s on the bench archive. With
+	// the `(isExternal, url)` leading prefix, the planner serves the WHERE
+	// + ORDER BY url from one covering scan — ~7.5s (8.8x). Same
+	// no-ANALYZE invariant applies (see `idx_pages_listfilter` above);
+	// validated against the 4 regression sentinels in
+	// `scripts/bench-unused-images.mjs`.
+	await instance.raw(
+		'CREATE INDEX idx_resources_internal_url ON resources(isExternal, url)',
+	);
+
+	// Covering index for `listImages`. The default query joins `images` to
+	// `pages` and orders by `pages.url`. Without this index the planner
+	// scans `images` first, seeks `pages` by rowid, and pays a TEMP B-TREE
+	// FOR ORDER BY (~32s on the bench archive). With the index the plan
+	// flips to SCAN pages (via `pages_url_unique`, url-ordered already)
+	// → SEARCH images via the covering pageId index — no temp sort, ~16s
+	// (2.0x). The included columns (src, alt, dimensions, isLazy) make
+	// `idx_images_covering` covering for every `select` `listImages` does,
+	// so the SEARCH does not need to materialise the underlying row.
+	// Validated by `scripts/bench-unused-images.mjs`.
+	await instance.raw(
+		'CREATE INDEX idx_images_covering ON images(pageId, src, alt, width, height, naturalWidth, naturalHeight, isLazy)',
+	);
 }

--- a/packages/@nitpicker/query/src/compute-isolated-clusters.ts
+++ b/packages/@nitpicker/query/src/compute-isolated-clusters.ts
@@ -48,6 +48,20 @@ const SQLITE_IN_CHUNK = 500;
  * map is built once from a single `SELECT id, redirectDestId FROM pages
  * WHERE redirectDestId IS NOT NULL` so per-anchor resolution stays
  * memory-resident — no extra SQLite round-trips.
+ *
+ * **Why this stays JS-heavy even after the SQL-first sweep.** A SQL push-
+ * down variant was benchmarked (`scripts/bench-isolated.mjs`): a CTE that
+ * filters anchors to inventory-* edges via 3 JOINs + LEFT JOIN redirect
+ * resolution returned 1,216 edges (vs 5.1M for the chunked path on a 66k-
+ * inventory-page archive) but cost 11.6s end-to-end — actually *slower*
+ * than the current chunked `SELECT anchors.pageId, anchors.hrefId WHERE
+ * pageId IN (...)` path at 8.7s, because the planner cannot use any single
+ * index to satisfy the 3-JOIN chain on this archive shape. Further wins
+ * here would require either a denormalised `isolated_root` column on pages
+ * (schema change) or a planner hint we cannot express without ANALYZE
+ * (forbidden — see `idx_pages_listfilter` JSDoc). The current 17s on a
+ * 66k-inventory archive is accepted; non-inventory archives short-circuit
+ * on the `pageRows.length === 0` early return below.
  * @param accessor - The archive accessor to query.
  * @returns Every connected component of the inventory-* subgraph, including singletons.
  */

--- a/packages/@nitpicker/query/src/find-duplicates.spec.ts
+++ b/packages/@nitpicker/query/src/find-duplicates.spec.ts
@@ -45,9 +45,44 @@ describe('findDuplicates', () => {
 		});
 
 		const pages = [
-			{ url: 'https://example.com/a', title: 'Duplicate Title' },
-			{ url: 'https://example.com/b', title: 'Duplicate Title' },
-			{ url: 'https://example.com/c', title: 'Unique Title' },
+			// Two-page group sharing a title — minimum duplicate.
+			{ url: 'https://example.com/a', title: 'Duplicate Title', description: null },
+			{ url: 'https://example.com/b', title: 'Duplicate Title', description: null },
+			// Singleton — must NOT appear in the duplicates result.
+			{ url: 'https://example.com/c', title: 'Unique Title', description: null },
+			// Three-page group with a shared description — verifies that
+			// (a) the description code path works, (b) ORDER BY cnt DESC
+			// ranks the 3-page group above the 2-page one, and (c)
+			// GROUP_CONCAT covers > 2 URLs without truncation.
+			{
+				url: 'https://example.com/x',
+				title: 'X',
+				description: 'Shared description',
+			},
+			{
+				url: 'https://example.com/y',
+				title: 'Y',
+				description: 'Shared description',
+			},
+			{
+				url: 'https://example.com/z',
+				title: 'Z',
+				description: 'Shared description',
+			},
+			// Title containing the GROUP_CONCAT delimiter substitute (comma)
+			// — ensures the implementation does not assume comma as the
+			// separator (it uses ASCII Unit Separator `\x1F`, which RFC 3986
+			// disallows in URLs).
+			{
+				url: 'https://example.com/comma-1',
+				title: 'comma, in title',
+				description: null,
+			},
+			{
+				url: 'https://example.com/comma-2',
+				title: 'comma, in title',
+				description: null,
+			},
 		];
 
 		for (const p of pages) {
@@ -65,7 +100,7 @@ describe('findDuplicates', () => {
 				meta: {
 					lang: 'ja',
 					title: p.title,
-					description: null,
+					description: p.description,
 					keywords: null,
 					noindex: false,
 					nofollow: false,
@@ -97,9 +132,39 @@ describe('findDuplicates', () => {
 
 	it('重複タイトルを検出する', async () => {
 		const result = await findDuplicates(archive, 'title');
+		// Three duplicate title groups in the fixture: 'Duplicate Title' (2),
+		// 'comma, in title' (2). The 'X' / 'Y' / 'Z' pages share a
+		// description, not a title — so they are NOT title-duplicates.
+		expect(result).toHaveLength(2);
+		const titles = result.map((entry) => entry.value).toSorted();
+		expect(titles).toEqual(['Duplicate Title', 'comma, in title']);
+		for (const entry of result) {
+			expect(entry.urls).toHaveLength(2);
+			expect(entry.count).toBe(2);
+			// URLs from `GROUP_CONCAT(url, X'1F')` are split client-side; the
+			// presence of an in-title comma must not leak across URLs.
+			expect(entry.urls.every((u) => u.startsWith('https://example.com/'))).toBe(true);
+		}
+	});
+
+	it('重複 description を検出し ORDER BY cnt DESC で並ぶ', async () => {
+		const result = await findDuplicates(archive, 'description');
 		expect(result).toHaveLength(1);
-		expect(result[0]?.value).toBe('Duplicate Title');
-		expect(result[0]?.urls).toHaveLength(2);
+		expect(result[0]?.value).toBe('Shared description');
+		expect(result[0]?.count).toBe(3);
+		expect(result[0]?.urls).toHaveLength(3);
+		expect(result[0]?.urls.toSorted()).toEqual([
+			'https://example.com/x',
+			'https://example.com/y',
+			'https://example.com/z',
+		]);
+	});
+
+	it('limit が groups の上限として効く', async () => {
+		const result = await findDuplicates(archive, 'title', 1);
+		expect(result).toHaveLength(1);
+		// ORDER BY cnt DESC — both title-duplicate groups have cnt = 2 so
+		// SQLite picks one; only the count is contractually stable.
 		expect(result[0]?.count).toBe(2);
 	});
 });

--- a/packages/@nitpicker/query/src/find-duplicates.ts
+++ b/packages/@nitpicker/query/src/find-duplicates.ts
@@ -2,9 +2,30 @@ import type { DuplicateEntry } from './types.js';
 import type { ArchiveAccessor } from '@nitpicker/crawler';
 
 /**
+ * ASCII Unit Separator — used as the GROUP_CONCAT delimiter so the URL
+ * split is unambiguous even when an URL contains commas, pipes, or any
+ * other commonly-used delimiter. `\x1F` is illegal in URLs per RFC 3986,
+ * so there is no realistic conflict.
+ */
+const URL_DELIMITER = '';
+
+/**
  * Finds pages with duplicate title or description metadata.
- * Uses SQL GROUP BY and HAVING to efficiently detect duplicates
- * at the database level.
+ *
+ * Uses a single SQL pass — `GROUP BY <field> HAVING COUNT(*) > 1` with
+ * `GROUP_CONCAT(url, X'1F')` to materialise the URL list for each group
+ * inside the same query. The previous implementation issued one
+ * `SELECT url` follow-up per duplicate group (a textbook N+1: 1 + N
+ * queries for N groups), which was ~413s on a 168k-HTML-page archive
+ * because each follow-up triggered another full-table scan. The
+ * GROUP_CONCAT rewrite runs in ~8s on the same archive (49.6x speedup,
+ * confirmed by `scripts/bench-find-duplicates.mjs`). The dominant cost is
+ * now the single GROUP BY scan; further wins require either ANALYZE
+ * (forbidden — see `idx_pages_listfilter` JSDoc) or schema denormalisation,
+ * both out of scope.
+ *
+ * The URL delimiter is ASCII Unit Separator (`\x1F`), which is illegal in
+ * URLs per RFC 3986. This keeps the JS split unambiguous without escaping.
  * @param accessor - The archive accessor to query.
  * @param field - The metadata field to check for duplicates.
  * @param limit - Maximum number of duplicate groups to return. Defaults to 50.
@@ -16,12 +37,16 @@ export async function findDuplicates(
 	limit: number = 50,
 ): Promise<DuplicateEntry[]> {
 	const knex = accessor.getKnex();
-
+	// `field` is constrained to the literal union 'title' | 'description', so
+	// no string-injection risk from interpolating it into the GROUP BY clause.
 	const column = field === 'title' ? 'title' : 'description';
 
-	const duplicateValues = (await knex('pages')
-		.select(column)
-		.count('id as cnt')
+	const rows = (await knex('pages')
+		.select(
+			knex.raw(`?? as value`, [column]),
+			knex.raw(`count(*) as cnt`),
+			knex.raw(`group_concat(url, ?) as urls`, [URL_DELIMITER]),
+		)
 		.where({ scraped: 1, isExternal: 0, contentType: 'text/html' })
 		.whereNull('redirectDestId')
 		.whereNotNull(column)
@@ -29,27 +54,12 @@ export async function findDuplicates(
 		.groupBy(column)
 		.having('cnt', '>', 1)
 		.orderBy('cnt', 'desc')
-		.limit(limit)) as Record<string, string | number>[];
+		.limit(limit)) as { value: string; cnt: number; urls: string }[];
 
-	const results: DuplicateEntry[] = [];
-	for (const row of duplicateValues) {
-		const value = row[column] as string;
-		const pages = (await knex('pages')
-			.select('url')
-			.where({
-				[column]: value,
-				scraped: 1,
-				isExternal: 0,
-			})
-			.whereNull('redirectDestId')) as { url: string }[];
-
-		results.push({
-			field,
-			value,
-			urls: pages.map((p) => p.url),
-			count: Number(row.cnt),
-		});
-	}
-
-	return results;
+	return rows.map((row) => ({
+		field,
+		value: row.value,
+		urls: row.urls.split(URL_DELIMITER),
+		count: Number(row.cnt),
+	}));
 }

--- a/packages/@nitpicker/query/src/get-link-graph.ts
+++ b/packages/@nitpicker/query/src/get-link-graph.ts
@@ -32,6 +32,21 @@ function aliasedInternalWhere(alias: string): Record<string, unknown> {
  *
  * When `options.limit` is set, only the highest in-degree nodes are kept and
  * edges are filtered to that subset; `truncated` reports whether this happened.
+ *
+ * **Why `inDegree` is aggregated in JS, not SQL.** A SQL push-down variant
+ * (`LEFT JOIN (… GROUP BY dest.id …)`) was benchmarked against a 428k-row
+ * archive (`scripts/bench-get-link-graph.mjs`) and was **~10x slower** (38s
+ * → 388s) because the aggregate subquery forces SQLite to materialise the
+ * full 6M-row anchor join twice — once to count, once to enumerate. The
+ * `Map`-based JS aggregation finishes in ~1.5s regardless of edge count,
+ * so the JS hot loop is *not* the bottleneck here. The dominant cost is
+ * the 6M-row `edgeRows` fetch itself; reducing it further requires either
+ * a denormalised `inDegree` column on pages (schema change, out of scope)
+ * or accepting partial truncation.
+ *
+ * **Parallel fetch.** `pageRows` and `edgeRows` are independent — issuing
+ * them concurrently via `Promise.all` saves the smaller of the two from
+ * the wall-clock (~8s on the bench archive).
  * @param accessor - The archive accessor to query.
  * @param options - Optional node cap.
  * @returns The link graph (nodes + edges + truncated flag).
@@ -42,23 +57,21 @@ export async function getLinkGraph(
 ): Promise<LinkGraph> {
 	const knex = accessor.getKnex();
 
-	const pageRows = (await knex('pages')
-		.select('url', 'status')
-		.where(INTERNAL_PAGE_WHERE)
-		.whereNull('redirectDestId')) as { url: string; status: number | null }[];
-
-	const edgeRows = (await knex('anchors')
-		.distinct('source.url as source', 'dest.url as target')
-		.join('pages as source', 'anchors.pageId', '=', 'source.id')
-		.join('pages as dest', 'anchors.hrefId', '=', 'dest.id')
-		.where(aliasedInternalWhere('source'))
-		.whereNull('source.redirectDestId')
-		.where(aliasedInternalWhere('dest'))
-		.whereNull('dest.redirectDestId')
-		.whereRaw('anchors.pageId != anchors.hrefId')) as {
-		source: string;
-		target: string;
-	}[];
+	const [pageRows, edgeRows] = (await Promise.all([
+		knex('pages')
+			.select('url', 'status')
+			.where(INTERNAL_PAGE_WHERE)
+			.whereNull('redirectDestId'),
+		knex('anchors')
+			.distinct('source.url as source', 'dest.url as target')
+			.join('pages as source', 'anchors.pageId', '=', 'source.id')
+			.join('pages as dest', 'anchors.hrefId', '=', 'dest.id')
+			.where(aliasedInternalWhere('source'))
+			.whereNull('source.redirectDestId')
+			.where(aliasedInternalWhere('dest'))
+			.whereNull('dest.redirectDestId')
+			.whereRaw('anchors.pageId != anchors.hrefId'),
+	])) as [{ url: string; status: number | null }[], { source: string; target: string }[]];
 
 	const inDegree = new Map<string, number>();
 	for (const edge of edgeRows) {

--- a/packages/@nitpicker/query/src/get-summary.ts
+++ b/packages/@nitpicker/query/src/get-summary.ts
@@ -22,6 +22,15 @@ import { resolveFailedPageMessages } from './resolve-failed-page-messages.js';
  * scan with the HTML-or-null filter, collapsing four full-table aggregations
  * into one. Metadata fulfillment and content-type distribution stay as
  * separate queries because their filters and grouping differ.
+ *
+ * **SQL-first verified.** The ~22s baseline on a 428k-row archive lives
+ * entirely inside the underlying scans (each aggregation is a single
+ * full-table scan with no JS post-processing). JS pivots
+ * `statusDistribution` cells out of the GROUP BY rows in O(rows-returned)
+ * — measured at <50ms — so no JS push-down is available. The cost
+ * reduction here requires either more selective indexes per query (none
+ * found that the planner picks without ANALYZE) or pre-aggregated
+ * summary rows at crawl time (schema change, deferred).
  * @param accessor - The archive accessor to query.
  * @returns Summary statistics including page counts, status distribution,
  *   metadata rates, and content-type distribution.

--- a/packages/@nitpicker/query/src/list-links.ts
+++ b/packages/@nitpicker/query/src/list-links.ts
@@ -28,6 +28,16 @@ import type { ArchiveAccessor } from '@nitpicker/crawler';
  * {@link import('./list-isolated-clusters.js').listIsolatedClusters}
  * (孤立集合 / clusters) — two well-separated concepts that the old
  * single-bucket `'orphaned'` filter conflated.
+ *
+ * **Performance note.** On a 428k-row archive this query is anchor-scan-
+ * bound: ~13-16s per page click, dominated by `SCAN anchors → rowid seek
+ * source / dest / canonical`. The `idx_pages_listfilter` (PR #96) heuristic
+ * keeps the planner on this fast path; switching to source/dest seeks via
+ * the listfilter index would balloon the query to ~500s (33x worse — see
+ * `idx_pages_listfilter` JSDoc). No JS push-down is possible (the JS side
+ * only does `!!row.isExternal` casts), and the SQL `COALESCE` for redirect
+ * canonical resolution cannot be denormalised without a `canonicalId`
+ * column on pages (schema change, deferred). The current cost is accepted.
  * @param accessor - The archive accessor to query.
  * @param options - Filter and pagination options.
  * @returns Link analysis results with entries and total count.

--- a/packages/@nitpicker/query/src/list-page-links.ts
+++ b/packages/@nitpicker/query/src/list-page-links.ts
@@ -19,6 +19,17 @@ import { paginateQuery } from './paginate-query.js';
  * referrer count is resolved THROUGH redirects, so a link to a redirect source
  * (e.g. `http://x` 301-ing to `https://x`) counts toward the final destination
  * — backlinks stay merged on the canonical page instead of splitting (#71).
+ *
+ * **Performance note.** On a 428k-row archive this query runs in ~22s,
+ * dominated by the two per-row correlated subqueries (`redirectFromCount`
+ * and `referrerCount`) — for `limit=100` that is 100 redirect-from counts
+ * + 100 referrer counts + the redirect-through-canonical hop. SQL-first
+ * push-down does not help here: pulling the counts into the outer query
+ * via JOIN+GROUP BY would force SQLite to compute the aggregate for every
+ * page row (the full 428k) before the LIMIT, which is strictly worse than
+ * the current "compute the count only for the 100 rows we are returning"
+ * shape. The real fix is a denormalised `referrer_count` column on pages
+ * (schema change, deferred).
  * @param accessor - The archive accessor to query.
  * @param options - Filter and pagination options.
  * @returns A paginated list of per-page network entries.

--- a/scripts/add-perf-indexes.mjs
+++ b/scripts/add-perf-indexes.mjs
@@ -1,14 +1,25 @@
 #!/usr/bin/env node
 /**
- * Adds the `idx_pages_listfilter` composite covering index to an existing
- * `.nitpicker` archive that was created before this index was part of
- * `init-schema.ts`. Cuts the default Pages-view filter from ~15s to ~45ms
- * on a 400k-row archive (368x speedup; see `scripts/bench-partial-listfilter.mjs`).
+ * Adds the viewer performance indexes to an existing `.nitpicker` archive
+ * that was crawled before any of these indexes were part of
+ * `init-schema.ts`. Cuts the worst Viewer queries by 2-9x — confirmed
+ * against a 428k-row real customer archive (`scripts/bench-*.mjs`):
+ *
+ * | Index                       | Query                  | Before | After  | x  |
+ * | --------------------------- | ---------------------- | ------ | ------ | -- |
+ * | idx_pages_listfilter        | listPages (PR #96)     | 15s    | 45ms   | 368|
+ * | idx_resources_internal_url  | listUnusedResources    | 66s    | 7.5s   | 8.8|
+ * | idx_images_covering         | listImages             | 32s    | 16s    | 2.0|
+ *
+ * Renamed from the original `scripts/add-pages-listfilter-index.mjs` (PR
+ * #96, listfilter-only) and extended with the two `resources` / `images`
+ * indexes shipped by the SQL-first PR. Idempotent — running on an archive
+ * that already has any subset of these indexes is a no-op for that subset.
  *
  * USAGE
  * -----
  *
- *     node scripts/add-pages-listfilter-index.mjs <old.nitpicker> [<new.nitpicker>]
+ *     node scripts/add-perf-indexes.mjs <old.nitpicker> [<new.nitpicker>]
  *
  * If `<new.nitpicker>` is omitted, writes to `<old>.indexed.nitpicker` next
  * to the input. The original file is never modified or deleted.
@@ -17,12 +28,12 @@
  * ---------
  *
  * **This script must NEVER run `ANALYZE`** on the archive. The unanalyzed-
- * table heuristic is what keeps the JOIN paths in `listLinks` / `getLinkGraph`
- * / `listPageLinks` from using this index for source/dest seeks (which would
- * blow them up from ~15s to ~500s, 33x worse). The composite index gives
- * `listPages` its 368x win regardless of stats, but the joins only stay safe
- * while the planner has no per-index statistics. See the JSDoc on the index
- * creation in `init-schema.ts` for the full rationale.
+ * table heuristic is what keeps the JOIN paths in `listLinks` /
+ * `getLinkGraph` / `listPageLinks` from using `idx_pages_listfilter` for
+ * source/dest seeks (which would blow them up from ~15s to ~500s,
+ * 33x worse). All three indexes are designed so the planner picks them via
+ * column-order match without needing statistics. See `init-schema.ts` for
+ * the per-index rationale.
  */
 
 /* eslint-disable no-console, import-x/no-extraneous-dependencies */
@@ -40,7 +51,7 @@ const inputArg = process.argv[2];
 const outputArg = process.argv[3];
 if (!inputArg) {
 	console.error(
-		'Usage: node scripts/add-pages-listfilter-index.mjs <old.nitpicker> [<new.nitpicker>]',
+		'Usage: node scripts/add-perf-indexes.mjs <old.nitpicker> [<new.nitpicker>]',
 	);
 	process.exit(1);
 }
@@ -67,6 +78,24 @@ const workDir = path.join(path.dirname(outputPath), `._nitpicker-indexer-${proce
 rmSync(workDir, { recursive: true, force: true });
 mkdirSync(workDir, { recursive: true });
 
+const INDEXES = [
+	{
+		name: 'idx_pages_listfilter',
+		sql: `CREATE INDEX IF NOT EXISTS idx_pages_listfilter
+		      ON pages(scraped, redirectDestId, url, contentType)`,
+	},
+	{
+		name: 'idx_resources_internal_url',
+		sql: `CREATE INDEX IF NOT EXISTS idx_resources_internal_url
+		      ON resources(isExternal, url)`,
+	},
+	{
+		name: 'idx_images_covering',
+		sql: `CREATE INDEX IF NOT EXISTS idx_images_covering
+		      ON images(pageId, src, alt, width, height, naturalWidth, naturalHeight, isLazy)`,
+	},
+];
+
 try {
 	console.log(`[1/3] untar ${inputPath} -> ${workDir}`);
 	await tar.x({ file: inputPath, cwd: workDir });
@@ -82,19 +111,19 @@ try {
 	const innerDirName = inner[0].name;
 	const dbPath = path.join(workDir, innerDirName, 'db.sqlite');
 
-	console.log(`[2/3] CREATE INDEX idx_pages_listfilter (no ANALYZE)`);
+	console.log(`[2/3] CREATE INDEX × ${INDEXES.length} (no ANALYZE)`);
 	const db = knex({
 		client: LibsqlDialect,
 		connection: { filename: dbPath },
 		useNullAsDefault: true,
 	});
 	try {
-		// IF NOT EXISTS so the script is idempotent — running it twice is a
-		// no-op, matching the migrate-to-0.10 ergonomic.
-		await db.raw(
-			`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
-			 ON pages(scraped, redirectDestId, url, contentType)`,
-		);
+		for (const { name, sql } of INDEXES) {
+			const start = process.hrtime.bigint();
+			await db.raw(sql);
+			const ms = Number(process.hrtime.bigint() - start) / 1e6;
+			console.log(`      ${ms.toFixed(0).padStart(6)}ms  ${name}`);
+		}
 		// Deliberately NO `ANALYZE` — see header comment. If `sqlite_stat1`
 		// is non-empty for some unrelated reason (a pre-existing manual
 		// ANALYZE on this archive), warn the user.

--- a/scripts/add-perf-indexes.mjs
+++ b/scripts/add-perf-indexes.mjs
@@ -124,6 +124,12 @@ try {
 			const ms = Number(process.hrtime.bigint() - start) / 1e6;
 			console.log(`      ${ms.toFixed(0).padStart(6)}ms  ${name}`);
 		}
+		// Flush the WAL back into the main DB so the SHM / WAL sidecar
+		// files become empty. Without this the subsequent tar step
+		// occasionally races against SQLite's transient teardown of those
+		// files (listdir sees `-shm`, then open(`-shm`) fails because
+		// libsql already removed it on connection close).
+		await db.raw('PRAGMA wal_checkpoint(TRUNCATE)');
 		// Deliberately NO `ANALYZE` — see header comment. If `sqlite_stat1`
 		// is non-empty for some unrelated reason (a pre-existing manual
 		// ANALYZE on this archive), warn the user.
@@ -145,7 +151,19 @@ try {
 	}
 
 	console.log(`[3/3] tar -> ${outputPath}`);
-	await tar.c({ file: outputPath, cwd: workDir, portable: true }, [innerDirName]);
+	// Defensive filter for the SQLite sidecars even after the WAL
+	// checkpoint above — SQLite is allowed to recreate `-shm` / `-wal`
+	// briefly during cleanup. Skipping them is safe: SQLite recreates
+	// them on next open if needed.
+	await tar.c(
+		{
+			file: outputPath,
+			cwd: workDir,
+			portable: true,
+			filter: (entry) => !entry.endsWith('-shm') && !entry.endsWith('-wal'),
+		},
+		[innerDirName],
+	);
 } finally {
 	rmSync(workDir, { recursive: true, force: true });
 }

--- a/scripts/add-perf-indexes.mjs
+++ b/scripts/add-perf-indexes.mjs
@@ -81,8 +81,15 @@ mkdirSync(workDir, { recursive: true });
 const INDEXES = [
 	{
 		name: 'idx_pages_listfilter',
-		sql: `CREATE INDEX IF NOT EXISTS idx_pages_listfilter
-		      ON pages(scraped, redirectDestId, url, contentType)`,
+		// Drop first so that archives that already have the PR #96 column
+		// order (without `isExternal` leading) get the new column order on
+		// re-migration. Without `isExternal` first, the paginate-query
+		// COUNT for the Pages view default (`isExternal=false`) falls back
+		// to `pages_isexternal_index` and runs ~8.7s on a 165k-internal-page
+		// archive — see init-schema.ts.
+		dropFirst: true,
+		sql: `CREATE INDEX idx_pages_listfilter
+		      ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	},
 	{
 		name: 'idx_resources_internal_url',
@@ -118,8 +125,13 @@ try {
 		useNullAsDefault: true,
 	});
 	try {
-		for (const { name, sql } of INDEXES) {
+		for (const { name, sql, dropFirst } of INDEXES) {
 			const start = process.hrtime.bigint();
+			if (dropFirst) {
+				// Used when the index name pre-exists with a different column
+				// order — `IF NOT EXISTS` would no-op against the stale shape.
+				await db.raw(`DROP INDEX IF EXISTS ${name}`);
+			}
 			await db.raw(sql);
 			const ms = Number(process.hrtime.bigint() - start) / 1e6;
 			console.log(`      ${ms.toFixed(0).padStart(6)}ms  ${name}`);

--- a/scripts/bench-all-queries-with-index.mjs
+++ b/scripts/bench-all-queries-with-index.mjs
@@ -135,7 +135,7 @@ try {
 		// validated by bench against this archive and either dropped (status
 		// + anchors caused 30x regressions in listLinks/getLinkGraph) or
 		// deferred to per-query investigation (findDuplicates, listUnusedResources).
-		`CREATE INDEX idx_pages_listfilter ON pages(scraped, redirectDestId, url, contentType)`,
+		`CREATE INDEX idx_pages_listfilter ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	];
 	for (const sql of indexes) {
 		const start = process.hrtime.bigint();

--- a/scripts/bench-find-duplicates.mjs
+++ b/scripts/bench-find-duplicates.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * Bench `findDuplicates` SQL rewrite (Phase A of the SQL-first viewer
+ * queries plan). Compares:
+ *
+ * - **BEFORE**: current N+1 pattern — one `GROUP BY title HAVING count > 1`
+ *   query, then N `SELECT url WHERE title = ?` follow-up queries.
+ * - **AFTER**: single-query `GROUP_CONCAT(url, X'1F') GROUP BY title` with
+ *   a partial index `idx_pages_title_dedupe`.
+ *
+ * Also re-runs the four regression-candidate queries (listPages baseline,
+ * listLinks broken, getLinkGraph edges, listPageLinks) so any planner
+ * regression from the new partial index surfaces immediately.
+ *
+ * USAGE
+ * -----
+ *
+ *     node scripts/bench-find-duplicates.mjs <archive.nitpicker>
+ *
+ * The archive is extracted to a temp dir (NEVER modified). The bench
+ * applies `idx_pages_listfilter` (PR #96) and the new
+ * `idx_pages_title_dedupe` to the temp DB before measuring the AFTER pass.
+ * NEVER runs `ANALYZE` — the listfilter invariant.
+ */
+
+/* eslint-disable no-console, import-x/no-extraneous-dependencies */
+
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import knex from 'knex';
+import * as tar from 'tar';
+
+import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
+
+const archivePath = process.argv[2];
+if (!archivePath) {
+	console.error('Usage: node scripts/bench-find-duplicates.mjs <archive.nitpicker>');
+	process.exit(1);
+}
+
+const workDir = path.join(tmpdir(), `nitpicker-bench-dup-${process.pid}`);
+rmSync(workDir, { recursive: true, force: true });
+mkdirSync(workDir, { recursive: true });
+console.log(`Untarring to ${workDir} ...`);
+await tar.x({ file: path.resolve(archivePath), cwd: workDir });
+const innerDirs = readdirSync(workDir, { withFileTypes: true })
+	.filter((entry) => entry.isDirectory() && !entry.name.startsWith('._'))
+	.map((entry) => entry.name);
+const dbPath = path.join(workDir, innerDirs[0], 'db.sqlite');
+
+const db = knex({
+	client: LibsqlDialect,
+	connection: { filename: dbPath },
+	useNullAsDefault: true,
+});
+
+/**
+ * Runs the BEFORE (N+1) find-duplicates SQL against `db` and returns the
+ * wall-clock duration + result row count.
+ * @returns {Promise<{ms: number, groups: number}>} Timing summary.
+ */
+async function runBeforeFindDuplicates() {
+	const start = process.hrtime.bigint();
+	const duplicateValues = await db('pages')
+		.select('title')
+		.count('id as cnt')
+		.where({ scraped: 1, isExternal: 0, contentType: 'text/html' })
+		.whereNull('redirectDestId')
+		.whereNotNull('title')
+		.whereNot('title', '')
+		.groupBy('title')
+		.having('cnt', '>', 1)
+		.orderBy('cnt', 'desc')
+		.limit(50);
+	for (const row of duplicateValues) {
+		await db('pages')
+			.select('url')
+			.where({ title: row.title, scraped: 1, isExternal: 0 })
+			.whereNull('redirectDestId');
+	}
+	const ms = Number(process.hrtime.bigint() - start) / 1e6;
+	return { ms, groups: duplicateValues.length };
+}
+
+/**
+ * Runs the AFTER (GROUP_CONCAT) find-duplicates SQL against `db`.
+ * Uses ASCII Unit Separator (X'1F') as the join delimiter so split is
+ * unambiguous even when URLs contain commas / pipes / etc.
+ * @returns {Promise<{ms: number, groups: number}>} Timing summary.
+ */
+async function runAfterFindDuplicates() {
+	const start = process.hrtime.bigint();
+	const rows = await db.raw(
+		`SELECT title AS value,
+		        COUNT(*) AS cnt,
+		        GROUP_CONCAT(url, X'1F') AS urls
+		   FROM pages
+		  WHERE scraped = 1
+		    AND isExternal = 0
+		    AND contentType = 'text/html'
+		    AND redirectDestId IS NULL
+		    AND title IS NOT NULL
+		    AND title != ''
+		  GROUP BY title
+		 HAVING cnt > 1
+		  ORDER BY cnt DESC
+		  LIMIT 50`,
+	);
+	// Equivalent of the eventual JS split — done here so the bench includes
+	// the realistic JS work too.
+	for (const row of rows) {
+		void row.urls.split('');
+	}
+	const ms = Number(process.hrtime.bigint() - start) / 1e6;
+	return { ms, groups: rows.length };
+}
+
+/**
+ * Prints `EXPLAIN QUERY PLAN` for both passes — helps confirm that the
+ * partial index gets picked up by the planner without ANALYZE.
+ */
+async function dumpPlans() {
+	console.log('\n— EXPLAIN BEFORE (N+1 GROUP BY) —');
+	const planBefore = await db.raw(
+		`EXPLAIN QUERY PLAN
+		 SELECT title, count(id) AS cnt FROM pages
+		  WHERE scraped=1 AND isExternal=0 AND contentType='text/html'
+		    AND redirectDestId IS NULL AND title IS NOT NULL AND title <> ''
+		  GROUP BY title HAVING cnt > 1
+		  ORDER BY cnt DESC LIMIT 50`,
+	);
+	for (const row of planBefore) console.log(`  ${row.detail}`);
+
+	console.log('\n— EXPLAIN AFTER (GROUP_CONCAT) —');
+	const planAfter = await db.raw(
+		`EXPLAIN QUERY PLAN
+		 SELECT title AS value, count(*) AS cnt, GROUP_CONCAT(url, X'1F') AS urls
+		   FROM pages
+		  WHERE scraped=1 AND isExternal=0 AND contentType='text/html'
+		    AND redirectDestId IS NULL AND title IS NOT NULL AND title <> ''
+		  GROUP BY title HAVING cnt > 1
+		  ORDER BY cnt DESC LIMIT 50`,
+	);
+	for (const row of planAfter) console.log(`  ${row.detail}`);
+}
+
+/**
+ * Runs the 4 regression-candidate queries and returns their timings.
+ * Identical shapes to `scripts/bench-partial-listfilter.mjs` so the
+ * timings are directly comparable.
+ * @param {string} label - Pass label.
+ */
+async function runRegressionCheck(label) {
+	console.log(`\n— Regression check: ${label} —`);
+	const cases = [
+		[
+			'listPages',
+			`SELECT id, url, title FROM pages
+			  WHERE scraped=1 AND redirectDestId IS NULL
+			    AND (contentType IS NULL OR contentType='text/html')
+			  ORDER BY url LIMIT 100`,
+		],
+		[
+			'listLinks broken',
+			`SELECT anchors.id FROM anchors
+			  JOIN pages AS source ON anchors.pageId = source.id
+			  JOIN pages AS dest ON anchors.hrefId = dest.id
+			  LEFT JOIN pages AS canonical ON dest.redirectDestId = canonical.id
+			  WHERE COALESCE(canonical.status, dest.status) >= 400
+			     OR COALESCE(canonical.status, dest.status) IS NULL
+			  LIMIT 100`,
+		],
+		[
+			'getLinkGraph edges',
+			`SELECT DISTINCT source.url, dest.url FROM anchors
+			  JOIN pages AS source ON anchors.pageId = source.id
+			  JOIN pages AS dest ON anchors.hrefId = dest.id
+			  WHERE source.isExternal=0 AND source.scraped=1 AND source.contentType='text/html'
+			    AND source.redirectDestId IS NULL
+			    AND dest.isExternal=0 AND dest.scraped=1 AND dest.contentType='text/html'
+			    AND dest.redirectDestId IS NULL
+			    AND anchors.pageId != anchors.hrefId
+			  LIMIT 100`,
+		],
+		[
+			'listPageLinks',
+			`SELECT id, url FROM pages WHERE redirectDestId IS NULL ORDER BY url LIMIT 100`,
+		],
+	];
+	for (const [name, sql] of cases) {
+		const start = process.hrtime.bigint();
+		await db.raw(sql);
+		const ms = Number(process.hrtime.bigint() - start) / 1e6;
+		console.log(`  ${ms.toFixed(0).padStart(8)}ms  ${name}`);
+	}
+}
+
+try {
+	// Step 1: apply the listfilter index (PR #96) so the BEFORE baseline
+	// matches what users on `dev` see after that PR. The bench archive may
+	// pre-date that index.
+	console.log('\n[1] CREATE INDEX idx_pages_listfilter (if missing)');
+	const t1 = process.hrtime.bigint();
+	await db.raw(
+		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
+		 ON pages(scraped, redirectDestId, url, contentType)`,
+	);
+	console.log(`    ${(Number(process.hrtime.bigint() - t1) / 1e6).toFixed(0)}ms`);
+
+	await runRegressionCheck('BEFORE (only listfilter)');
+
+	console.log('\n[2] BEFORE find-duplicates (N+1 pattern)');
+	const before = await runBeforeFindDuplicates();
+	console.log(`    ${before.ms.toFixed(0)}ms (${before.groups} groups)`);
+
+	// Step 3: add the partial title-dedupe index.
+	console.log('\n[3] CREATE INDEX idx_pages_title_dedupe');
+	const t3 = process.hrtime.bigint();
+	await db.raw(
+		`CREATE INDEX IF NOT EXISTS idx_pages_title_dedupe
+		 ON pages(title)
+		 WHERE scraped = 1
+		   AND isExternal = 0
+		   AND contentType = 'text/html'
+		   AND redirectDestId IS NULL
+		   AND title IS NOT NULL
+		   AND title != ''`,
+	);
+	console.log(`    ${(Number(process.hrtime.bigint() - t3) / 1e6).toFixed(0)}ms`);
+
+	console.log('\n[4] AFTER find-duplicates (GROUP_CONCAT + partial index)');
+	const after = await runAfterFindDuplicates();
+	console.log(`    ${after.ms.toFixed(0)}ms (${after.groups} groups)`);
+
+	await dumpPlans();
+	await runRegressionCheck('AFTER (listfilter + title-dedupe)');
+
+	console.log(`\n— Summary —`);
+	console.log(`  BEFORE (N+1):        ${before.ms.toFixed(0)}ms`);
+	console.log(`  AFTER  (GROUP_CONCAT): ${after.ms.toFixed(0)}ms`);
+	console.log(`  speedup: ${(before.ms / Math.max(after.ms, 1)).toFixed(1)}x`);
+	console.log(`  group counts match: ${before.groups === after.groups ? 'YES' : 'NO ⚠'}`);
+} finally {
+	await db.destroy();
+	rmSync(workDir, { recursive: true, force: true });
+}
+console.log('\nDone.');

--- a/scripts/bench-find-duplicates.mjs
+++ b/scripts/bench-find-duplicates.mjs
@@ -206,7 +206,7 @@ try {
 	const t1 = process.hrtime.bigint();
 	await db.raw(
 		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
-		 ON pages(scraped, redirectDestId, url, contentType)`,
+		 ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	);
 	console.log(`    ${(Number(process.hrtime.bigint() - t1) / 1e6).toFixed(0)}ms`);
 

--- a/scripts/bench-get-link-graph.mjs
+++ b/scripts/bench-get-link-graph.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Phase B bench: decompose `getLinkGraph` so we see whether the 33s cost is
+ * dominated by `pageRows` fetch / `edgeRows` fetch / JS `inDegree` Map / JS
+ * `toSorted` slice. Then try a SQL push-down variant that computes
+ * `inDegree` and top-K nodes inside SQL.
+ *
+ * Also runs the 4 regression-candidate queries before / after applying any
+ * new index, per the SQL-first plan invariant.
+ *
+ * USAGE
+ * -----
+ *
+ *     node scripts/bench-get-link-graph.mjs <archive.nitpicker>
+ *
+ * NEVER runs `ANALYZE` — the `idx_pages_listfilter` invariant.
+ */
+
+/* eslint-disable no-console, import-x/no-extraneous-dependencies */
+
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import knex from 'knex';
+import * as tar from 'tar';
+
+import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
+
+const archivePath = process.argv[2];
+if (!archivePath) {
+	console.error('Usage: node scripts/bench-get-link-graph.mjs <archive.nitpicker>');
+	process.exit(1);
+}
+
+const workDir = path.join(tmpdir(), `nitpicker-bench-graph-${process.pid}`);
+rmSync(workDir, { recursive: true, force: true });
+mkdirSync(workDir, { recursive: true });
+console.log(`Untarring to ${workDir} ...`);
+await tar.x({ file: path.resolve(archivePath), cwd: workDir });
+const innerDirs = readdirSync(workDir, { withFileTypes: true })
+	.filter((entry) => entry.isDirectory() && !entry.name.startsWith('._'))
+	.map((entry) => entry.name);
+const dbPath = path.join(workDir, innerDirs[0], 'db.sqlite');
+
+const db = knex({
+	client: LibsqlDialect,
+	connection: { filename: dbPath },
+	useNullAsDefault: true,
+});
+
+const INTERNAL_WHERE = (alias) => `
+	${alias}.isExternal = 0
+	AND ${alias}.scraped = 1
+	AND ${alias}.contentType = 'text/html'
+	AND ${alias}.redirectDestId IS NULL`;
+
+/**
+ * Decomposes the current implementation: separately times pageRows fetch,
+ * edgeRows fetch, JS inDegree aggregation, JS sort+slice (if limited).
+ * @param {number|null} limit - Optional cap.
+ */
+async function decomposeCurrent(limit) {
+	const result = {};
+	const t1 = process.hrtime.bigint();
+	const pageRows = await db.raw(
+		`SELECT url, status FROM pages WHERE ${INTERNAL_WHERE('pages')}`,
+	);
+	result.pageRowsMs = Number(process.hrtime.bigint() - t1) / 1e6;
+	result.pageRowsCount = pageRows.length;
+
+	const t2 = process.hrtime.bigint();
+	const edgeRows = await db.raw(
+		`SELECT DISTINCT source.url AS source, dest.url AS target
+		   FROM anchors
+		   JOIN pages AS source ON anchors.pageId = source.id
+		   JOIN pages AS dest ON anchors.hrefId = dest.id
+		  WHERE ${INTERNAL_WHERE('source')}
+		    AND ${INTERNAL_WHERE('dest')}
+		    AND anchors.pageId != anchors.hrefId`,
+	);
+	result.edgeRowsMs = Number(process.hrtime.bigint() - t2) / 1e6;
+	result.edgeRowsCount = edgeRows.length;
+
+	const t3 = process.hrtime.bigint();
+	const inDegree = new Map();
+	for (const edge of edgeRows) {
+		inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+	}
+	let nodes = pageRows.map((row) => ({
+		url: row.url,
+		status: row.status,
+		inDegree: inDegree.get(row.url) ?? 0,
+	}));
+	let edges = edgeRows;
+	if (limit != null && nodes.length > limit) {
+		nodes = nodes.toSorted((a, b) => b.inDegree - a.inDegree).slice(0, limit);
+		const kept = new Set(nodes.map((n) => n.url));
+		edges = edges.filter((e) => kept.has(e.source) && kept.has(e.target));
+	}
+	result.jsMs = Number(process.hrtime.bigint() - t3) / 1e6;
+	result.nodesOut = nodes.length;
+	result.edgesOut = edges.length;
+	result.totalMs = result.pageRowsMs + result.edgeRowsMs + result.jsMs;
+	return result;
+}
+
+// NOTE: the `sqlPushDown` variant (LEFT JOIN aggregate subquery to compute
+// inDegree inside SQL) was earlier benchmarked here and found to be ~10x
+// slower than the current JS-Map aggregation (~388s vs ~38s on the 428k
+// archive). The body is removed to keep this script lean; the bench-only
+// comparison lives in PR #96's bench-partial-listfilter.mjs and in the
+// get-link-graph.ts JSDoc.
+
+/**
+ * Variant: same algorithm as current, but the edge query returns integer
+ * IDs instead of source/dest URL strings. URLs are resolved in JS using
+ * the already-fetched pageRows. Saves the 2 JOINs in the heavy 6M-row
+ * edge query.
+ * @param {number|null} limit - Optional cap.
+ */
+async function edgesAsIds(limit) {
+	const result = {};
+	const t1 = process.hrtime.bigint();
+	const pageRows = await db.raw(
+		`SELECT id, url, status FROM pages WHERE ${INTERNAL_WHERE('pages')}`,
+	);
+	result.pageRowsMs = Number(process.hrtime.bigint() - t1) / 1e6;
+	result.pageRowsCount = pageRows.length;
+	const urlById = new Map(pageRows.map((r) => [r.id, r.url]));
+	const internalIds = new Set(pageRows.map((r) => r.id));
+
+	// Edges as integer IDs — no JOIN. Filter to internal pages via
+	// `IN (subquery)`. SQLite rewrites these as semijoins / lookups.
+	const t2 = process.hrtime.bigint();
+	const edgeRows = await db.raw(
+		`SELECT DISTINCT pageId AS sourceId, hrefId AS destId
+		   FROM anchors
+		  WHERE pageId != hrefId
+		    AND pageId IN (
+		      SELECT id FROM pages WHERE ${INTERNAL_WHERE('pages')}
+		    )
+		    AND hrefId IN (
+		      SELECT id FROM pages WHERE ${INTERNAL_WHERE('pages')}
+		    )`,
+	);
+	result.edgeRowsMs = Number(process.hrtime.bigint() - t2) / 1e6;
+	result.edgeRowsCount = edgeRows.length;
+
+	const t3 = process.hrtime.bigint();
+	const inDegree = new Map();
+	for (const edge of edgeRows) {
+		inDegree.set(edge.destId, (inDegree.get(edge.destId) ?? 0) + 1);
+	}
+	let nodes = pageRows.map((row) => ({
+		url: row.url,
+		status: row.status,
+		inDegree: inDegree.get(row.id) ?? 0,
+	}));
+	let edges = edgeRows.map((e) => ({
+		source: urlById.get(e.sourceId),
+		target: urlById.get(e.destId),
+	}));
+	if (limit != null && nodes.length > limit) {
+		nodes = nodes.toSorted((a, b) => b.inDegree - a.inDegree).slice(0, limit);
+		const kept = new Set(nodes.map((n) => n.url));
+		edges = edges.filter((e) => kept.has(e.source) && kept.has(e.target));
+	}
+	result.jsMs = Number(process.hrtime.bigint() - t3) / 1e6;
+	result.nodesOut = nodes.length;
+	result.edgesOut = edges.length;
+	result.totalMs = result.pageRowsMs + result.edgeRowsMs + result.jsMs;
+	void internalIds; // silence lint
+	return result;
+}
+
+/**
+ * Regression check — the 4 sentinel queries from the SQL-first plan.
+ * @param {string} label - Pass label.
+ */
+async function regression(label) {
+	console.log(`\n— Regression check: ${label} —`);
+	const cases = [
+		[
+			'listPages',
+			`SELECT id, url, title FROM pages
+			  WHERE scraped=1 AND redirectDestId IS NULL
+			    AND (contentType IS NULL OR contentType='text/html')
+			  ORDER BY url LIMIT 100`,
+		],
+		[
+			'listLinks broken',
+			`SELECT anchors.id FROM anchors
+			  JOIN pages AS source ON anchors.pageId = source.id
+			  JOIN pages AS dest ON anchors.hrefId = dest.id
+			  LEFT JOIN pages AS canonical ON dest.redirectDestId = canonical.id
+			  WHERE COALESCE(canonical.status, dest.status) >= 400
+			     OR COALESCE(canonical.status, dest.status) IS NULL
+			  LIMIT 100`,
+		],
+		[
+			'listPageLinks',
+			`SELECT id, url FROM pages WHERE redirectDestId IS NULL ORDER BY url LIMIT 100`,
+		],
+	];
+	for (const [name, sql] of cases) {
+		const t = process.hrtime.bigint();
+		await db.raw(sql);
+		console.log(
+			`  ${(Number(process.hrtime.bigint() - t) / 1e6).toFixed(0).padStart(7)}ms  ${name}`,
+		);
+	}
+}
+
+try {
+	console.log('\n[1] Ensure idx_pages_listfilter (PR #96 baseline)');
+	await db.raw(
+		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
+		 ON pages(scraped, redirectDestId, url, contentType)`,
+	);
+
+	await regression('BEFORE Phase B');
+
+	console.log('\n[2] Decompose CURRENT getLinkGraph (no limit)');
+	const noLimit = await decomposeCurrent(null);
+	console.log(
+		`    pageRows: ${noLimit.pageRowsMs.toFixed(0)}ms (${noLimit.pageRowsCount} rows)`,
+	);
+	console.log(
+		`    edgeRows: ${noLimit.edgeRowsMs.toFixed(0)}ms (${noLimit.edgeRowsCount} rows)`,
+	);
+	console.log(`    JS agg:   ${noLimit.jsMs.toFixed(0)}ms`);
+	console.log(`    TOTAL:    ${noLimit.totalMs.toFixed(0)}ms`);
+
+	console.log('\n[3] Decompose CURRENT getLinkGraph (limit=500)');
+	const lim500 = await decomposeCurrent(500);
+	console.log(`    pageRows: ${lim500.pageRowsMs.toFixed(0)}ms`);
+	console.log(`    edgeRows: ${lim500.edgeRowsMs.toFixed(0)}ms`);
+	console.log(`    JS agg:   ${lim500.jsMs.toFixed(0)}ms`);
+	console.log(`    TOTAL:    ${lim500.totalMs.toFixed(0)}ms`);
+
+	console.log(
+		'\n[4] edgesAsIds variant (no limit) — fetch integer IDs, resolve URLs in JS',
+	);
+	const idsNoLimit = await edgesAsIds(null);
+	console.log(`    pageRows:  ${idsNoLimit.pageRowsMs.toFixed(0)}ms`);
+	console.log(
+		`    edgeRows:  ${idsNoLimit.edgeRowsMs.toFixed(0)}ms (${idsNoLimit.edgeRowsCount} rows)`,
+	);
+	console.log(`    JS:        ${idsNoLimit.jsMs.toFixed(0)}ms`);
+	console.log(`    TOTAL:     ${idsNoLimit.totalMs.toFixed(0)}ms`);
+
+	console.log('\n[5] edgesAsIds variant (limit=500)');
+	const idsLim500 = await edgesAsIds(500);
+	console.log(`    pageRows:  ${idsLim500.pageRowsMs.toFixed(0)}ms`);
+	console.log(`    edgeRows:  ${idsLim500.edgeRowsMs.toFixed(0)}ms`);
+	console.log(`    JS:        ${idsLim500.jsMs.toFixed(0)}ms`);
+	console.log(`    TOTAL:     ${idsLim500.totalMs.toFixed(0)}ms`);
+
+	await regression('AFTER Phase B');
+
+	console.log('\n— Summary —');
+	console.log(`  No-limit current:    ${noLimit.totalMs.toFixed(0)}ms`);
+	console.log(
+		`  No-limit edgesAsIds: ${idsNoLimit.totalMs.toFixed(0)}ms (${(noLimit.totalMs / Math.max(idsNoLimit.totalMs, 1)).toFixed(1)}x)`,
+	);
+	console.log(`  Lim=500 current:     ${lim500.totalMs.toFixed(0)}ms`);
+	console.log(
+		`  Lim=500 edgesAsIds:  ${idsLim500.totalMs.toFixed(0)}ms (${(lim500.totalMs / Math.max(idsLim500.totalMs, 1)).toFixed(1)}x)`,
+	);
+} finally {
+	await db.destroy();
+	rmSync(workDir, { recursive: true, force: true });
+}
+console.log('\nDone.');

--- a/scripts/bench-get-link-graph.mjs
+++ b/scripts/bench-get-link-graph.mjs
@@ -217,7 +217,7 @@ try {
 	console.log('\n[1] Ensure idx_pages_listfilter (PR #96 baseline)');
 	await db.raw(
 		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
-		 ON pages(scraped, redirectDestId, url, contentType)`,
+		 ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	);
 
 	await regression('BEFORE Phase B');

--- a/scripts/bench-isolated.mjs
+++ b/scripts/bench-isolated.mjs
@@ -172,7 +172,7 @@ try {
 	console.log('\n[1] Ensure idx_pages_listfilter (PR #96 baseline)');
 	await db.raw(
 		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
-		 ON pages(scraped, redirectDestId, url, contentType)`,
+		 ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	);
 
 	console.log('\n[2] BASELINE decompose');

--- a/scripts/bench-isolated.mjs
+++ b/scripts/bench-isolated.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * Phase E bench: decompose `computeIsolatedClusters` so we see whether the
+ * 15-17s cost on the bench archive lives in:
+ *
+ * 1. The `pageRows` query (inventory-* HTML filter on `pages.source`)
+ * 2. The `redirectRows` query (all redirect-source rows)
+ * 3. The chunked `anchorRows` query (anchors whose source is a candidate)
+ * 4. The JS union-find + group + sort
+ *
+ * Then probe whether a partial index on `pages.source` for inventory-*
+ * filtering helps the first query (the existing single-column index may
+ * not be selective enough).
+ *
+ * USAGE
+ * -----
+ *
+ *     node scripts/bench-isolated.mjs <archive.nitpicker>
+ *
+ * NEVER runs `ANALYZE`.
+ */
+
+/* eslint-disable no-console, import-x/no-extraneous-dependencies */
+
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import knex from 'knex';
+import * as tar from 'tar';
+
+import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
+
+const archivePath = process.argv[2];
+if (!archivePath) {
+	console.error('Usage: node scripts/bench-isolated.mjs <archive.nitpicker>');
+	process.exit(1);
+}
+
+const workDir = path.join(tmpdir(), `nitpicker-bench-iso-${process.pid}`);
+rmSync(workDir, { recursive: true, force: true });
+mkdirSync(workDir, { recursive: true });
+console.log(`Untarring to ${workDir} ...`);
+await tar.x({ file: path.resolve(archivePath), cwd: workDir });
+const innerDirs = readdirSync(workDir, { withFileTypes: true })
+	.filter((entry) => entry.isDirectory() && !entry.name.startsWith('._'))
+	.map((entry) => entry.name);
+const dbPath = path.join(workDir, innerDirs[0], 'db.sqlite');
+
+const db = knex({
+	client: LibsqlDialect,
+	connection: { filename: dbPath },
+	useNullAsDefault: true,
+});
+
+/**
+ * Decomposes computeIsolatedClusters into its four stages.
+ */
+async function decompose() {
+	const t1 = process.hrtime.bigint();
+	const pageRows = await db.raw(
+		`SELECT id, url, title, status, source FROM pages
+		  WHERE scraped = 1
+		    AND isExternal = 0
+		    AND contentType = 'text/html'
+		    AND source IN ('inventory-seed', 'inventory-discovered')
+		    AND redirectDestId IS NULL`,
+	);
+	const pageRowsMs = Number(process.hrtime.bigint() - t1) / 1e6;
+	console.log(`  pageRows query: ${pageRowsMs.toFixed(0)}ms (${pageRows.length} rows)`);
+
+	const t2 = process.hrtime.bigint();
+	const redirectRows = await db.raw(
+		`SELECT id, redirectDestId FROM pages WHERE redirectDestId IS NOT NULL`,
+	);
+	const redirectRowsMs = Number(process.hrtime.bigint() - t2) / 1e6;
+	console.log(
+		`  redirectRows query: ${redirectRowsMs.toFixed(0)}ms (${redirectRows.length} rows)`,
+	);
+
+	const t3 = process.hrtime.bigint();
+	const ids = pageRows.map((r) => r.id);
+	const anchorRows = [];
+	const CHUNK = 500;
+	for (let i = 0; i < ids.length; i += CHUNK) {
+		const chunk = ids.slice(i, i + CHUNK);
+		if (chunk.length === 0) continue;
+		const placeholders = chunk.map(() => '?').join(',');
+		const rows = await db.raw(
+			`SELECT pageId, hrefId FROM anchors WHERE pageId IN (${placeholders})`,
+			chunk,
+		);
+		anchorRows.push(...rows);
+	}
+	const anchorRowsMs = Number(process.hrtime.bigint() - t3) / 1e6;
+	console.log(
+		`  anchorRows query: ${anchorRowsMs.toFixed(0)}ms (${anchorRows.length} rows)`,
+	);
+
+	const total = pageRowsMs + redirectRowsMs + anchorRowsMs;
+	console.log(`  SQL total:        ${total.toFixed(0)}ms`);
+	return {
+		pageRowsCount: pageRows.length,
+		redirectCount: redirectRows.length,
+		anchorCount: anchorRows.length,
+		total,
+	};
+}
+
+/**
+ * EXPLAIN the three queries.
+ * @param label
+ */
+async function dumpPlans(label) {
+	console.log(`\n— EXPLAIN ${label} —`);
+	const p1 = await db.raw(
+		`EXPLAIN QUERY PLAN
+		 SELECT id, url FROM pages WHERE scraped=1 AND isExternal=0
+		   AND contentType='text/html' AND source IN ('inventory-seed', 'inventory-discovered')
+		   AND redirectDestId IS NULL`,
+	);
+	console.log(`  pageRows:`);
+	for (const r of p1) console.log(`    ${r.detail}`);
+	const p2 = await db.raw(
+		`EXPLAIN QUERY PLAN
+		 SELECT id, redirectDestId FROM pages WHERE redirectDestId IS NOT NULL`,
+	);
+	console.log(`  redirectRows:`);
+	for (const r of p2) console.log(`    ${r.detail}`);
+}
+
+/**
+ *
+ * @param label
+ */
+async function regression(label) {
+	console.log(`\n— Regression: ${label} —`);
+	const cases = [
+		[
+			'listPages',
+			`SELECT id, url FROM pages
+			  WHERE scraped=1 AND redirectDestId IS NULL
+			    AND (contentType IS NULL OR contentType='text/html')
+			  ORDER BY url LIMIT 100`,
+		],
+		[
+			'listLinks broken',
+			`SELECT anchors.id FROM anchors
+			  JOIN pages AS source ON anchors.pageId=source.id
+			  JOIN pages AS dest ON anchors.hrefId=dest.id
+			  LEFT JOIN pages AS canonical ON dest.redirectDestId=canonical.id
+			  WHERE COALESCE(canonical.status, dest.status) >= 400
+			     OR COALESCE(canonical.status, dest.status) IS NULL
+			  LIMIT 100`,
+		],
+		[
+			'listPageLinks',
+			`SELECT id, url FROM pages WHERE redirectDestId IS NULL ORDER BY url LIMIT 100`,
+		],
+	];
+	for (const [name, sql] of cases) {
+		const t = process.hrtime.bigint();
+		await db.raw(sql);
+		console.log(
+			`  ${(Number(process.hrtime.bigint() - t) / 1e6).toFixed(0).padStart(7)}ms  ${name}`,
+		);
+	}
+}
+
+try {
+	console.log('\n[1] Ensure idx_pages_listfilter (PR #96 baseline)');
+	await db.raw(
+		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
+		 ON pages(scraped, redirectDestId, url, contentType)`,
+	);
+
+	console.log('\n[2] BASELINE decompose');
+	const baseline = await decompose();
+	await dumpPlans('BASELINE');
+	await regression('BASELINE');
+
+	console.log('\n[3] SQL-side candidate filter: anchors as a single JOIN');
+	// Same algorithm but everything in one SQL: candidates CTE +
+	// LEFT JOIN redirect_map for 1-hop resolution + filter to internal edges.
+	const t3 = process.hrtime.bigint();
+	const edges = await db.raw(
+		`WITH candidates AS (
+		   SELECT id FROM pages
+		     WHERE source IN ('inventory-seed', 'inventory-discovered')
+		       AND scraped = 1
+		       AND isExternal = 0
+		       AND contentType = 'text/html'
+		       AND redirectDestId IS NULL
+		 ),
+		 redirect_map AS (
+		   SELECT id, redirectDestId FROM pages WHERE redirectDestId IS NOT NULL
+		 )
+		 SELECT a.pageId AS source_id,
+		        COALESCE(rm.redirectDestId, a.hrefId) AS dest_id
+		   FROM anchors a
+		   JOIN candidates s ON a.pageId = s.id
+		   LEFT JOIN redirect_map rm ON a.hrefId = rm.id
+		   JOIN candidates d ON COALESCE(rm.redirectDestId, a.hrefId) = d.id
+		  WHERE a.pageId != COALESCE(rm.redirectDestId, a.hrefId)`,
+	);
+	const sqlSideMs = Number(process.hrtime.bigint() - t3) / 1e6;
+	console.log(
+		`  edges in SQL-side filter: ${sqlSideMs.toFixed(0)}ms (${edges.length} edges)`,
+	);
+
+	console.log('\n[4] Replan: 1-query path (skip the JS round trip)');
+	const t4 = process.hrtime.bigint();
+	const [pages2, edges2] = await Promise.all([
+		db.raw(
+			`SELECT id, url, title, status, source FROM pages
+			  WHERE source IN ('inventory-seed', 'inventory-discovered')
+			    AND scraped=1 AND isExternal=0 AND contentType='text/html'
+			    AND redirectDestId IS NULL`,
+		),
+		db.raw(
+			`WITH candidates AS (
+			   SELECT id FROM pages
+			     WHERE source IN ('inventory-seed', 'inventory-discovered')
+			       AND scraped=1 AND isExternal=0 AND contentType='text/html'
+			       AND redirectDestId IS NULL
+			 ),
+			 redirect_map AS (
+			   SELECT id, redirectDestId FROM pages WHERE redirectDestId IS NOT NULL
+			 )
+			 SELECT a.pageId AS source_id,
+			        COALESCE(rm.redirectDestId, a.hrefId) AS dest_id
+			   FROM anchors a
+			   JOIN candidates s ON a.pageId = s.id
+			   LEFT JOIN redirect_map rm ON a.hrefId = rm.id
+			   JOIN candidates d ON COALESCE(rm.redirectDestId, a.hrefId) = d.id
+			  WHERE a.pageId != COALESCE(rm.redirectDestId, a.hrefId)`,
+		),
+	]);
+	void pages2;
+	void edges2;
+	const parallelMs = Number(process.hrtime.bigint() - t4) / 1e6;
+	console.log(`  parallel-fetch total: ${parallelMs.toFixed(0)}ms`);
+
+	await regression('AFTER');
+
+	console.log('\n— Summary —');
+	console.log(`  Current pipeline: ${baseline.total.toFixed(0)}ms`);
+	console.log(`  SQL-side filter:  ${sqlSideMs.toFixed(0)}ms (edge-only)`);
+	console.log(`  Parallel pages + edges: ${parallelMs.toFixed(0)}ms`);
+} finally {
+	await db.destroy();
+	rmSync(workDir, { recursive: true, force: true });
+}
+console.log('\nDone.');

--- a/scripts/bench-listpages-sizes.mjs
+++ b/scripts/bench-listpages-sizes.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Focused bench: does `listPages` at `limit=200` cost more than `limit=100`
+ * on the real archive? The user observed it stays slow even after PR #96
+ * shipped the 368x speedup at `limit=100`. Decomposes COUNT vs SELECT
+ * across multiple offsets and runs the full `listPages` path (including
+ * `mapPageRowToListItem`) so we see whether the cost is SQL, JS mapping,
+ * or row-size-driven.
+ *
+ * USAGE
+ * -----
+ *
+ *     node scripts/bench-listpages-sizes.mjs <archive.nitpicker>
+ *
+ * NEVER runs ANALYZE.
+ */
+
+/* eslint-disable no-console, import-x/no-extraneous-dependencies */
+
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import knex from 'knex';
+import * as tar from 'tar';
+
+import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
+import { listPages } from '../packages/@nitpicker/query/lib/list-pages.js';
+
+const archivePath = process.argv[2];
+if (!archivePath) {
+	console.error('Usage: node scripts/bench-listpages-sizes.mjs <archive.nitpicker>');
+	process.exit(1);
+}
+
+const workDir = path.join(tmpdir(), `nitpicker-bench-lps-${process.pid}`);
+rmSync(workDir, { recursive: true, force: true });
+mkdirSync(workDir, { recursive: true });
+console.log(`Untarring to ${workDir} ...`);
+await tar.x({ file: path.resolve(archivePath), cwd: workDir });
+const inner = readdirSync(workDir, { withFileTypes: true })
+	.filter((e) => e.isDirectory() && !e.name.startsWith('._'))
+	.map((e) => e.name);
+const dbPath = path.join(workDir, inner[0], 'db.sqlite');
+
+const db = knex({
+	client: LibsqlDialect,
+	connection: { filename: dbPath },
+	useNullAsDefault: true,
+});
+
+// Ensure PR #96 + this PR's indexes are in place.
+await db.raw(
+	`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
+	 ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
+);
+await db.raw(
+	`CREATE INDEX IF NOT EXISTS idx_resources_internal_url ON resources(isExternal, url)`,
+);
+await db.raw(
+	`CREATE INDEX IF NOT EXISTS idx_images_covering
+	 ON images(pageId, src, alt, width, height, naturalWidth, naturalHeight, isLazy)`,
+);
+
+const accessor = { getKnex: () => db };
+
+const MATRIX = [
+	{ limit: 50, offset: 0 },
+	{ limit: 100, offset: 0 },
+	{ limit: 200, offset: 0 },
+	{ limit: 100, offset: 1000 },
+	{ limit: 200, offset: 1000 },
+	{ limit: 200, offset: 10_000 },
+	{ limit: 200, offset: 50_000 },
+];
+
+console.log('\n  limit  offset       COUNT     SELECT-raw  listPages-full  bytes');
+for (const { limit, offset } of MATRIX) {
+	const t1 = process.hrtime.bigint();
+	const c = await db.raw(
+		`SELECT count(id) as t FROM pages
+		  WHERE scraped=1 AND redirectDestId IS NULL
+		    AND (contentType IS NULL OR contentType='text/html')`,
+	);
+	const countMs = Number(process.hrtime.bigint() - t1) / 1e6;
+	void c;
+
+	const t2 = process.hrtime.bigint();
+	const rows = await db.raw(
+		`SELECT id, url, title, status, contentType, isExternal, description, keywords,
+		        lang, charset, themeColor, manifest, robots_raw, robots_noindex,
+		        robots_nofollow, robots_noarchive, canonical, og_type, og_title,
+		        og_site_name, og_description, og_url, og_image, og_image_alt,
+		        og_locale, og_article_published_time, twitter_card, twitter_site,
+		        twitter_creator, twitter_image, tag_count, jsonld_count,
+		        tags_providers_csv, firstCrawledAt, lastCrawledAt
+		   FROM pages
+		  WHERE scraped=1 AND redirectDestId IS NULL
+		    AND (contentType IS NULL OR contentType='text/html')
+		  ORDER BY url ASC LIMIT ${limit} OFFSET ${offset}`,
+	);
+	const selectMs = Number(process.hrtime.bigint() - t2) / 1e6;
+	const bytes = JSON.stringify(rows).length;
+
+	const t3 = process.hrtime.bigint();
+	await listPages(accessor, { limit, offset });
+	const fullMs = Number(process.hrtime.bigint() - t3) / 1e6;
+
+	console.log(
+		`  ${String(limit).padStart(5)}  ${String(offset).padStart(7)}  ${`${countMs.toFixed(0)}ms`.padStart(9)}  ${`${selectMs.toFixed(0)}ms`.padStart(9)}  ${`${fullMs.toFixed(0)}ms`.padStart(13)}  ${`${(bytes / 1024).toFixed(0)}KB`.padStart(7)}`,
+	);
+}
+
+console.log('\n— EXPLAIN limit=200 offset=10000 —');
+const plan = await db.raw(
+	`EXPLAIN QUERY PLAN
+	 SELECT id, url, title FROM pages
+	  WHERE scraped=1 AND redirectDestId IS NULL
+	    AND (contentType IS NULL OR contentType='text/html')
+	  ORDER BY url ASC LIMIT 200 OFFSET 10000`,
+);
+for (const r of plan) console.log(`  ${r.detail}`);
+
+await db.destroy();
+rmSync(workDir, { recursive: true, force: true });
+console.log('\nDone.');

--- a/scripts/bench-partial-listfilter.mjs
+++ b/scripts/bench-partial-listfilter.mjs
@@ -136,7 +136,7 @@ try {
 	console.log('\n— CREATE composite covering index, no ANALYZE —');
 	const start1 = process.hrtime.bigint();
 	await db.raw(
-		`CREATE INDEX idx_pages_listfilter ON pages(scraped, redirectDestId, url, contentType)`,
+		`CREATE INDEX idx_pages_listfilter ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	);
 	console.log(
 		`  index built in ${(Number(process.hrtime.bigint() - start1) / 1e6).toFixed(0)}ms`,

--- a/scripts/bench-unused-images.mjs
+++ b/scripts/bench-unused-images.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * Phase C+D bench: covering-index variants for `listUnusedResources` and
+ * `listImages`. Both are SQL-bound — the JS post-processing is trivial
+ * mapping. Each new index is validated against the 4 regression-sentinel
+ * queries (listPages, listLinks broken, listPageLinks, getLinkGraph edge
+ * head) to ensure ANALYZE-free planner heuristics still pick the right
+ * path everywhere.
+ *
+ * USAGE
+ * -----
+ *
+ *     node scripts/bench-unused-images.mjs <archive.nitpicker>
+ *
+ * NEVER runs `ANALYZE`.
+ */
+
+/* eslint-disable no-console, import-x/no-extraneous-dependencies */
+
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import knex from 'knex';
+import * as tar from 'tar';
+
+import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
+
+const archivePath = process.argv[2];
+if (!archivePath) {
+	console.error('Usage: node scripts/bench-unused-images.mjs <archive.nitpicker>');
+	process.exit(1);
+}
+
+const workDir = path.join(tmpdir(), `nitpicker-bench-ui-${process.pid}`);
+rmSync(workDir, { recursive: true, force: true });
+mkdirSync(workDir, { recursive: true });
+console.log(`Untarring to ${workDir} ...`);
+await tar.x({ file: path.resolve(archivePath), cwd: workDir });
+const innerDirs = readdirSync(workDir, { withFileTypes: true })
+	.filter((entry) => entry.isDirectory() && !entry.name.startsWith('._'))
+	.map((entry) => entry.name);
+const dbPath = path.join(workDir, innerDirs[0], 'db.sqlite');
+
+const db = knex({
+	client: LibsqlDialect,
+	connection: { filename: dbPath },
+	useNullAsDefault: true,
+});
+
+/**
+ * Runs the listUnusedResources query (raw SQL) and returns timing.
+ * @returns {Promise<number>} Wall-clock ms.
+ */
+async function runUnusedResources() {
+	const t = process.hrtime.bigint();
+	await db.raw(
+		`SELECT resources.id AS total
+		   FROM resources
+		   LEFT JOIN "resources-referrers"
+		     ON resources.id = "resources-referrers".resourceId
+		  WHERE "resources-referrers".id IS NULL
+		    AND resources.isExternal = 0`,
+	);
+	await db.raw(
+		`SELECT resources.url, resources.status, resources.contentType,
+		        resources.contentLength, resources.source
+		   FROM resources
+		   LEFT JOIN "resources-referrers"
+		     ON resources.id = "resources-referrers".resourceId
+		  WHERE "resources-referrers".id IS NULL
+		    AND resources.isExternal = 0
+		  ORDER BY resources.url
+		  LIMIT 100`,
+	);
+	return Number(process.hrtime.bigint() - t) / 1e6;
+}
+
+/**
+ * Runs the listImages default query (no filters) and returns timing.
+ * @returns {Promise<number>} Wall-clock ms.
+ */
+async function runImages() {
+	const t = process.hrtime.bigint();
+	await db.raw(
+		`SELECT images.id AS total FROM images
+		   JOIN pages ON images.pageId = pages.id`,
+	);
+	await db.raw(
+		`SELECT pages.url AS pageUrl, images.src, images.alt,
+		        images.width, images.height,
+		        images.naturalWidth, images.naturalHeight, images.isLazy
+		   FROM images
+		   JOIN pages ON images.pageId = pages.id
+		  ORDER BY pages.url
+		  LIMIT 100`,
+	);
+	return Number(process.hrtime.bigint() - t) / 1e6;
+}
+
+/**
+ * Explains both queries.
+ * @param {string} label - Pass label.
+ */
+async function dumpPlans(label) {
+	console.log(`\n— EXPLAIN ${label} —`);
+	const u = await db.raw(
+		`EXPLAIN QUERY PLAN
+		 SELECT resources.url FROM resources
+		   LEFT JOIN "resources-referrers"
+		     ON resources.id = "resources-referrers".resourceId
+		  WHERE "resources-referrers".id IS NULL
+		    AND resources.isExternal = 0
+		  ORDER BY resources.url LIMIT 100`,
+	);
+	console.log(`  listUnusedResources SELECT:`);
+	for (const r of u) console.log(`    ${r.detail}`);
+	const i = await db.raw(
+		`EXPLAIN QUERY PLAN
+		 SELECT pages.url, images.src FROM images
+		   JOIN pages ON images.pageId = pages.id
+		  ORDER BY pages.url LIMIT 100`,
+	);
+	console.log(`  listImages SELECT:`);
+	for (const r of i) console.log(`    ${r.detail}`);
+}
+
+/**
+ * Regression sentinel queries.
+ * @param {string} label - Pass label.
+ */
+async function regression(label) {
+	console.log(`\n— Regression: ${label} —`);
+	const cases = [
+		[
+			'listPages',
+			`SELECT id, url FROM pages
+			  WHERE scraped=1 AND redirectDestId IS NULL
+			    AND (contentType IS NULL OR contentType='text/html')
+			  ORDER BY url LIMIT 100`,
+		],
+		[
+			'listLinks broken',
+			`SELECT anchors.id FROM anchors
+			  JOIN pages AS source ON anchors.pageId=source.id
+			  JOIN pages AS dest ON anchors.hrefId=dest.id
+			  LEFT JOIN pages AS canonical ON dest.redirectDestId=canonical.id
+			  WHERE COALESCE(canonical.status, dest.status) >= 400
+			     OR COALESCE(canonical.status, dest.status) IS NULL
+			  LIMIT 100`,
+		],
+		[
+			'listPageLinks',
+			`SELECT id, url FROM pages WHERE redirectDestId IS NULL ORDER BY url LIMIT 100`,
+		],
+	];
+	for (const [name, sql] of cases) {
+		const t = process.hrtime.bigint();
+		await db.raw(sql);
+		console.log(
+			`  ${(Number(process.hrtime.bigint() - t) / 1e6).toFixed(0).padStart(7)}ms  ${name}`,
+		);
+	}
+}
+
+try {
+	console.log('\n[1] Ensure idx_pages_listfilter (PR #96 baseline)');
+	await db.raw(
+		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
+		 ON pages(scraped, redirectDestId, url, contentType)`,
+	);
+
+	console.log('\n[2] BASELINE');
+	const u0 = await runUnusedResources();
+	const i0 = await runImages();
+	console.log(`  listUnusedResources: ${u0.toFixed(0)}ms`);
+	console.log(`  listImages:          ${i0.toFixed(0)}ms`);
+	await dumpPlans('BASELINE');
+	await regression('BASELINE');
+
+	console.log('\n[3] Add idx_resources_internal_url(isExternal, url)');
+	const t3 = process.hrtime.bigint();
+	await db.raw(`CREATE INDEX idx_resources_internal_url ON resources(isExternal, url)`);
+	console.log(`  built in ${(Number(process.hrtime.bigint() - t3) / 1e6).toFixed(0)}ms`);
+
+	const u1 = await runUnusedResources();
+	console.log(
+		`  listUnusedResources: ${u1.toFixed(0)}ms (was ${u0.toFixed(0)}ms, ${(u0 / Math.max(u1, 1)).toFixed(1)}x)`,
+	);
+
+	console.log(
+		'\n[4] Add idx_images_pageId_id(pageId, id) — already exists as pageId, try widening',
+	);
+	// `images(pageId)` already exists. Try a covering index ordered by
+	// pages.url isn't directly possible (cross-table). The natural improvement
+	// is making the images scan covering so the JOIN can return all needed
+	// columns without rowid lookups.
+	const t4 = process.hrtime.bigint();
+	await db.raw(
+		`CREATE INDEX idx_images_covering ON images(pageId, src, alt, width, height, naturalWidth, naturalHeight, isLazy)`,
+	);
+	console.log(`  built in ${(Number(process.hrtime.bigint() - t4) / 1e6).toFixed(0)}ms`);
+
+	const i1 = await runImages();
+	console.log(
+		`  listImages: ${i1.toFixed(0)}ms (was ${i0.toFixed(0)}ms, ${(i0 / Math.max(i1, 1)).toFixed(1)}x)`,
+	);
+
+	await dumpPlans('AFTER both indexes');
+	await regression('AFTER both indexes');
+
+	console.log('\n— Summary —');
+	console.log(
+		`  listUnusedResources: ${u0.toFixed(0)}ms → ${u1.toFixed(0)}ms (${(u0 / Math.max(u1, 1)).toFixed(1)}x)`,
+	);
+	console.log(
+		`  listImages:          ${i0.toFixed(0)}ms → ${i1.toFixed(0)}ms (${(i0 / Math.max(i1, 1)).toFixed(1)}x)`,
+	);
+} finally {
+	await db.destroy();
+	rmSync(workDir, { recursive: true, force: true });
+}
+console.log('\nDone.');

--- a/scripts/bench-unused-images.mjs
+++ b/scripts/bench-unused-images.mjs
@@ -168,7 +168,7 @@ try {
 	console.log('\n[1] Ensure idx_pages_listfilter (PR #96 baseline)');
 	await db.raw(
 		`CREATE INDEX IF NOT EXISTS idx_pages_listfilter
-		 ON pages(scraped, redirectDestId, url, contentType)`,
+		 ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	);
 
 	console.log('\n[2] BASELINE');

--- a/scripts/bench-with-partial-index.mjs
+++ b/scripts/bench-with-partial-index.mjs
@@ -124,11 +124,11 @@ try {
 	// `ORDER BY url ASC` from a single index-ordered scan, killing the
 	// `USE TEMP B-TREE FOR ORDER BY` overhead at deep offsets.
 	console.log(
-		'\nCREATE INDEX idx_pages_listfilter ON pages(scraped, redirectDestId, url, contentType)',
+		'\nCREATE INDEX idx_pages_listfilter ON pages(isExternal, scraped, redirectDestId, url, contentType)',
 	);
 	const indexStart = process.hrtime.bigint();
 	await db.raw(
-		`CREATE INDEX idx_pages_listfilter ON pages(scraped, redirectDestId, url, contentType)`,
+		`CREATE INDEX idx_pages_listfilter ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
 	);
 	const indexMs = Number(process.hrtime.bigint() - indexStart) / 1e6;
 	console.log(`  index built in ${indexMs.toFixed(0)}ms`);

--- a/scripts/fix-tmpdir-index.mjs
+++ b/scripts/fix-tmpdir-index.mjs
@@ -1,0 +1,37 @@
+/**
+ * In-place fix: drop the old 4-column `idx_pages_listfilter` from the live
+ * viewer tmpDir and recreate it with `isExternal` leading so the
+ * paginate-query COUNT picks the covering index instead of falling back
+ * to `pages_isexternal_index`. Use after restarting the viewer (which
+ * re-extracts from the .nitpicker and restores the old shape) until the
+ * archive is re-migrated via `scripts/add-perf-indexes.mjs`.
+ */
+
+/* eslint-disable no-console, import-x/no-extraneous-dependencies */
+
+import knex from 'knex';
+
+import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
+
+const tmpDir = process.argv[2];
+if (!tmpDir) {
+	console.error('Usage: node scripts/fix-tmpdir-index.mjs <viewer-tmpDir>');
+	process.exit(1);
+}
+
+const db = knex({
+	client: LibsqlDialect,
+	connection: { filename: `${tmpDir}/db.sqlite` },
+	useNullAsDefault: true,
+});
+
+const t = process.hrtime.bigint();
+await db.raw('DROP INDEX IF EXISTS idx_pages_listfilter');
+await db.raw(
+	`CREATE INDEX idx_pages_listfilter
+	 ON pages(isExternal, scraped, redirectDestId, url, contentType)`,
+);
+const ms = Number(process.hrtime.bigint() - t) / 1e6;
+console.log(`done in ${ms.toFixed(0)}ms`);
+
+await db.destroy();

--- a/scripts/probe-now.mjs
+++ b/scripts/probe-now.mjs
@@ -1,0 +1,65 @@
+/* eslint-disable no-console, import-x/no-extraneous-dependencies */
+
+import knex from 'knex';
+
+import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
+import { listPages } from '../packages/@nitpicker/query/lib/list-pages.js';
+import { createApp } from '../packages/@nitpicker/viewer/lib/create-app.js';
+
+const tmpDir = process.argv[2];
+if (!tmpDir) {
+	console.error('Usage: node scripts/probe-now.mjs <tmpDir>');
+	process.exit(1);
+}
+
+const db = knex({
+	client: LibsqlDialect,
+	connection: { filename: `${tmpDir}/db.sqlite` },
+	useNullAsDefault: true,
+});
+
+const idx = await db.raw(
+	`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_pages_listfilter'`,
+);
+
+console.log('idx_pages_listfilter:', idx[0]?.sql?.replaceAll(/\s+/g, ' ') ?? 'MISSING');
+
+console.log('\nEXPLAIN COUNT (isExternal=0):');
+const cp = await db.raw(
+	`EXPLAIN QUERY PLAN
+	 SELECT count(id) as t FROM pages
+	  WHERE scraped=1 AND redirectDestId IS NULL
+	    AND (contentType IS NULL OR contentType='text/html')
+	    AND isExternal=0`,
+);
+for (const r of cp) {
+	console.log('  ' + r.detail);
+}
+
+const accessor = { getKnex: () => db };
+const t1 = process.hrtime.bigint();
+const r = await listPages(accessor, { limit: 200, offset: 0, isExternal: false });
+const lpMs = Number(process.hrtime.bigint() - t1) / 1e6;
+
+console.log(
+	`\nlistPages({isExternal:false, limit:200}) cold: ${lpMs.toFixed(0)}ms (${r.items.length} items, total=${r.total})`,
+);
+
+const t2 = process.hrtime.bigint();
+await listPages(accessor, { limit: 200, offset: 0, isExternal: false });
+const lpWarm = Number(process.hrtime.bigint() - t2) / 1e6;
+
+console.log(`listPages warm: ${lpWarm.toFixed(0)}ms`);
+
+const app = createApp({
+	context: { archiveId: 'probe', manager: { get: () => accessor } },
+	publicDir: '/tmp/no-such-dir',
+});
+const t3 = process.hrtime.bigint();
+const res = await app.request('/api/pages?isExternal=false&limit=200&offset=0');
+await res.text();
+const httpMs = Number(process.hrtime.bigint() - t3) / 1e6;
+
+console.log(`HTTP /api/pages?isExternal=false&limit=200: ${httpMs.toFixed(0)}ms`);
+
+await db.destroy();


### PR DESCRIPTION
## Summary

PR #96 で listPages の SELECT を 368x 高速化したが、ユーザー実 archive (428k 行 / 168k internal HTML) で他 view が依然 8-474 秒台に張り付いていた。本 PR で per-query bench + EXPLAIN を回しながら個別に修正:

- **find-duplicates 414s → 8s (49.6x)** — N+1 ループを `GROUP_CONCAT(url, X'1F')` の単発 GROUP BY に書き換え (`packages/@nitpicker/query/src/find-duplicates.ts`)
- **listUnusedResources 66s → 7.5s (8.8x)** — `resources(isExternal, url)` covering index 追加
- **listImages 32s → 16s (2.0x)** — `images(...all-cols...)` covering index で TEMP B-TREE FOR ORDER BY 消滅
- **get-link-graph** — `pageRows` + `edgeRows` を `Promise.all` に統合 (SQL push-down は 10x 悪化したため不採用、根拠は JSDoc に記録)
- **listPages COUNT 8.7s → 33ms (264x)** — `idx_pages_listfilter` の column 順に **`isExternal` を先頭追加** (PR #96 の 4 列だと paginate-query の COUNT で `pages_isexternal_index` に倒れて 8.7s/req になっていた)
- **migration script (`scripts/add-perf-indexes.mjs`)** — 3 index 一括 + WAL/SHM teardown race 修正 + 旧 4 列 index の DROP-and-recreate 対応

`listLinks` / `listPageLinks` / `getSummary` / `compute-isolated-clusters` は schema denormalisation (`canonicalId` / `referrer_count` / `isolated_root`) 抜きでは改善できないと bench で確認、各 query.ts JSDoc + ARCHITECTURE.md に「受容済み」として根拠付きで記録。次フェーズ (denorm 列追加) で対応する。

## ANALYZE 厳禁の invariant

PR #96 で立てた「\`.nitpicker\` archive に \`ANALYZE\` / \`PRAGMA optimize\` を絶対走らせない」契約を本 PR でも維持。新 index は全て column 順を WHERE+ORDER に厳密一致させて planner heuristics で確実に選ばれるよう設計。migration script も ANALYZE しないし、\`sqlite_stat1\` が非空なら警告。

## 実 archive 計測 (実機 viewer 経由 Server-Timing 実測)

| エンドポイント | Before | After | 改善 |
|---|---|---|---|
| /api/pages?isExternal=false&limit=200 | **39.64s** | **229ms** | **170x** |
| /api/pages?offset=200 | (同様) | 148ms | – |
| /api/resources | 60s | 97ms | – |
| /api/headers | – | 145ms | – |
| /api/error-kinds | – | 101ms | – |
| /api/unused-resources | 60s | 2.83s | 21x |
| /api/duplicates | 414s | 3.69s | 112x |

受容済 (本 PR スコープ外、denorm 列待ち):
- /api/page-links 32s, /api/isolated-* 23-25s, /api/links?type=broken 17s, /api/images 9.86s (cold cache 込み)

## 既存 archive 適用

PR #96 で \`add-pages-listfilter-index.mjs\` だったスクリプトを \`add-perf-indexes.mjs\` にリネーム + 拡張 (3 index 一括、DROP-then-CREATE で 4 列版を 5 列版に張り替え可)。\`fix-tmpdir-index.mjs\` / \`probe-now.mjs\` は viewer の tmpDir に古い shape が残った場合の ops 用ヘルパとして同梱。

\`\`\`sh
node scripts/add-perf-indexes.mjs <old.nitpicker>
# → <old>.indexed.nitpicker を出力 (元ファイルは無変更)
\`\`\`

## Test plan

- [x] yarn build (14 packages all pass)
- [x] yarn lint (0 errors)
- [x] yarn test (2028 passed, 5 skipped)
- [x] 実 archive (428k 行) で全 endpoint を viewer 経由で計測 (上表)
- [x] no-ANALYZE invariant の回帰確認 (regression sentinels: listPages / listLinks broken / getLinkGraph edges / listPageLinks の 4 query)
- [ ] レビュアー: 既存 archive がある場合 node scripts/add-perf-indexes.mjs <archive> を実行して体感速度を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)