### PR TITLE
feat(query): add viewer read model cache infrastructure

### DIFF
--- a/packages/@nitpicker/query/src/query.ts
+++ b/packages/@nitpicker/query/src/query.ts
@@ -8,6 +8,7 @@
 
 export { ArchiveManager } from './archive-manager.js';
 export type { OpenResult } from './archive-manager.js';
+export { buildViewerReadModel } from './viewer-read-model/build-viewer-read-model.js';
 export { checkHeaders } from './check-headers.js';
 export { classifyErrorKind } from '@nitpicker/crawler';
 export { computeIsolatedClusters } from './compute-isolated-clusters.js';
@@ -16,6 +17,8 @@ export { CONTENT_TYPE_RULES } from './content-type-rules.js';
 export type { ContentTypeRule, MimeMatcher } from './content-type-rules.js';
 export { countPagesByJsonLdType } from './count-pages-by-jsonld-type.js';
 export { countPagesByTag } from './count-pages-by-tag.js';
+export { dropViewerReadModel } from './viewer-read-model/drop-viewer-read-model.js';
+export { ensureViewerReadModel } from './viewer-read-model/ensure-viewer-read-model.js';
 export { findDuplicates } from './find-duplicates.js';
 export { findMismatches } from './find-mismatches.js';
 export { getErrorKinds } from './get-error-kinds.js';
@@ -29,7 +32,9 @@ export { getResourceReferrers } from './get-resource-referrers.js';
 export { getSummary } from './get-summary.js';
 export { getTagInventory } from './get-tag-inventory.js';
 export { getIsolatedCluster } from './get-isolated-cluster.js';
+export { getViewerReadModelVersion } from './viewer-read-model/get-viewer-read-model-version.js';
 export { getViolations } from './get-violations.js';
+export { hasViewerReadModel } from './viewer-read-model/has-viewer-read-model.js';
 export { listImages } from './list-images.js';
 export { listInventoryRuns } from './list-inventory-runs.js';
 export { listIsolatedClusters } from './list-isolated-clusters.js';

