### PR TITLE
test(query): sweep leaked lock dirs in archive-manager spec

### DIFF
--- a/packages/@nitpicker/query/src/archive-manager.spec.ts
+++ b/packages/@nitpicker/query/src/archive-manager.spec.ts
@@ -567,14 +567,46 @@ describe('ArchiveManager stub mode', () => {
 	});
 });
 
+/**
+ * Remove the orphan `._nitpicker-<name>.lock` directories that mocked-`close`
+ * tests leak into `process.cwd()`. `ArchiveManager.open` calls `Archive.open`
+ * without forwarding `cwd`, so `Archive.open` defaults to `process.cwd()` and
+ * acquires `<cwd>/._nitpicker-<basename>.lock`. The lock is normally released
+ * inside `Archive.#runFullClose`'s `finally`, but these tests fully mock
+ * `archive.close` to reject — that path never runs, and `cleanupOnFailure`
+ * does not touch the `.lock` directory. We sweep them here so the repo root
+ * does not accumulate stale `pid.txt` directories across test runs.
+ *
+ * Whitelist-by-basename (not a glob of `._nitpicker-*.lock` in `process.cwd()`)
+ * is deliberate: vitest worker pools run multiple spec files in parallel against
+ * the same `process.cwd()`, and a glob sweep would race-delete locks owned by
+ * sibling specs that are still mid-test.
+ *
+ * **Drift caveat**: when you add a new test that does
+ * `vi.spyOn(archive, 'close').mockRejectedValue(...)` (or otherwise prevents
+ * `Archive.#runFullClose` from reaching its `finally` releaseLock), append
+ * that archive's basename to the calling describe's `leakedLockBasenames`
+ * array. Forgetting reintroduces the original leak silently — CI does not
+ * fail on residual lock dirs.
+ * @param basenames - The archive basenames whose lock directories to remove.
+ */
+function cleanupLeakedLocksInCwd(basenames: readonly string[]) {
+	for (const basename of basenames) {
+		const lockDir = path.resolve(process.cwd(), `._nitpicker-${basename}.lock`);
+		rmSync(lockDir, { recursive: true, force: true });
+	}
+}
+
 describe('ArchiveManager lifecycle races and partial-failure recovery', () => {
 	const raceWorkingDir = path.resolve(
 		__dirname,
 		'__test_fixtures_archive_manager_race__',
 	);
 	const raceArchiveFilePath = path.resolve(raceWorkingDir, 'race-archive.nitpicker');
+	const raceLeakedLockBasenames = ['race-archive'] as const;
 
 	beforeAll(async () => {
+		cleanupLeakedLocksInCwd(raceLeakedLockBasenames);
 		mkdirSync(raceWorkingDir, { recursive: true });
 		// Build a small finished archive once so the race tests can re-open
 		// it cheaply without rebuilding a full DB each time.
@@ -608,6 +640,7 @@ describe('ArchiveManager lifecycle races and partial-failure recovery', () => {
 
 	afterAll(() => {
 		rmSync(raceWorkingDir, { recursive: true, force: true });
+		cleanupLeakedLocksInCwd(raceLeakedLockBasenames);
 	});
 
 	it('close 中の同一パスへの concurrent open は close 完了を待ち、新しい accessor を返す', async () => {
@@ -673,13 +706,16 @@ describe('ArchiveManager warning sink (onWarn)', () => {
 		__dirname,
 		'__test_fixtures_archive_manager_warn__',
 	);
+	const warnLeakedLockBasenames = ['routed', 'default-sink', 'non-error'] as const;
 
 	beforeAll(() => {
+		cleanupLeakedLocksInCwd(warnLeakedLockBasenames);
 		mkdirSync(warnWorkingDir, { recursive: true });
 	});
 
 	afterAll(() => {
 		rmSync(warnWorkingDir, { recursive: true, force: true });
+		cleanupLeakedLocksInCwd(warnLeakedLockBasenames);
 	});
 
 	/**

--- a/packages/@nitpicker/query/src/archive-manager.ts
+++ b/packages/@nitpicker/query/src/archive-manager.ts
@@ -455,6 +455,16 @@ export class ArchiveManager {
 			};
 		}
 
+		// Known limitation: `cwd` is not forwarded here, so `Archive.open`
+		// falls back to `process.cwd()` and materialises `tmpDir` /
+		// `<tmpDir>.lock` next to the caller's cwd rather than next to the
+		// archive file. In production this is harmless (the `finally` in
+		// `Archive.#runFullClose` always releases the lock) but it makes the
+		// writer path (`crawl --append` / `--retry-failed` invoked from an
+		// unrelated directory) drop a `._nitpicker-<basename>` workspace into
+		// the user's cwd for the duration of the run. Forwarding cwd here
+		// (and exposing it on `ArchiveManager.open`) is the cleaner fix — out
+		// of scope for the surrounding work.
 		const archive = await Archive.open({ filePath: realPath, openPluginData: true });
 		// Capture both `tmpDir` and `archive.renamedDir` so a partial-failure
 		// rmSync recovery can clean either — `Archive.write()` renames the


### PR DESCRIPTION
## Summary

- `ArchiveManager.open` calls `Archive.open` without forwarding `cwd`, so the writer path materialises `._nitpicker-<basename>.lock` at `process.cwd()`. Production is fine — `Archive.#runFullClose`'s `finally` always releases the lock — but four spec tests in `archive-manager.spec.ts` fully mock `archive.close` to reject, skipping the `finally`, and `cleanupOnFailure` does not touch the `.lock` directory. Result: every test run leaks `._nitpicker-{default-sink,non-error,race-archive,routed}.lock` into the repo root.
- Add `cleanupLeakedLocksInCwd(basenames)` helper, called from `beforeAll` (prior-run residue) and `afterAll` (current-run cleanup) of the two affected describes (`lifecycle races`, `warning sink`). Whitelist by basename rather than glob `._nitpicker-*.lock` — vitest worker pools share `process.cwd()`, and a glob sweep would race-delete locks owned by sibling specs.
- Document the cwd-non-forwarded limitation in `archive-manager.ts` so the production root cause is discoverable from where it actually lives (out of scope for this PR to fix).

## Test plan

- [x] `yarn lint` (cspell + eslint + prettier + stylelint + markuplint + textlint) passes
- [x] `yarn build` (lerna run build, 14 projects) passes
- [x] `yarn test` (2111 tests, 251 files) passes — including `archive-manager.spec.ts` (32 tests, 31 pass / 1 skipped)
- [x] No `._nitpicker-*.lock` directories remain at repo root after `yarn test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)