--- a/packages/@nitpicker/query/src/viewer-read-model/build-viewer-read-model.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/build-viewer-read-model.spec.ts
@@ -1,0 +1,522 @@
+import path from 'node:path';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { Archive } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { listPages } from '../list-pages.js';
+
+import { buildViewerReadModel } from './build-viewer-read-model.js';
+import { hasViewerReadModel } from './has-viewer-read-model.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+
+const BASE_CONFIG = {
+	baseUrl: 'https://example.com',
+	name: 'test',
+	version: '0.10.0',
+	recursive: true,
+	interval: 0,
+	image: true,
+	fetchExternal: false,
+	parallels: 1,
+	roots: ['https://example.com'],
+	excludes: [],
+	excludeKeywords: [],
+	excludeUrls: [],
+	maxExcludedDepth: 0,
+	retry: 3,
+	fromList: false,
+	disableQueries: false,
+	userAgent: 'test',
+	ignoreRobots: false,
+};
+
+const META = {
+	lang: null,
+	title: null,
+	description: null,
+	keywords: null,
+	noindex: false,
+	nofollow: false,
+	noarchive: false,
+	canonical: null,
+	alternate: null,
+	'og:type': null,
+	'og:title': null,
+	'og:site_name': null,
+	'og:description': null,
+	'og:url': null,
+	'og:image': null,
+	'twitter:card': null,
+};
+
+describe('buildViewerReadModel', () => {
+	describe('read-only guard', () => {
+		const workingDir = path.resolve(
+			__dirname,
+			'__test_fixtures_build_read_model_readonly__',
+		);
+		const archiveFilePath = path.resolve(workingDir, 'readonly-test.nitpicker');
+		let archive: InstanceType<typeof Archive>;
+
+		beforeAll(async () => {
+			const { mkdirSync } = await import('node:fs');
+			mkdirSync(workingDir, { recursive: true });
+			archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+			await archive.setConfig(BASE_CONFIG);
+			await archive.setPage({
+				url: parseUrl('https://example.com/')!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: true,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '<html></html>',
+				meta: { ...META, title: 'Home' },
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+		});
+
+		afterAll(async () => {
+			if (archive) {
+				await archive.releaseHandle();
+			}
+			const { rmSync } = await import('node:fs');
+			rmSync(workingDir, { recursive: true, force: true });
+		});
+
+		it('throws on a read-only accessor and leaves the archive untouched', async () => {
+			const readOnlyAccessor = await Archive.connect(archive.tmpDir);
+			try {
+				await expect(buildViewerReadModel(readOnlyAccessor)).rejects.toThrow(
+					/read-only/i,
+				);
+				// The throw happens before any DB access, so the archive must be
+				// exactly as it was: no read model, and the write-model row count
+				// unaffected.
+				expect(await hasViewerReadModel(readOnlyAccessor)).toBe(false);
+				expect(await hasViewerReadModel(archive)).toBe(false);
+				const pageCount = await archive.getKnex()('pages').count<{ count: string }[]>({
+					count: '*',
+				});
+				expect(Number(pageCount[0]?.count)).toBe(1);
+			} finally {
+				await readOnlyAccessor.close();
+			}
+		});
+	});
+
+	describe('population + idempotency', () => {
+		const workingDir = path.resolve(__dirname, '__test_fixtures_build_read_model__');
+		const archiveFilePath = path.resolve(workingDir, 'build-test.nitpicker');
+		let archive: InstanceType<typeof Archive>;
+
+		beforeAll(async () => {
+			const { mkdirSync } = await import('node:fs');
+			mkdirSync(workingDir, { recursive: true });
+			archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+			await archive.setConfig(BASE_CONFIG);
+
+			// Listable, full metadata.
+			await archive.setPage({
+				url: parseUrl('https://example.com/')!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: true,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '<html></html>',
+				meta: {
+					...META,
+					title: 'Home',
+					description: 'Home description',
+					og: { title: 'OG Home' },
+				},
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+
+			// Listable, empty-string title/description (must count as "missing",
+			// same idiom as list-pages.ts's missingTitle/missingDescription).
+			await archive.setPage({
+				url: parseUrl('https://example.com/empty-meta')!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: true,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '<html></html>',
+				meta: { ...META, title: '', description: '', robots: { noindex: true } },
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+
+			// Listable, external.
+			await archive.setPage({
+				url: parseUrl('https://example.net/')!,
+				redirectPaths: [],
+				isExternal: true,
+				isTarget: false,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '',
+				meta: META,
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+
+			// Listable, errored/unreached (null contentType + null status).
+			await archive.setPage({
+				url: parseUrl('https://example.com/errored')!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: true,
+				status: null,
+				statusText: null,
+				contentType: null,
+				contentLength: 0,
+				responseHeaders: {},
+				html: '',
+				meta: META,
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+
+			// Redirect destination (listable) + redirect source (must be
+			// EXCLUDED from viewer_pages: it has redirectDestId set).
+			await archive.setPage({
+				url: parseUrl('https://example.com/new-canonical')!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: true,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '<html></html>',
+				meta: { ...META, title: 'Canonical' },
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+			await archive.setRedirect({
+				url: parseUrl('https://example.com/old')!,
+				redirectPaths: ['https://example.com/new-canonical'],
+				isExternal: false,
+				isTarget: true,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '',
+				meta: META,
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+		});
+
+		afterAll(async () => {
+			if (archive) {
+				await archive.releaseHandle();
+			}
+			const { rmSync } = await import('node:fs');
+			rmSync(workingDir, { recursive: true, force: true });
+		});
+
+		it('populates viewer_pages with exactly the 5 listable fixture pages (redirect source excluded)', async () => {
+			await buildViewerReadModel(archive);
+			const knex = archive.getKnex();
+
+			// Hardcoded literal, not re-derived from another query: home,
+			// empty-meta, external, errored, and the redirect destination.
+			// The redirect *source* (/old) has redirectDestId set and must
+			// not count.
+			const viewerPagesCount = await knex('viewer_pages').count<{ count: string }[]>({
+				count: '*',
+			});
+			expect(Number(viewerPagesCount[0]?.count)).toBe(5);
+
+			const oldRow = await knex('viewer_pages')
+				.where('url', 'https://example.com/old')
+				.first();
+			expect(oldRow).toBeUndefined();
+		});
+
+		it("matches listPages()'s listable-page total (independent cross-check)", async () => {
+			const knex = archive.getKnex();
+			const { total } = await listPages(archive, {});
+			const viewerPagesCount = await knex('viewer_pages').count<{ count: string }[]>({
+				count: '*',
+			});
+			// Every fixture page here is 'text/html' or null-contentType, so
+			// listPages()'s default (html + null) view covers the exact same
+			// set as viewer_pages' unfiltered listable projection. This is a
+			// cross-check against a separately-implemented, already-tested
+			// query function — not a re-derivation of the same arithmetic
+			// buildViewerReadModel itself does.
+			expect(Number(viewerPagesCount[0]?.count)).toBe(total);
+		});
+
+		it('derives has_title/has_description/has_og_title using the same "non-null and non-empty" idiom as list-pages.ts', async () => {
+			const knex = archive.getKnex();
+			// parseUrl normalises a bare-root URL by stripping the trailing
+			// slash (same convention list-links.spec.ts's own assertions
+			// rely on), so the stored/queried form here is without one.
+			const home = await knex('viewer_pages').where('url', 'https://example.com').first();
+			expect(home).toMatchObject({ has_title: 1, has_description: 1, has_og_title: 1 });
+
+			const emptyMeta = await knex('viewer_pages')
+				.where('url', 'https://example.com/empty-meta')
+				.first();
+			expect(emptyMeta).toMatchObject({
+				has_title: 0,
+				has_description: 0,
+				has_og_title: 0,
+				robots_noindex: 1,
+			});
+		});
+
+		it('classifies a null contentType page as content_category "unknown"', async () => {
+			const knex = archive.getKnex();
+			const errored = await knex('viewer_pages')
+				.where('url', 'https://example.com/errored')
+				.first();
+			expect(errored).toMatchObject({ content_category: 'unknown', status: null });
+		});
+
+		it('flows is_external through for external pages', async () => {
+			const knex = archive.getKnex();
+			const external = await knex('viewer_pages')
+				.where('url', 'https://example.net')
+				.first();
+			expect(external).toMatchObject({ is_external: 1 });
+		});
+
+		it('seeds one matching viewer_query_profiles and viewer_count_buckets row, both equal to the hardcoded 5-page total', async () => {
+			const knex = archive.getKnex();
+
+			const profiles = await knex('viewer_query_profiles').select('*');
+			expect(profiles).toHaveLength(1);
+			expect(profiles[0]).toMatchObject({ scope: 'pages', total: 5 });
+
+			const buckets = await knex('viewer_count_buckets').select('*');
+			expect(buckets).toHaveLength(1);
+			expect(buckets[0]).toMatchObject({ scope: 'pages', count: 5 });
+
+			const meta = await knex('viewer_read_model_meta').where('id', 1).first();
+			expect(meta).toMatchObject({ source_row_count: 5 });
+		});
+
+		it('viewer_page_anchors stays empty (page-jump population is out of scope for #108)', async () => {
+			const knex = archive.getKnex();
+			const rows = await knex('viewer_page_anchors').select('*');
+			expect(rows).toHaveLength(0);
+		});
+
+		it('rebuilds idempotently — calling twice leaves exactly one meta row and the same page count', async () => {
+			const knex = archive.getKnex();
+			const before = await knex('viewer_pages').count<{ count: string }[]>({
+				count: '*',
+			});
+
+			await buildViewerReadModel(archive);
+
+			const after = await knex('viewer_pages').count<{ count: string }[]>({ count: '*' });
+			expect(after[0]?.count).toBe(before[0]?.count);
+
+			const metaRows = await knex('viewer_read_model_meta').select('*');
+			expect(metaRows).toHaveLength(1);
+		});
+	});
+
+	describe('isSkipped exclusion', () => {
+		const workingDir = path.resolve(
+			__dirname,
+			'__test_fixtures_build_read_model_skipped__',
+		);
+		const archiveFilePath = path.resolve(workingDir, 'skipped-test.nitpicker');
+		let archive: InstanceType<typeof Archive>;
+
+		beforeAll(async () => {
+			const { mkdirSync } = await import('node:fs');
+			mkdirSync(workingDir, { recursive: true });
+			archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+			await archive.setConfig(BASE_CONFIG);
+
+			await archive.setPage({
+				url: parseUrl('https://example.com/')!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: true,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '<html></html>',
+				meta: { ...META, title: 'Home' },
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+
+			// A discovery-only placeholder row matched by an --exclude
+			// pattern: status/contentType are always null and it must never
+			// surface in viewer_pages (same predicate excludeSkippedPages
+			// guards get-summary.ts against — see that helper's docs for
+			// the production incident this mirrors).
+			await archive.setPage({
+				url: parseUrl('https://example.com/excluded')!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: false,
+				status: null,
+				statusText: null,
+				contentType: null,
+				contentLength: 0,
+				responseHeaders: {},
+				html: '',
+				meta: META,
+				anchorList: [],
+				imageList: [],
+				isSkipped: true,
+			});
+		});
+
+		afterAll(async () => {
+			if (archive) {
+				await archive.releaseHandle();
+			}
+			const { rmSync } = await import('node:fs');
+			rmSync(workingDir, { recursive: true, force: true });
+		});
+
+		it('excludes isSkipped rows from viewer_pages', async () => {
+			await buildViewerReadModel(archive);
+			const knex = archive.getKnex();
+
+			const rows = await knex('viewer_pages').select('url');
+			expect(rows.map((r) => r.url)).toEqual(['https://example.com']);
+
+			const excluded = await knex('viewer_pages')
+				.where('url', 'https://example.com/excluded')
+				.first();
+			expect(excluded).toBeUndefined();
+		});
+	});
+
+	describe('legacy rows with null tag_count/jsonld_count/robots_noindex/isExternal and an unparseable URL', () => {
+		const workingDir = path.resolve(
+			__dirname,
+			'__test_fixtures_build_read_model_legacy__',
+		);
+		const archiveFilePath = path.resolve(workingDir, 'legacy-test.nitpicker');
+		let archive: InstanceType<typeof Archive>;
+
+		beforeAll(async () => {
+			const { mkdirSync } = await import('node:fs');
+			mkdirSync(workingDir, { recursive: true });
+			archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+			await archive.setConfig(BASE_CONFIG);
+
+			// Bypass setPage() entirely: none of `setPage`'s callers ever
+			// leave tag_count/jsonld_count/robots_noindex/isExternal null
+			// (compute-page-denormalized.ts always writes a `.length`, and
+			// beholder always writes 0/1), and every URL setPage stores was
+			// already validated by parseUrl. This raw insert simulates a
+			// pre-migration/legacy row where those columns are genuinely
+			// null and the URL predates strict validation, to exercise
+			// buildViewerReadModel's defensive `?? 0` fallbacks and
+			// derivePathSortKey's unparseable-URL catch branch — neither of
+			// which any setPage()-based fixture can reach.
+			await archive.getKnex()('pages').insert({
+				url: 'not a valid url',
+				scraped: 1,
+				isTarget: 1,
+				isExternal: null,
+				robots_noindex: null,
+				tag_count: null,
+				jsonld_count: null,
+			});
+		});
+
+		afterAll(async () => {
+			if (archive) {
+				await archive.releaseHandle();
+			}
+			const { rmSync } = await import('node:fs');
+			rmSync(workingDir, { recursive: true, force: true });
+		});
+
+		it('defaults null counters to 0, null flags to 0, and falls back to the raw URL for path_sort_key', async () => {
+			await buildViewerReadModel(archive);
+			const knex = archive.getKnex();
+
+			const row = await knex('viewer_pages').where('url', 'not a valid url').first();
+			expect(row).toMatchObject({
+				is_external: 0,
+				robots_noindex: 0,
+				tag_count: 0,
+				jsonld_count: 0,
+				url_sort_key: 'not a valid url',
+				path_sort_key: 'not a valid url',
+			});
+		});
+	});
+
+	describe('empty archive', () => {
+		const workingDir = path.resolve(
+			__dirname,
+			'__test_fixtures_build_read_model_empty__',
+		);
+		const archiveFilePath = path.resolve(workingDir, 'empty-test.nitpicker');
+		let archive: InstanceType<typeof Archive>;
+
+		beforeAll(async () => {
+			const { mkdirSync } = await import('node:fs');
+			mkdirSync(workingDir, { recursive: true });
+			archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+			await archive.setConfig(BASE_CONFIG);
+		});
+
+		afterAll(async () => {
+			if (archive) {
+				await archive.releaseHandle();
+			}
+			const { rmSync } = await import('node:fs');
+			rmSync(workingDir, { recursive: true, force: true });
+		});
+
+		it('succeeds with zero pages, leaving viewer_pages empty and source_row_count = 0', async () => {
+			await expect(buildViewerReadModel(archive)).resolves.toBeUndefined();
+			const knex = archive.getKnex();
+			const pageRows = await knex('viewer_pages').select('*');
+			expect(pageRows).toHaveLength(0);
+			const meta = await knex('viewer_read_model_meta').where('id', 1).first();
+			expect(meta).toMatchObject({ source_row_count: 0 });
+		});
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/build-viewer-read-model.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/build-viewer-read-model.ts
@@ -1,0 +1,241 @@
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+import { eachSplitted } from '@nitpicker/crawler';
+
+import { classifyContentType } from '../classify-content-type.js';
+import { excludeSkippedPages } from '../exclude-skipped-pages.js';
+
+import { createViewerReadModelTables } from './create-viewer-read-model-tables.js';
+import { dropViewerReadModelTables } from './drop-viewer-read-model-tables.js';
+import { VIEWER_READ_MODEL_SCHEMA_VERSION } from './viewer-read-model-schema-version.js';
+
+/** Number of rows written per `INSERT` statement while populating `viewer_pages`. */
+const INSERT_CHUNK_SIZE = 500;
+
+/**
+ * Row shape read from the write-model `pages` table while populating
+ * `viewer_pages`. Column names match `pages` verbatim (see
+ * `@nitpicker/crawler`'s `init-schema.ts` and this package's
+ * `list-pages.ts`, which filters/sorts on the same columns).
+ */
+interface PagesSourceRow {
+	/** `pages.id` — becomes `viewer_pages.page_id`. */
+	id: number;
+	/** The page's absolute URL. */
+	url: string;
+	/** The page's `<title>` text, or `null` when absent. */
+	title: string | null;
+	/** HTTP status code, or `null` for not-yet-classified/errored rows. */
+	status: number | null;
+	/** Raw `Content-Type` response header value, or `null`. */
+	contentType: string | null;
+	/**
+	 * `1`/`0` when known, `null` on legacy rows written before this column
+	 * was backfilled (the `pages.isExternal` column has no `NOT NULL`
+	 * constraint — see `init-schema.ts`).
+	 */
+	isExternal: number | null;
+	/** The page's meta description text, or `null` when absent. */
+	description: string | null;
+	/** The page's `og:title` text, or `null` when absent. */
+	og_title: string | null;
+	/**
+	 * `1`/`0` when known, `null` when no `<meta name="robots">` tag was
+	 * ever parsed (the `pages.robots_noindex` column has no `NOT NULL`
+	 * constraint — see `init-schema.ts`).
+	 */
+	robots_noindex: number | null;
+	/** Denormalised count of Wappalyzer tags detected on the page. */
+	tag_count: number | null;
+	/** Denormalised count of JSON-LD / SpeculationRules entries on the page. */
+	jsonld_count: number | null;
+}
+
+/** One row to insert into `viewer_pages`, derived from a {@link PagesSourceRow}. */
+interface ViewerPageInsertRow {
+	/** Copied from `PagesSourceRow.id`. */
+	page_id: number;
+	/** Copied from `PagesSourceRow.url`. */
+	url: string;
+	/** Copied from `PagesSourceRow.title`. */
+	title: string | null;
+	/** Copied from `PagesSourceRow.status`. */
+	status: number | null;
+	/** `classifyContentType(PagesSourceRow.contentType)`. */
+	content_category: string;
+	/** Normalised `0`/`1` form of `PagesSourceRow.isExternal`. */
+	is_external: number;
+	/** `1` iff `title` is non-null and non-empty. */
+	has_title: number;
+	/** `1` iff `description` is non-null and non-empty. */
+	has_description: number;
+	/** `1` iff `og_title` is non-null and non-empty. */
+	has_og_title: number;
+	/** Normalised `0`/`1` form of `PagesSourceRow.robots_noindex`. */
+	robots_noindex: number;
+	/** `PagesSourceRow.tag_count`, defaulted to `0` when `null`. */
+	tag_count: number;
+	/** `PagesSourceRow.jsonld_count`, defaulted to `0` when `null`. */
+	jsonld_count: number;
+	/**
+	 * Case-preserving sort key for URL ordering — currently just `url`
+	 * verbatim, matching `listPages`'s plain `ORDER BY url` (SQLite's
+	 * default `BINARY` collation is case-sensitive; lower-casing here would
+	 * be a behavior change, left to whichever issue actually wires up
+	 * `/api/pages` sorting).
+	 */
+	url_sort_key: string;
+	/** Case-preserving sort key for title ordering — `title` verbatim. */
+	title_sort_key: string | null;
+	/**
+	 * The URL's path component, for directory-prefix range scans (per
+	 * `docs/viewer-sql-query-plan.md`'s `/api/pages` directory filter
+	 * notes). Stored now but intentionally has no index and no reader yet
+	 * in #108 — like `viewer_page_anchors`, wiring the actual directory
+	 * filter query/index is out of scope here and belongs to whichever
+	 * issue implements `/api/pages`'s directory filter.
+	 */
+	path_sort_key: string;
+}
+
+/**
+ * Derives the path-only sort key used for directory-prefix filtering.
+ * Falls back to the full URL string when it cannot be parsed as a URL
+ * (defensive only — every URL in `pages` was already parsed once during
+ * crawling, so this branch should not be reachable in practice).
+ * @param url - The page's absolute URL.
+ * @returns The URL's pathname, or `url` itself if unparseable.
+ */
+function derivePathSortKey(url: string): string {
+	try {
+		return new URL(url).pathname;
+	} catch {
+		return url;
+	}
+}
+
+/**
+ * Maps one `pages` row to its `viewer_pages` insert row.
+ * @param row - The source row read from `pages`.
+ * @returns The corresponding `viewer_pages` insert row.
+ */
+function toViewerPageInsertRow(row: PagesSourceRow): ViewerPageInsertRow {
+	return {
+		page_id: row.id,
+		url: row.url,
+		title: row.title,
+		status: row.status,
+		content_category: classifyContentType(row.contentType),
+		is_external: row.isExternal ? 1 : 0,
+		has_title: row.title != null && row.title !== '' ? 1 : 0,
+		has_description: row.description != null && row.description !== '' ? 1 : 0,
+		has_og_title: row.og_title != null && row.og_title !== '' ? 1 : 0,
+		robots_noindex: row.robots_noindex ? 1 : 0,
+		tag_count: row.tag_count ?? 0,
+		jsonld_count: row.jsonld_count ?? 0,
+		url_sort_key: row.url,
+		title_sort_key: row.title,
+		path_sort_key: derivePathSortKey(row.url),
+	};
+}
+
+/**
+ * Performs a full rebuild of the viewer read model: drops all 5 tables if
+ * present, recreates them, populates `viewer_pages` from the current
+ * `pages` write-model table, seeds one smoke-test row into
+ * `viewer_query_profiles` and `viewer_count_buckets`, and writes the
+ * `viewer_read_model_meta` row — all inside one transaction, so a mid-build
+ * failure leaves the previous read model (or no read model) intact, never a
+ * partially-built one.
+ *
+ * `viewer_pages` includes every listable page regardless of content-type
+ * category (`scraped = 1 AND redirectDestId IS NULL`, plus excluding
+ * `isSkipped` discovery-only placeholder rows — the same predicate
+ * `Database.resetFailedPages` and `excludeSkippedPages` guard against, see
+ * that helper's docs for the production incident that motivated it).
+ * `content_category` is stored as a column precisely so a future
+ * `/api/pages` consumer can filter by it; unlike `listPages`'s *default*
+ * view (which only shows HTML + not-yet-classified rows), this table is
+ * intentionally NOT pre-filtered to that subset — unfiltered totals here
+ * can legitimately exceed `listPages(accessor, {}).total` on an archive
+ * that also has known non-HTML pages (PDFs, images, etc.).
+ *
+ * `viewer_page_anchors` is created but left with zero rows: populating it
+ * requires real pagination-cursor math tied to a specific page size/page
+ * number, which belongs to whichever issue actually wires up `/api/pages`
+ * page-number jumps.
+ *
+ * Always a full rebuild — there is no incremental/diff path.
+ * @param accessor - The archive accessor to build against. Must be
+ *   writable (`accessor.readOnly === false`) — typically an `Archive`
+ *   returned by `Archive.create`/`Archive.open`, not `Archive.connect`/
+ *   `Archive.openCached` (always read-only) or a stub-mode accessor.
+ * @throws {Error} When `accessor.readOnly` is `true`.
+ * @example
+ * // Typically called once, right after a crawl finishes writing `pages`:
+ * await buildViewerReadModel(archive);
+ */
+export async function buildViewerReadModel(accessor: ArchiveAccessor): Promise<void> {
+	if (accessor.readOnly) {
+		throw new Error(
+			'buildViewerReadModel: cannot build the viewer read model on a read-only ' +
+				'ArchiveAccessor (stub-mode, or an accessor opened via Archive.connect / ' +
+				'Archive.openCached). The read model may only be built against a writable ' +
+				'Archive (Archive.create / Archive.open), typically from the crawl-completion step.',
+		);
+	}
+
+	const knex = accessor.getKnex();
+	await knex.transaction(async (trx) => {
+		await dropViewerReadModelTables(trx);
+		await createViewerReadModelTables(trx);
+
+		const sourceRows: PagesSourceRow[] = await trx('pages')
+			.where('scraped', 1)
+			.whereNull('redirectDestId')
+			.where((qb) => excludeSkippedPages(qb))
+			.select(
+				'id',
+				'url',
+				'title',
+				'status',
+				'contentType',
+				'isExternal',
+				'description',
+				'og_title',
+				'robots_noindex',
+				'tag_count',
+				'jsonld_count',
+			);
+
+		const insertRows = sourceRows.map(toViewerPageInsertRow);
+
+		await eachSplitted(insertRows, INSERT_CHUNK_SIZE, async (chunk) => {
+			if (chunk.length > 0) {
+				await trx('viewer_pages').insert(chunk);
+			}
+		});
+
+		const total = insertRows.length;
+		await trx('viewer_query_profiles').insert({
+			scope: 'pages',
+			profile_key: 'default',
+			sort_key: 'url_sort_key',
+			sort_order: 'asc',
+			total,
+		});
+		await trx('viewer_count_buckets').insert({
+			scope: 'pages',
+			key: 'total',
+			value: 'all',
+			count: total,
+		});
+
+		await trx('viewer_read_model_meta').insert({
+			id: 1,
+			schema_version: VIEWER_READ_MODEL_SCHEMA_VERSION,
+			built_at: Date.now(),
+			source_row_count: total,
+		});
+	});
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/create-viewer-read-model-tables.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/create-viewer-read-model-tables.spec.ts
@@ -1,0 +1,85 @@
+import path from 'node:path';
+
+import { Archive } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createViewerReadModelTables } from './create-viewer-read-model-tables.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(
+	__dirname,
+	'__test_fixtures_create_viewer_read_model_tables__',
+);
+
+describe('createViewerReadModelTables', () => {
+	let archive: InstanceType<typeof Archive>;
+	const archiveFilePath = path.resolve(workingDir, 'create-tables-test.nitpicker');
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.releaseHandle();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('creates all 5 tables and the 5 named viewer_pages indexes', async () => {
+		const knex = archive.getKnex();
+		await knex.transaction((trx) => createViewerReadModelTables(trx));
+
+		for (const table of [
+			'viewer_read_model_meta',
+			'viewer_pages',
+			'viewer_query_profiles',
+			'viewer_count_buckets',
+			'viewer_page_anchors',
+		]) {
+			expect(await knex.schema.hasTable(table)).toBe(true);
+		}
+
+		const indexRows: Array<{ name: string }> = await knex('sqlite_master')
+			.where({ type: 'index', tbl_name: 'viewer_pages' })
+			.select('name');
+		const indexNames = new Set(indexRows.map((r) => r.name));
+		for (const indexName of [
+			'vp_default',
+			'vp_status',
+			'vp_title',
+			'vp_missing_title',
+			'vp_noindex',
+		]) {
+			expect(indexNames.has(indexName)).toBe(true);
+		}
+	});
+
+	it('viewer_query_profiles enforces a composite (scope, profile_key) key, not a single-column rowid', async () => {
+		const knex = archive.getKnex();
+		await knex('viewer_query_profiles').insert([
+			{
+				scope: 'pages',
+				profile_key: 'a',
+				sort_key: 'url_sort_key',
+				sort_order: 'asc',
+				total: 1,
+			},
+			{
+				scope: 'pages',
+				profile_key: 'b',
+				sort_key: 'url_sort_key',
+				sort_order: 'asc',
+				total: 2,
+			},
+		]);
+		const rows = await knex('viewer_query_profiles')
+			.select('profile_key')
+			.orderBy('profile_key');
+		expect(rows.map((r) => r.profile_key)).toEqual(['a', 'b']);
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/create-viewer-read-model-tables.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/create-viewer-read-model-tables.ts
@@ -1,0 +1,99 @@
+import type { Knex } from 'knex';
+
+/**
+ * Creates all 5 viewer-read-model tables (and `viewer_pages`'s named
+ * indexes) against the given connection. Assumes none of the tables
+ * currently exist — callers (`buildViewerReadModel`) are responsible for
+ * dropping any prior version first, inside the same transaction, so this
+ * function is not itself idempotent.
+ *
+ * Every statement runs via `raw()` rather than knex's chainable schema
+ * builder: 4 of the 5 tables need `WITHOUT ROWID` / a composite primary key
+ * / a `CHECK` constraint, none of which the chainable builder can express
+ * (the same reason `page_html_blobs` / `page_html_ref` drop to `raw()` in
+ * `@nitpicker/crawler`'s `init-schema.ts`). Using `raw()` for the 5th table
+ * (`viewer_pages`) too keeps this function a single uniform style instead
+ * of mixing two schema-definition APIs.
+ * @param trx - An open Knex transaction (a plain `Knex` instance also works,
+ *   e.g. in tests that don't need transactional rollback).
+ */
+export async function createViewerReadModelTables(trx: Knex): Promise<void> {
+	await trx.raw(`
+		CREATE TABLE viewer_read_model_meta (
+			id integer primary key check (id = 1),
+			schema_version integer not null,
+			built_at integer not null,
+			source_row_count integer not null
+		)
+	`);
+
+	await trx.raw(`
+		CREATE TABLE viewer_pages (
+			page_id integer primary key,
+			url text not null,
+			title text,
+			status integer,
+			content_category text not null,
+			is_external integer not null,
+			has_title integer not null,
+			has_description integer not null,
+			has_og_title integer not null,
+			robots_noindex integer not null,
+			tag_count integer not null default 0,
+			jsonld_count integer not null default 0,
+			url_sort_key text not null,
+			title_sort_key text,
+			path_sort_key text not null
+		)
+	`);
+	await trx.raw(
+		'CREATE INDEX vp_default ON viewer_pages(is_external, content_category, url_sort_key, page_id)',
+	);
+	await trx.raw(
+		'CREATE INDEX vp_status ON viewer_pages(is_external, content_category, status, url_sort_key, page_id)',
+	);
+	await trx.raw(
+		'CREATE INDEX vp_title ON viewer_pages(is_external, content_category, title_sort_key, url_sort_key, page_id)',
+	);
+	await trx.raw(
+		'CREATE INDEX vp_missing_title ON viewer_pages(is_external, content_category, has_title, url_sort_key, page_id)',
+	);
+	await trx.raw(
+		'CREATE INDEX vp_noindex ON viewer_pages(is_external, content_category, robots_noindex, url_sort_key, page_id)',
+	);
+
+	await trx.raw(`
+		CREATE TABLE viewer_query_profiles (
+			scope text not null,
+			profile_key text not null,
+			sort_key text not null,
+			sort_order text not null,
+			total integer not null,
+			primary key(scope, profile_key)
+		) WITHOUT ROWID
+	`);
+
+	await trx.raw(`
+		CREATE TABLE viewer_count_buckets (
+			scope text not null,
+			key text not null,
+			value text not null,
+			count integer not null,
+			primary key(scope, key, value)
+		) WITHOUT ROWID
+	`);
+
+	await trx.raw(`
+		CREATE TABLE viewer_page_anchors (
+			scope text not null,
+			profile_key text not null,
+			page_size integer not null,
+			page_index integer not null,
+			anchor_text_key text,
+			anchor_number_key integer,
+			anchor_id integer not null,
+			row_offset integer not null,
+			primary key(scope, profile_key, page_size, page_index)
+		) WITHOUT ROWID
+	`);
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model-tables.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model-tables.spec.ts
@@ -1,0 +1,64 @@
+import path from 'node:path';
+
+import { Archive } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createViewerReadModelTables } from './create-viewer-read-model-tables.js';
+import { dropViewerReadModelTables } from './drop-viewer-read-model-tables.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(
+	__dirname,
+	'__test_fixtures_drop_viewer_read_model_tables__',
+);
+
+describe('dropViewerReadModelTables', () => {
+	let archive: InstanceType<typeof Archive>;
+	const archiveFilePath = path.resolve(workingDir, 'drop-tables-test.nitpicker');
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.releaseHandle();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('is a no-op when the tables were never created', async () => {
+		await expect(
+			archive.getKnex().transaction((trx) => dropViewerReadModelTables(trx)),
+		).resolves.toBeUndefined();
+	});
+
+	it('drops all 5 tables after they were created', async () => {
+		const knex = archive.getKnex();
+		await knex.transaction((trx) => createViewerReadModelTables(trx));
+		for (const table of [
+			'viewer_read_model_meta',
+			'viewer_pages',
+			'viewer_query_profiles',
+			'viewer_count_buckets',
+			'viewer_page_anchors',
+		]) {
+			expect(await knex.schema.hasTable(table)).toBe(true);
+		}
+
+		await knex.transaction((trx) => dropViewerReadModelTables(trx));
+		for (const table of [
+			'viewer_read_model_meta',
+			'viewer_pages',
+			'viewer_query_profiles',
+			'viewer_count_buckets',
+			'viewer_page_anchors',
+		]) {
+			expect(await knex.schema.hasTable(table)).toBe(false);
+		}
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model-tables.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model-tables.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+/**
+ * Drops all 5 viewer-read-model tables if present, against the given
+ * connection. Shared by `buildViewerReadModel` (which drops before
+ * recreating, inside its own rebuild transaction) and
+ * `dropViewerReadModel` (which drops with no recreate), so the 5-table
+ * list only needs to be kept in sync with `createViewerReadModelTables`
+ * in one place.
+ * @param trx - An open Knex transaction (a plain `Knex` instance also
+ *   works, e.g. in tests).
+ */
+export async function dropViewerReadModelTables(trx: Knex): Promise<void> {
+	await trx.schema.dropTableIfExists('viewer_page_anchors');
+	await trx.schema.dropTableIfExists('viewer_count_buckets');
+	await trx.schema.dropTableIfExists('viewer_query_profiles');
+	await trx.schema.dropTableIfExists('viewer_pages');
+	await trx.schema.dropTableIfExists('viewer_read_model_meta');
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model.spec.ts
@@ -1,0 +1,125 @@
+import path from 'node:path';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { Archive } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { buildViewerReadModel } from './build-viewer-read-model.js';
+import { dropViewerReadModel } from './drop-viewer-read-model.js';
+import { hasViewerReadModel } from './has-viewer-read-model.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_drop_viewer_read_model__');
+
+describe('dropViewerReadModel', () => {
+	let archive: InstanceType<typeof Archive>;
+	const archiveFilePath = path.resolve(workingDir, 'drop-test.nitpicker');
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+		await archive.setConfig({
+			baseUrl: 'https://example.com',
+			name: 'test',
+			version: '0.10.0',
+			recursive: true,
+			interval: 0,
+			image: true,
+			fetchExternal: false,
+			parallels: 1,
+			roots: ['https://example.com'],
+			excludes: [],
+			excludeKeywords: [],
+			excludeUrls: [],
+			maxExcludedDepth: 0,
+			retry: 3,
+			fromList: false,
+			disableQueries: false,
+			userAgent: 'test',
+			ignoreRobots: false,
+		});
+		await archive.setPage({
+			url: parseUrl('https://example.com/')!,
+			redirectPaths: [],
+			isExternal: false,
+			isTarget: true,
+			status: 200,
+			statusText: 'OK',
+			contentType: 'text/html',
+			contentLength: 100,
+			responseHeaders: {},
+			html: '<html></html>',
+			meta: {
+				lang: null,
+				title: 'Home',
+				description: null,
+				keywords: null,
+				noindex: false,
+				nofollow: false,
+				noarchive: false,
+				canonical: null,
+				alternate: null,
+				'og:type': null,
+				'og:title': null,
+				'og:site_name': null,
+				'og:description': null,
+				'og:url': null,
+				'og:image': null,
+				'twitter:card': null,
+			},
+			anchorList: [],
+			imageList: [],
+			isSkipped: false,
+		});
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.releaseHandle();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('is a no-op when nothing was ever built', async () => {
+		await expect(dropViewerReadModel(archive)).resolves.toBeUndefined();
+		expect(await hasViewerReadModel(archive)).toBe(false);
+	});
+
+	it('drops all 5 tables after a build, leaving the write model untouched', async () => {
+		await buildViewerReadModel(archive);
+		expect(await hasViewerReadModel(archive)).toBe(true);
+
+		const knex = archive.getKnex();
+		const pagesBefore = await knex('pages').count<{ count: string }[]>({ count: '*' });
+
+		await dropViewerReadModel(archive);
+
+		expect(await hasViewerReadModel(archive)).toBe(false);
+		for (const table of [
+			'viewer_pages',
+			'viewer_query_profiles',
+			'viewer_count_buckets',
+			'viewer_page_anchors',
+		]) {
+			expect(await knex.schema.hasTable(table)).toBe(false);
+		}
+
+		const pagesAfter = await knex('pages').count<{ count: string }[]>({ count: '*' });
+		expect(pagesAfter[0]?.count).toBe(pagesBefore[0]?.count);
+	});
+
+	it('throws on a read-only accessor and leaves the archive untouched', async () => {
+		await buildViewerReadModel(archive);
+		const readOnlyAccessor = await Archive.connect(archive.tmpDir);
+		try {
+			await expect(dropViewerReadModel(readOnlyAccessor)).rejects.toThrow(/read-only/i);
+			expect(await hasViewerReadModel(archive)).toBe(true);
+		} finally {
+			await readOnlyAccessor.close();
+			await dropViewerReadModel(archive);
+		}
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/drop-viewer-read-model.ts
@@ -1,0 +1,30 @@
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+import { dropViewerReadModelTables } from './drop-viewer-read-model-tables.js';
+
+/**
+ * Drops all 5 viewer-read-model tables if present. Idempotent — calling
+ * this on an archive with no read model is a no-op, not an error. Only
+ * ever touches the 5 `viewer_*` tables; the write-model tables (`pages`,
+ * `anchors`, etc.) are never referenced.
+ * @param accessor - The archive accessor to drop from. Must be writable
+ *   (`accessor.readOnly === false`).
+ * @throws {Error} When `accessor.readOnly` is `true`.
+ * @example
+ * // Force a clean rebuild instead of relying on ensureViewerReadModel's
+ * // version check:
+ * await dropViewerReadModel(archive);
+ * await buildViewerReadModel(archive);
+ */
+export async function dropViewerReadModel(accessor: ArchiveAccessor): Promise<void> {
+	if (accessor.readOnly) {
+		throw new Error(
+			'dropViewerReadModel: cannot drop the viewer read model on a read-only ' +
+				'ArchiveAccessor (stub-mode, or an accessor opened via Archive.connect / ' +
+				'Archive.openCached).',
+		);
+	}
+
+	const knex = accessor.getKnex();
+	await knex.transaction((trx) => dropViewerReadModelTables(trx));
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/ensure-viewer-read-model.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/ensure-viewer-read-model.spec.ts
@@ -1,0 +1,123 @@
+import path from 'node:path';
+
+import { Archive } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { ensureViewerReadModel } from './ensure-viewer-read-model.js';
+import { hasViewerReadModel } from './has-viewer-read-model.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_ensure_viewer_read_model__');
+
+describe('ensureViewerReadModel', () => {
+	let archive: InstanceType<typeof Archive>;
+	const archiveFilePath = path.resolve(workingDir, 'ensure-test.nitpicker');
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.releaseHandle();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('builds the read model when missing', async () => {
+		expect(await hasViewerReadModel(archive)).toBe(false);
+		await ensureViewerReadModel(archive);
+		expect(await hasViewerReadModel(archive)).toBe(true);
+	});
+
+	it('does not rebuild when already current', async () => {
+		// A rebuild always drops-and-recreates viewer_query_profiles, so a
+		// marker row inserted here can only survive a no-op call. Asserting
+		// on `built_at` instead would be timing-flaky: a real (buggy)
+		// rebuild could complete within the same millisecond and produce an
+		// identical `Date.now()` value, masking the bug.
+		const knex = archive.getKnex();
+		await knex('viewer_query_profiles').insert({
+			scope: 'marker',
+			profile_key: 'marker',
+			sort_key: 'x',
+			sort_order: 'asc',
+			total: 0,
+		});
+
+		await ensureViewerReadModel(archive);
+
+		const marker = await knex('viewer_query_profiles')
+			.where({ scope: 'marker', profile_key: 'marker' })
+			.first();
+		expect(marker).toBeDefined();
+
+		await knex('viewer_query_profiles')
+			.where({ scope: 'marker', profile_key: 'marker' })
+			.del();
+	});
+
+	it('rebuilds when the persisted schema_version is stale', async () => {
+		// Same marker-row technique as above: a real rebuild always
+		// drops-and-recreates viewer_query_profiles, so the marker's absence
+		// proves a rebuild ran (timing-independent, unlike comparing
+		// `built_at`, which a same-millisecond rebuild could leave unchanged).
+		const knex = archive.getKnex();
+		await knex('viewer_read_model_meta').where('id', 1).update({ schema_version: 0 });
+		await knex('viewer_query_profiles').insert({
+			scope: 'marker',
+			profile_key: 'marker',
+			sort_key: 'x',
+			sort_order: 'asc',
+			total: 0,
+		});
+
+		await ensureViewerReadModel(archive);
+
+		const after = await knex('viewer_read_model_meta').where('id', 1).first();
+		expect(after?.schema_version).not.toBe(0);
+		const marker = await knex('viewer_query_profiles')
+			.where({ scope: 'marker', profile_key: 'marker' })
+			.first();
+		expect(marker).toBeUndefined();
+	});
+
+	it('does not throw on a read-only accessor that is already current', async () => {
+		const readOnlyAccessor = await Archive.connect(archive.tmpDir);
+		try {
+			await expect(ensureViewerReadModel(readOnlyAccessor)).resolves.toBeUndefined();
+		} finally {
+			await readOnlyAccessor.close();
+		}
+	});
+
+	it('throws on a read-only accessor with no read model', async () => {
+		const freshWorkingDir = path.resolve(
+			__dirname,
+			'__test_fixtures_ensure_viewer_read_model_fresh__',
+		);
+		const { mkdirSync, rmSync } = await import('node:fs');
+		mkdirSync(freshWorkingDir, { recursive: true });
+		const freshArchive = await Archive.create({
+			filePath: path.resolve(freshWorkingDir, 'fresh.nitpicker'),
+			cwd: freshWorkingDir,
+		});
+		try {
+			const readOnlyAccessor = await Archive.connect(freshArchive.tmpDir);
+			try {
+				await expect(ensureViewerReadModel(readOnlyAccessor)).rejects.toThrow(
+					/read-only/i,
+				);
+			} finally {
+				await readOnlyAccessor.close();
+			}
+		} finally {
+			await freshArchive.releaseHandle();
+			rmSync(freshWorkingDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/ensure-viewer-read-model.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/ensure-viewer-read-model.ts
@@ -1,0 +1,31 @@
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+import { buildViewerReadModel } from './build-viewer-read-model.js';
+import { getViewerReadModelVersion } from './get-viewer-read-model-version.js';
+import { VIEWER_READ_MODEL_SCHEMA_VERSION } from './viewer-read-model-schema-version.js';
+
+/**
+ * Builds the viewer read model if it is missing or stale (schema version
+ * mismatch), otherwise does nothing. The idempotent entry point intended
+ * for a future crawl-completion build trigger and any other on-demand
+ * caller that just wants "make sure this is current."
+ *
+ * When the read model is already current, this function returns without
+ * ever inspecting `accessor.readOnly` — a read-only caller polling an
+ * already-built, up-to-date archive never throws.
+ * @param accessor - The archive accessor. Must be writable
+ *   (`accessor.readOnly === false`) whenever a build actually turns out to
+ *   be necessary — see {@link buildViewerReadModel}'s guard, which this
+ *   function inherits by delegating to it.
+ * @throws {Error} When a build is needed and `accessor.readOnly` is `true`.
+ * @example
+ * // After a crawl completes, against the writable Archive that just wrote it:
+ * await ensureViewerReadModel(archive);
+ */
+export async function ensureViewerReadModel(accessor: ArchiveAccessor): Promise<void> {
+	const version = await getViewerReadModelVersion(accessor);
+	if (version === VIEWER_READ_MODEL_SCHEMA_VERSION) {
+		return;
+	}
+	await buildViewerReadModel(accessor);
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/get-viewer-read-model-version.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/get-viewer-read-model-version.spec.ts
@@ -1,0 +1,51 @@
+import path from 'node:path';
+
+import { Archive } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createViewerReadModelTables } from './create-viewer-read-model-tables.js';
+import { getViewerReadModelVersion } from './get-viewer-read-model-version.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(
+	__dirname,
+	'__test_fixtures_get_viewer_read_model_version__',
+);
+
+describe('getViewerReadModelVersion', () => {
+	let archive: InstanceType<typeof Archive>;
+	const archiveFilePath = path.resolve(workingDir, 'get-version-test.nitpicker');
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.releaseHandle();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('returns null when no read model has been built', async () => {
+		expect(await getViewerReadModelVersion(archive)).toBeNull();
+	});
+
+	it('returns the persisted schema_version once built', async () => {
+		const knex = archive.getKnex();
+		await knex.transaction(async (trx) => {
+			await createViewerReadModelTables(trx);
+			await trx('viewer_read_model_meta').insert({
+				id: 1,
+				schema_version: 7,
+				built_at: 1,
+				source_row_count: 0,
+			});
+		});
+		expect(await getViewerReadModelVersion(archive)).toBe(7);
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/get-viewer-read-model-version.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/get-viewer-read-model-version.ts
@@ -1,0 +1,37 @@
+import type { ViewerReadModelMetaRow } from './types.js';
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+/**
+ * Returns the persisted schema/build version of the viewer read model, or
+ * `null` if no read model has been built yet. A pure read — safe to call on
+ * read-only accessors, never mutates anything.
+ *
+ * Coerces the stored value with `Number(...)`: libsql/knex sometimes returns
+ * integer columns as strings (the same known quirk `count-pages-by-tag.ts`
+ * and friends work around), and a bare string would break the strict `===`
+ * comparison `ensureViewerReadModel` does against
+ * `VIEWER_READ_MODEL_SCHEMA_VERSION`.
+ * @param accessor - The archive accessor to check.
+ * @returns The `schema_version` value, or `null` when absent.
+ * @example
+ * const version = await getViewerReadModelVersion(accessor);
+ * if (version !== VIEWER_READ_MODEL_SCHEMA_VERSION) {
+ *   // stale or never built — throws a clear error instead of rebuilding.
+ *   throw new Error(`viewer read model is stale (version=${version})`);
+ * }
+ */
+export async function getViewerReadModelVersion(
+	accessor: ArchiveAccessor,
+): Promise<number | null> {
+	const knex = accessor.getKnex();
+	const exists = await knex.schema.hasTable('viewer_read_model_meta');
+	if (!exists) {
+		return null;
+	}
+	const row: Pick<ViewerReadModelMetaRow, 'schema_version'> | undefined = await knex(
+		'viewer_read_model_meta',
+	)
+		.where('id', 1)
+		.first('schema_version');
+	return row?.schema_version == null ? null : Number(row.schema_version);
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/has-viewer-read-model.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/has-viewer-read-model.spec.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+
+import { Archive } from '@nitpicker/crawler';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createViewerReadModelTables } from './create-viewer-read-model-tables.js';
+import { hasViewerReadModel } from './has-viewer-read-model.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_has_viewer_read_model__');
+
+describe('hasViewerReadModel', () => {
+	let archive: InstanceType<typeof Archive>;
+	const archiveFilePath = path.resolve(workingDir, 'has-read-model-test.nitpicker');
+
+	beforeAll(async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({ filePath: archiveFilePath, cwd: workingDir });
+	});
+
+	afterAll(async () => {
+		if (archive) {
+			await archive.releaseHandle();
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('returns false when the read model has not been built', async () => {
+		expect(await hasViewerReadModel(archive)).toBe(false);
+	});
+
+	it('returns true once the tables and meta row exist', async () => {
+		const knex = archive.getKnex();
+		await knex.transaction(async (trx) => {
+			await createViewerReadModelTables(trx);
+			await trx('viewer_read_model_meta').insert({
+				id: 1,
+				schema_version: 1,
+				built_at: 1,
+				source_row_count: 0,
+			});
+		});
+		expect(await hasViewerReadModel(archive)).toBe(true);
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/has-viewer-read-model.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/has-viewer-read-model.ts
@@ -1,0 +1,23 @@
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+import { getViewerReadModelVersion } from './get-viewer-read-model-version.js';
+
+/**
+ * Checks whether the viewer read model has been built at all, regardless of
+ * schema version. A pure read — safe to call on read-only accessors (stub
+ * mode, `Archive.connect`, `Archive.openCached`), never mutates anything.
+ *
+ * Composes on {@link getViewerReadModelVersion} rather than re-probing
+ * `viewer_read_model_meta` independently, so the "does the singleton row
+ * exist" check only has one implementation to keep in sync.
+ * @param accessor - The archive accessor to check.
+ * @returns `true` iff `viewer_read_model_meta` exists as a table and holds
+ *   its singleton row (`id = 1`).
+ * @example
+ * if (!(await hasViewerReadModel(accessor))) {
+ *   // fall back to the live query path, or prompt a build.
+ * }
+ */
+export async function hasViewerReadModel(accessor: ArchiveAccessor): Promise<boolean> {
+	return (await getViewerReadModelVersion(accessor)) !== null;
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/types.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Row shape of the `viewer_read_model_meta` singleton table (always exactly
+ * one row, `id = 1`). Shared between `hasViewerReadModel` and
+ * `getViewerReadModelVersion`, which both probe this table.
+ */
+export interface ViewerReadModelMetaRow {
+	/** Always `1` — enforced by a `CHECK (id = 1)` constraint. */
+	id: 1;
+	/**
+	 * The read-model schema/build version that produced this row. Compared
+	 * against `VIEWER_READ_MODEL_SCHEMA_VERSION` by `ensureViewerReadModel`
+	 * to decide whether a rebuild is needed.
+	 */
+	schema_version: number;
+	/** Unix epoch milliseconds when this build completed. */
+	built_at: number;
+	/** Number of rows written to `viewer_pages` during this build. */
+	source_row_count: number;
+}

--- a/packages/@nitpicker/query/src/viewer-read-model/viewer-read-model-schema-version.spec.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/viewer-read-model-schema-version.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { VIEWER_READ_MODEL_SCHEMA_VERSION } from './viewer-read-model-schema-version.js';
+
+describe('VIEWER_READ_MODEL_SCHEMA_VERSION', () => {
+	it('is a positive integer', () => {
+		expect(Number.isInteger(VIEWER_READ_MODEL_SCHEMA_VERSION)).toBe(true);
+		expect(VIEWER_READ_MODEL_SCHEMA_VERSION).toBeGreaterThan(0);
+	});
+});

--- a/packages/@nitpicker/query/src/viewer-read-model/viewer-read-model-schema-version.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/viewer-read-model-schema-version.ts
@@ -1,0 +1,10 @@
+/**
+ * Current schema/build version of the viewer read model. Bump this whenever
+ * the table shapes or population logic in `viewer-read-model/` change in a
+ * way that requires existing archives to rebuild.
+ *
+ * `ensureViewerReadModel` compares this constant against the persisted
+ * `viewer_read_model_meta.schema_version` to decide whether a rebuild is
+ * needed.
+ */
+export const VIEWER_READ_MODEL_SCHEMA_VERSION = 1;


### PR DESCRIPTION
## Summary

- Adds `ensureViewerReadModel` / `hasViewerReadModel` / `buildViewerReadModel` / `dropViewerReadModel` / `getViewerReadModelVersion` to `@nitpicker/query`, plus 5 new self-contained tables (`viewer_read_model_meta`, `viewer_pages`, `viewer_query_profiles`, `viewer_count_buckets`, `viewer_page_anchors`) — the schemas for the latter 3 are copied verbatim from `docs/viewer-sql-query-plan.md`.
- **Write safety**: `build`/`drop` throw immediately on a read-only `ArchiveAccessor` (stub-mode, `Archive.connect`/`Archive.openCached`). The real trigger for building is a future crawl-completion hook, which always hands a writable `Archive`. No sidecar files, no `@nitpicker/crawler` changes.
- **Rebuild**: full drop-and-recreate inside one transaction, so a mid-build failure leaves the previous read model (or none) intact — never partial.
- `viewer_pages` is populated from the current `pages` write-model table (no changes to `init-schema.ts`/migrations), reusing existing helpers (`classifyContentType`, `excludeSkippedPages`, `eachSplitted`) rather than reimplementing their logic.
- **Infrastructure only** — no wiring into crawl completion (tracked as #112) or any viewer route (tracked as #105). `viewer_page_anchors` is created but intentionally left empty; real pagination-cursor population belongs to #105.
- Filed and linked a follow-up issue, #139, for the shared text/URL dedup ref table implied by `docs/viewer-sql-query-plan.md`'s `title_text_id` (deferred — `viewer_pages.title`/`url` are stored inline for now).

Closes #108.

## Test plan

- [x] `yarn tsc --noEmit -p packages/@nitpicker/query/tsconfig.json` — 0 errors (see note below on `yarn build`)
- [x] `yarn vitest run packages/@nitpicker/query` — 49 files / 252 tests / 1 pre-existing skip, all green
- [x] `yarn lint` — 0 errors
- [x] `/code-review xhigh`, `/qa-engineer`, `/product-manager`, `/doc` all run; findings fixed (isSkipped-row exclusion bug, nullable-column type fixes, `getViewerReadModelVersion`/`hasViewerReadModel` dedup, shared drop-tables helper, ghost-code coverage for defensive fallbacks, `@example` JSDoc on all 5 public functions)

**Known environment caveat (pre-existing, unrelated to this PR):** in this worktree, `yarn build`'s per-package `tsc` invocation (via lerna/Nx) silently produces no output for several packages (`@nitpicker/core`, `@nitpicker/types`, etc.) without surfacing an error — a full `yarn test` run therefore shows ~68 pre-existing failures in `analyze-axe`/`analyze-markuplint`/`analyze-textlint`/`analyze-main-contents`/`analyze-search` and a couple of `@nitpicker/crawler`/`report-google-sheets` specs, all failing on `@nitpicker/core` module resolution. None of them touch `@nitpicker/query` or this diff; every `@nitpicker/query` test passes. Used `yarn tsc --noEmit` as a one-off substitute to verify type-correctness for this PR's package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)