### PR TITLE
fix(viewer): unify status filters and default sorting across tables

### DIFF
--- a/packages/@nitpicker/query/src/get-isolated-cluster.spec.ts
+++ b/packages/@nitpicker/query/src/get-isolated-cluster.spec.ts
@@ -92,8 +92,8 @@ describe('getIsolatedCluster', () => {
 				redirectPaths: [],
 				isExternal: false,
 				isTarget: true,
-				status: 200,
-				statusText: 'OK',
+				status: 404,
+				statusText: 'Not Found',
 				contentType: 'text/html',
 				contentLength: 100,
 				responseHeaders: {},
@@ -148,5 +148,15 @@ describe('getIsolatedCluster', () => {
 			// the public DTO must not expose database row ids.
 			expect(member).not.toHaveProperty('id');
 		}
+	});
+
+	it('filters cluster members by status', async () => {
+		const result = await getIsolatedCluster(archive, 'https://example.com/cluster/a', {
+			status: 404,
+		});
+		expect(result?.size).toBe(1);
+		expect(result?.members.map((member) => member.url)).toEqual([
+			'https://example.com/cluster/b',
+		]);
 	});
 });

--- a/packages/@nitpicker/query/src/get-isolated-cluster.ts
+++ b/packages/@nitpicker/query/src/get-isolated-cluster.ts
@@ -70,6 +70,9 @@ export async function getIsolatedCluster(
 				if (options.source && member.source !== options.source) {
 					return false;
 				}
+				if (options.status != null && member.status !== options.status) {
+					return false;
+				}
 				return true;
 			});
 		const sorted = sortArrayItems(

--- a/packages/@nitpicker/query/src/list-isolated-clusters.spec.ts
+++ b/packages/@nitpicker/query/src/list-isolated-clusters.spec.ts
@@ -80,13 +80,19 @@ describe('listIsolatedClusters', () => {
 		);
 
 		// Cluster of size 3: a → b → c (chained anchors).
-		const buildSeed = (urlPath: string, anchorPath: string | null, title: string) => ({
+		const buildSeed = (
+			urlPath: string,
+			anchorPath: string | null,
+			title: string,
+			status = 200,
+			statusText = 'OK',
+		) => ({
 			url: parseUrl(`https://example.com${urlPath}`)!,
 			redirectPaths: [],
 			isExternal: false,
 			isTarget: true,
-			status: 200,
-			statusText: 'OK',
+			status,
+			statusText,
 			contentType: 'text/html',
 			contentLength: 100,
 			responseHeaders: {},
@@ -119,7 +125,7 @@ describe('listIsolatedClusters', () => {
 
 		// Cluster of size 2: x → y.
 		await archive.setPage(
-			buildSeed('/small-cluster/x', '/small-cluster/y', 'X'),
+			buildSeed('/small-cluster/x', '/small-cluster/y', 'X', 404, 'Not Found'),
 			'inventory-seed',
 		);
 		await archive.setPage(buildSeed('/small-cluster/y', null, 'Y'), 'inventory-seed');
@@ -170,5 +176,13 @@ describe('listIsolatedClusters', () => {
 		const third = await listIsolatedClusters(archive, { limit: 1, offset: 2 });
 		expect(third.items).toHaveLength(0);
 		expect(third.total).toBe(2);
+	});
+
+	it('filters cluster summaries by representative status', async () => {
+		const result = await listIsolatedClusters(archive, { status: 404 });
+		expect(result.total).toBe(1);
+		expect(result.items[0]?.representativeUrl).toBe(
+			'https://example.com/small-cluster/x',
+		);
 	});
 });

--- a/packages/@nitpicker/query/src/list-isolated-clusters.ts
+++ b/packages/@nitpicker/query/src/list-isolated-clusters.ts
@@ -62,11 +62,18 @@ export async function listIsolatedClusters(
 		});
 	}
 
-	const filtered = options.urlPattern
-		? clusters.filter((item) =>
-				item.representativeUrl.includes(options.urlPattern!.replaceAll('%', '')),
-			)
-		: clusters;
+	const filtered = clusters.filter((item) => {
+		if (
+			options.urlPattern &&
+			!item.representativeUrl.includes(options.urlPattern.replaceAll('%', ''))
+		) {
+			return false;
+		}
+		if (options.status != null && item.representativeStatus !== options.status) {
+			return false;
+		}
+		return true;
+	});
 	const sorted = sortArrayItems(
 		filtered,
 		options.sortBy ?? 'size',

--- a/packages/@nitpicker/query/src/list-isolated-pages.spec.ts
+++ b/packages/@nitpicker/query/src/list-isolated-pages.spec.ts
@@ -183,8 +183,8 @@ describe('listIsolatedPages', () => {
 				redirectPaths: [],
 				isExternal: false,
 				isTarget: true,
-				status: 200,
-				statusText: 'OK',
+				status: 404,
+				statusText: 'Not Found',
 				contentType: 'text/html',
 				contentLength: 100,
 				responseHeaders: {},
@@ -267,6 +267,12 @@ describe('listIsolatedPages', () => {
 		const third = await listIsolatedPages(archive, { limit: 1, offset: 2 });
 		expect(third.items).toHaveLength(0);
 		expect(third.total).toBe(2);
+	});
+
+	it('filters singletons by status', async () => {
+		const result = await listIsolatedPages(archive, { status: 404 });
+		expect(result.total).toBe(1);
+		expect(result.items[0]?.url).toBe('https://example.com/outbound-to-crawled');
 	});
 
 	it('uses precomputedComponents when supplied so the union-find pass is skipped', async () => {

--- a/packages/@nitpicker/query/src/list-isolated-pages.ts
+++ b/packages/@nitpicker/query/src/list-isolated-pages.ts
@@ -80,6 +80,9 @@ export async function listIsolatedPages(
 		if (options.source && item.source !== options.source) {
 			return false;
 		}
+		if (options.status != null && item.status !== options.status) {
+			return false;
+		}
 		return true;
 	});
 	const sorted = sortArrayItems(filtered, options.sortBy ?? 'url', options.sortOrder, {

--- a/packages/@nitpicker/query/src/list-links.spec.ts
+++ b/packages/@nitpicker/query/src/list-links.spec.ts
@@ -233,6 +233,12 @@ describe('listLinks', () => {
 		});
 	});
 
+	it('status でリンク先をフィルタする', async () => {
+		const result = await listLinks(archive, { type: 'external', status: 404 });
+		expect(result.items).toHaveLength(0);
+		expect(result.total).toBe(0);
+	});
+
 	it('ページネーションが機能する', async () => {
 		const result = await listLinks(archive, { type: 'broken', limit: 1, offset: 0 });
 		expect(result.items).toHaveLength(1);

--- a/packages/@nitpicker/query/src/list-links.ts
+++ b/packages/@nitpicker/query/src/list-links.ts
@@ -82,6 +82,9 @@ export async function listLinks(
 	const destUrlExpression = includeRedirectSources
 		? '"dest"."url"'
 		: 'COALESCE("canonical"."url", "dest"."url")';
+	const statusExpression = includeRedirectSources
+		? '"dest"."status"'
+		: 'COALESCE("canonical"."status", "dest"."status")';
 
 	baseQuery.select(
 		'source.url as sourceUrl',
@@ -113,6 +116,9 @@ export async function listLinks(
 			);
 		});
 	}
+	if (options.status != null) {
+		baseQuery.whereRaw(`${statusExpression} = ?`, [options.status]);
+	}
 
 	const countResult = (await baseQuery
 		.clone()
@@ -128,9 +134,7 @@ export async function listLinks(
 			type: 'url',
 		},
 		status: {
-			column: includeRedirectSources
-				? '"dest"."status"'
-				: 'COALESCE("canonical"."status", "dest"."status")',
+			column: statusExpression,
 		},
 		isExternal: {
 			column: includeRedirectSources

--- a/packages/@nitpicker/query/src/list-page-links.spec.ts
+++ b/packages/@nitpicker/query/src/list-page-links.spec.ts
@@ -90,8 +90,8 @@ describe('listPageLinks', () => {
 			redirectPaths: [],
 			isExternal: false,
 			isTarget: true,
-			status: 200,
-			statusText: 'OK',
+			status: 404,
+			statusText: 'Not Found',
 			contentType: 'text/html',
 			contentLength: 100,
 			responseHeaders: {},
@@ -136,6 +136,12 @@ describe('listPageLinks', () => {
 		const about = result.items.find((i) => i.url === 'https://example.com/about');
 		expect(home?.hasResponseHeaders).toBe(true);
 		expect(about?.hasResponseHeaders).toBe(false);
+	});
+
+	it('status でフィルタする', async () => {
+		const result = await listPageLinks(archive, { status: 404 });
+		expect(result.total).toBe(1);
+		expect(result.items[0]?.url).toBe('https://example.com/about');
 	});
 
 	it('precomputedReferrerCounts を渡すと SQL 経由ではなく Map lookup で referrerCount を埋める', async () => {

--- a/packages/@nitpicker/query/src/list-page-links.ts
+++ b/packages/@nitpicker/query/src/list-page-links.ts
@@ -54,6 +54,9 @@ export async function listPageLinks(
 	if (options.urlPattern) {
 		baseQuery.where('url', 'like', options.urlPattern);
 	}
+	if (options.status != null) {
+		baseQuery.where('status', options.status);
+	}
 	if (options.contentType) {
 		baseQuery.where('contentType', 'like', `${options.contentType}%`);
 	}

--- a/packages/@nitpicker/query/src/list-resources.spec.ts
+++ b/packages/@nitpicker/query/src/list-resources.spec.ts
@@ -95,8 +95,8 @@ describe('listResources', () => {
 			url: parseUrl('https://cdn.example.com/app.js')!,
 			isExternal: true,
 			isError: false,
-			status: 200,
-			statusText: 'OK',
+			status: 404,
+			statusText: 'Not Found',
 			contentType: 'application/javascript',
 			contentLength: 5000,
 			compress: false,
@@ -129,6 +129,12 @@ describe('listResources', () => {
 		const result = await listResources(archive, { isExternal: true });
 		expect(result.total).toBe(1);
 		expect(result.items[0]!.url).toBe('https://cdn.example.com/app.js');
+	});
+
+	it('status でフィルタする', async () => {
+		const result = await listResources(archive, { status: 200 });
+		expect(result.total).toBe(1);
+		expect(result.items[0]!.url).toBe('https://example.com/style.css');
 	});
 
 	it('ページネーションが機能する', async () => {

--- a/packages/@nitpicker/query/src/list-resources.ts
+++ b/packages/@nitpicker/query/src/list-resources.ts
@@ -33,6 +33,9 @@ export async function listResources(
 	if (options.urlPattern) {
 		baseQuery.where('url', 'like', options.urlPattern);
 	}
+	if (options.status != null) {
+		baseQuery.where('status', options.status);
+	}
 	if (options.contentType) {
 		baseQuery.where('contentType', 'like', `${options.contentType}%`);
 	}

--- a/packages/@nitpicker/query/src/list-unused-resources.spec.ts
+++ b/packages/@nitpicker/query/src/list-unused-resources.spec.ts
@@ -149,8 +149,8 @@ describe('listUnusedResources', () => {
 				url: parseUrl('https://example.com/inventory-discovered.png')!,
 				isExternal: false,
 				isError: false,
-				status: 200,
-				statusText: 'OK',
+				status: 404,
+				statusText: 'Not Found',
 				contentType: 'image/png',
 				contentLength: 500,
 				compress: false,
@@ -195,6 +195,12 @@ describe('listUnusedResources', () => {
 		expect(bySource['https://example.com/inventory-discovered.png']).toBe(
 			'inventory-discovered',
 		);
+	});
+
+	it('filters unused resources by status', async () => {
+		const result = await listUnusedResources(archive, { status: 404 });
+		expect(result.total).toBe(1);
+		expect(result.items[0]?.url).toBe('https://example.com/inventory-discovered.png');
 	});
 
 	it('respects limit and offset across the full unused set', async () => {

--- a/packages/@nitpicker/query/src/list-unused-resources.ts
+++ b/packages/@nitpicker/query/src/list-unused-resources.ts
@@ -53,6 +53,9 @@ export async function listUnusedResources(
 		if (options.urlPattern) {
 			query.where('resources.url', 'like', options.urlPattern);
 		}
+		if (options.status != null) {
+			query.where('resources.status', options.status);
+		}
 		if (options.contentType) {
 			query.where('resources.contentType', 'like', `${options.contentType}%`);
 		}

--- a/packages/@nitpicker/query/src/types.ts
+++ b/packages/@nitpicker/query/src/types.ts
@@ -46,6 +46,8 @@ export interface IsolatedPageEntry {
 export interface ListIsolatedPagesOptions {
 	/** URL pattern to search (SQL LIKE-ish substring for computed results). */
 	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
 	/** Filter by source. */
 	source?: PageSource;
 	/** Field to sort results by. */
@@ -135,6 +137,8 @@ export interface IsolatedComponent {
 export interface ListIsolatedClustersOptions {
 	/** URL pattern to search representative URLs. */
 	urlPattern?: string;
+	/** Filter by representative member status. */
+	status?: number;
 	/** Field to sort results by. */
 	sortBy?: 'representativeUrl' | 'representativeTitle' | 'representativeStatus' | 'size';
 	/** Sort direction. */
@@ -157,6 +161,8 @@ export interface ListIsolatedClustersOptions {
 export interface GetIsolatedClusterOptions {
 	/** URL pattern to search member URLs. */
 	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
 	/** Filter by source. */
 	source?: PageSource;
 	/** Field to sort results by. */
@@ -198,6 +204,8 @@ export interface UnusedResourceEntry {
 export interface ListUnusedResourcesOptions {
 	/** URL pattern to search. */
 	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
 	/** Filter by content type prefix. */
 	contentType?: string;
 	/** Filter by source. */
@@ -977,6 +985,8 @@ export interface ListLinksOptions {
 	includeRedirectSources?: boolean;
 	/** URL pattern to search source or destination URLs. */
 	urlPattern?: string;
+	/** Filter by destination HTTP status. */
+	status?: number;
 	/** Field to sort results by. */
 	sortBy?: 'sourceUrl' | 'destUrl' | 'status' | 'isExternal' | 'textContent';
 	/** Sort direction. */
@@ -1015,6 +1025,8 @@ export interface LinkAnalysisResult {
 export interface ListResourcesOptions {
 	/** URL pattern to filter resource URLs. */
 	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
 	/** Filter by content type prefix (e.g., "text/css", "application/javascript"). */
 	contentType?: string;
 	/** Filter by external (true) or internal (false) resources. */
@@ -1318,6 +1330,8 @@ export interface ListPageLinksOptions {
 	isExternal?: boolean;
 	/** URL pattern to search (SQL LIKE pattern). */
 	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
 	/** Filter by content type prefix. */
 	contentType?: string;
 	/** Filter to rows with or without response headers. */

--- a/packages/@nitpicker/viewer/src/routes/register-isolated-clusters-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-isolated-clusters-route.ts
@@ -28,6 +28,7 @@ export function registerIsolatedClustersRoute(app: Hono, context: ArchiveContext
 		const precomputedComponents = await getCachedIsolatedClusters(context);
 		const result = await listIsolatedClusters(accessor, {
 			urlPattern: c.req.query('urlPattern'),
+			status: toNumber(c.req.query('status')),
 			sortBy: c.req.query('sortBy') as
 				| 'representativeUrl'
 				| 'representativeTitle'
@@ -48,6 +49,7 @@ export function registerIsolatedClustersRoute(app: Hono, context: ArchiveContext
 		const precomputedComponents = await getCachedIsolatedClusters(context);
 		const result = await getIsolatedCluster(accessor, representativeUrl, {
 			urlPattern: c.req.query('urlPattern'),
+			status: toNumber(c.req.query('status')),
 			source: c.req.query('source') as
 				| 'crawled'
 				| 'inventory-seed'

--- a/packages/@nitpicker/viewer/src/routes/register-isolated-pages-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-isolated-pages-route.ts
@@ -24,6 +24,7 @@ export function registerIsolatedPagesRoute(app: Hono, context: ArchiveContext): 
 		const precomputedComponents = await getCachedIsolatedClusters(context);
 		const result = await listIsolatedPages(accessor, {
 			urlPattern: c.req.query('urlPattern'),
+			status: toNumber(c.req.query('status')),
 			source: c.req.query('source') as
 				| 'crawled'
 				| 'inventory-seed'

--- a/packages/@nitpicker/viewer/src/routes/register-links-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-links-route.ts
@@ -38,6 +38,7 @@ export function registerLinksRoute(app: Hono, context: ArchiveContext): void {
 			offset: toNumber(c.req.query('offset')),
 			includeRedirectSources,
 			urlPattern: c.req.query('urlPattern'),
+			status: toNumber(c.req.query('status')),
 			sortBy: c.req.query('sortBy') as
 				| 'sourceUrl'
 				| 'destUrl'

--- a/packages/@nitpicker/viewer/src/routes/register-page-links-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-page-links-route.ts
@@ -29,6 +29,7 @@ export function registerPageLinksRoute(app: Hono, context: ArchiveContext): void
 		const options: ListPageLinksOptions = {
 			isExternal: toBoolean(q.isExternal),
 			urlPattern: q.urlPattern,
+			status: toNumber(q.status),
 			contentType: q.contentType,
 			hasResponseHeaders: toBoolean(q.hasResponseHeaders),
 			sortBy: q.sortBy as ListPageLinksOptions['sortBy'],

--- a/packages/@nitpicker/viewer/src/routes/register-resources-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-resources-route.ts
@@ -18,6 +18,7 @@ export function registerResourcesRoute(app: Hono, context: ArchiveContext): void
 		const accessor = context.manager.get(context.archiveId);
 		const options: ListResourcesOptions = {
 			urlPattern: q.urlPattern,
+			status: toNumber(q.status),
 			contentType: q.contentType,
 			isExternal: toBoolean(q.isExternal),
 			sortBy: q.sortBy as ListResourcesOptions['sortBy'],

--- a/packages/@nitpicker/viewer/src/routes/register-unused-resources-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-unused-resources-route.ts
@@ -17,6 +17,7 @@ export function registerUnusedResourcesRoute(app: Hono, context: ArchiveContext)
 		const accessor = context.manager.get(context.archiveId);
 		const result = await listUnusedResources(accessor, {
 			urlPattern: c.req.query('urlPattern'),
+			status: toNumber(c.req.query('status')),
 			contentType: c.req.query('contentType'),
 			source: c.req.query('source') as
 				| 'crawled'

--- a/packages/@nitpicker/viewer/web/api/use-isolated-cluster.ts
+++ b/packages/@nitpicker/viewer/web/api/use-isolated-cluster.ts
@@ -8,6 +8,7 @@ export interface UseIsolatedClusterOptions {
 	limit?: number;
 	offset?: number;
 	urlPattern?: string;
+	status?: number;
 	source?: string;
 	sortBy?: string;
 	sortOrder?: string;

--- a/packages/@nitpicker/viewer/web/api/use-isolated-clusters-infinite.ts
+++ b/packages/@nitpicker/viewer/web/api/use-isolated-clusters-infinite.ts
@@ -7,6 +7,17 @@ import { apiGet } from './api-client.js';
 import { getNextOffset } from './get-next-offset.js';
 import { PAGE_SIZE } from './page-size.js';
 
+export interface IsolatedClustersFilter {
+	/** URL pattern applied to representative URLs. */
+	urlPattern?: string;
+	/** Filter by representative member status. */
+	status?: number;
+	/** Sort field. */
+	sortBy?: string;
+	/** Sort direction. */
+	sortOrder?: string;
+}
+
 /**
  * Paginated response shape from `GET /api/isolated-clusters` — duplicated
  * client-side so the React component can type the response without
@@ -23,15 +34,20 @@ export interface IsolatedClustersPage {
  * Infinite-scrolling **孤立集合** cluster summary list. Each row identifies
  * a cluster by its `representativeUrl`; the viewer drills into a specific
  * cluster via {@link import('./use-isolated-cluster.js').useIsolatedCluster}.
+ * @param filter - The active filter state.
  * @param options - Optional flags (`enabled`).
  * @returns The TanStack infinite-query result for cluster summaries.
  */
-export function useIsolatedClustersInfinite(options?: InfiniteQueryOptions) {
+export function useIsolatedClustersInfinite(
+	filter: IsolatedClustersFilter,
+	options?: InfiniteQueryOptions,
+) {
 	return useInfiniteQuery({
-		queryKey: ['isolated-clusters-infinite'],
+		queryKey: ['isolated-clusters-infinite', filter],
 		initialPageParam: 0,
 		queryFn: ({ pageParam }) =>
 			apiGet<IsolatedClustersPage>('/api/isolated-clusters', {
+				...filter,
 				limit: PAGE_SIZE,
 				offset: pageParam,
 			}),

--- a/packages/@nitpicker/viewer/web/api/use-isolated-pages-infinite.ts
+++ b/packages/@nitpicker/viewer/web/api/use-isolated-pages-infinite.ts
@@ -7,6 +7,19 @@ import { apiGet } from './api-client.js';
 import { getNextOffset } from './get-next-offset.js';
 import { PAGE_SIZE } from './page-size.js';
 
+export interface IsolatedPagesFilter {
+	/** URL pattern (SQL LIKE-ish substring). */
+	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
+	/** Filter by source label. */
+	source?: string;
+	/** Sort field. */
+	sortBy?: string;
+	/** Sort direction. */
+	sortOrder?: string;
+}
+
 /**
  * Paginated response shape from `GET /api/isolated-pages` — duplicated
  * client-side so the React component can type the response without
@@ -25,15 +38,20 @@ export interface IsolatedPagesPage {
  * loaded — replaces the previous fixed-100-row {@link useIsolatedPages}
  * hook so the rendered list count matches the displayed total at every
  * scroll position.
+ * @param filter - The active filter state.
  * @param options - Optional flags (`enabled`).
  * @returns The TanStack infinite-query result for singleton inventory pages.
  */
-export function useIsolatedPagesInfinite(options?: InfiniteQueryOptions) {
+export function useIsolatedPagesInfinite(
+	filter: IsolatedPagesFilter,
+	options?: InfiniteQueryOptions,
+) {
 	return useInfiniteQuery({
-		queryKey: ['isolated-pages-infinite'],
+		queryKey: ['isolated-pages-infinite', filter],
 		initialPageParam: 0,
 		queryFn: ({ pageParam }) =>
 			apiGet<IsolatedPagesPage>('/api/isolated-pages', {
+				...filter,
 				limit: PAGE_SIZE,
 				offset: pageParam,
 			}),

--- a/packages/@nitpicker/viewer/web/api/use-links-infinite.ts
+++ b/packages/@nitpicker/viewer/web/api/use-links-infinite.ts
@@ -17,6 +17,17 @@ export type LinkType = 'broken' | 'external';
 /** A link analysis row. */
 export type LinkRow = LinkEntry;
 
+export interface LinksFilter {
+	/** URL pattern applied to source or destination URL. */
+	urlPattern?: string;
+	/** Filter by destination HTTP status. */
+	status?: number;
+	/** Sort field. */
+	sortBy?: string;
+	/** Sort direction. */
+	sortOrder?: string;
+}
+
 /** Paginated link analysis response shape. */
 interface LinksPage {
 	/** Rows for this page. */
@@ -28,16 +39,22 @@ interface LinksPage {
 /**
  * Infinite-scrolling link analysis (broken / external).
  * @param type - The link analysis type.
+ * @param filter
  * @param options - Optional flags (`enabled`).
  * @returns The TanStack infinite-query result.
  */
-export function useLinksInfinite(type: LinkType, options?: InfiniteQueryOptions) {
+export function useLinksInfinite(
+	type: LinkType,
+	filter: LinksFilter,
+	options?: InfiniteQueryOptions,
+) {
 	return useInfiniteQuery({
-		queryKey: ['links', type],
+		queryKey: ['links', type, filter],
 		initialPageParam: 0,
 		queryFn: ({ pageParam }) =>
 			apiGet<LinksPage>('/api/links', {
 				type,
+				...filter,
 				limit: PAGE_SIZE,
 				offset: pageParam,
 			}),

--- a/packages/@nitpicker/viewer/web/api/use-page-links-infinite.ts
+++ b/packages/@nitpicker/viewer/web/api/use-page-links-infinite.ts
@@ -13,6 +13,16 @@ export interface PageLinksFilter {
 	isExternal?: boolean;
 	/** URL pattern (SQL LIKE). */
 	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
+	/** Filter by content type prefix. */
+	contentType?: string;
+	/** Filter to rows with/without response headers. */
+	hasResponseHeaders?: boolean;
+	/** Sort field. */
+	sortBy?: string;
+	/** Sort direction. */
+	sortOrder?: string;
 }
 
 /**

--- a/packages/@nitpicker/viewer/web/api/use-resources-infinite.ts
+++ b/packages/@nitpicker/viewer/web/api/use-resources-infinite.ts
@@ -9,10 +9,18 @@ import { PAGE_SIZE } from './page-size.js';
 
 /** Filter state for the resources view. */
 export interface ResourcesFilter {
+	/** URL pattern (SQL LIKE). */
+	urlPattern?: string;
+	/** Filter by HTTP status. */
+	status?: number;
 	/** Filter by content-type prefix. */
 	contentType?: string;
 	/** Filter by external/internal. */
 	isExternal?: boolean;
+	/** Sort field. */
+	sortBy?: string;
+	/** Sort direction. */
+	sortOrder?: string;
 }
 
 /**

--- a/packages/@nitpicker/viewer/web/components/build-status-filter-options.ts
+++ b/packages/@nitpicker/viewer/web/components/build-status-filter-options.ts
@@ -1,0 +1,45 @@
+import type { TableFilterOption } from './paged-table.js';
+
+/**
+ * Builds radio options for a numeric status filter from the visible dataset,
+ * preserving the currently selected value even when it is absent from the
+ * current page.
+ * @param items - Rows from which to collect status values.
+ * @param getStatus - Extracts the numeric status from a row.
+ * @param currentStatus - Raw `?status=` query value.
+ * @param allLabel - Label for the "all statuses" option.
+ * @returns Radio options sorted numerically ascending.
+ */
+export function buildStatusFilterOptions<T>(
+	items: readonly T[] | undefined,
+	getStatus: (item: T) => number | null | undefined,
+	currentStatus: string | null,
+	allLabel: string,
+): TableFilterOption[] {
+	const selectedStatus =
+		currentStatus != null && currentStatus.length > 0 ? Number(currentStatus) : undefined;
+	const statuses = new Set<number>();
+	for (const item of items ?? []) {
+		const status = getStatus(item);
+		if (typeof status === 'number' && Number.isFinite(status)) {
+			statuses.add(status);
+		}
+	}
+	if (selectedStatus != null && Number.isFinite(selectedStatus)) {
+		statuses.add(selectedStatus);
+	}
+	return [
+		{
+			value: '',
+			label: allLabel,
+			checked: currentStatus == null || currentStatus === '',
+		},
+		...[...statuses]
+			.toSorted((a, b) => a - b)
+			.map((status) => ({
+				value: String(status),
+				label: String(status),
+				checked: currentStatus === String(status),
+			})),
+	];
+}

--- a/packages/@nitpicker/viewer/web/components/create-table-controls.spec.ts
+++ b/packages/@nitpicker/viewer/web/components/create-table-controls.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { addRadioFilter, createTableControls } from './create-table-controls.js';
+
+describe('addRadioFilter', () => {
+	it('falls back to the checked option when the URL omits the filter key', () => {
+		const updateMany = vi.fn();
+		const params = new URLSearchParams();
+		const controls = createTableControls({ params, updateMany });
+
+		addRadioFilter(controls, { params, updateMany }, 'scope', 'isExternal', 'Scope', [
+			{ value: 'all', label: 'All', checked: false },
+			{ value: 'false', label: 'Internal', checked: true },
+			{ value: 'true', label: 'External', checked: false },
+		]);
+
+		expect(controls.filter?.scope?.options).toEqual([
+			{ value: 'all', label: 'All', checked: false },
+			{ value: 'false', label: 'Internal', checked: true },
+			{ value: 'true', label: 'External', checked: false },
+		]);
+	});
+
+	it('keeps explicit defaultValue precedence when no option is pre-checked', () => {
+		const updateMany = vi.fn();
+		const params = new URLSearchParams();
+		const controls = createTableControls({ params, updateMany });
+
+		addRadioFilter(
+			controls,
+			{ params, updateMany },
+			'type',
+			'type',
+			'Type',
+			[
+				{ value: 'broken', label: 'Broken', checked: false },
+				{ value: 'external', label: 'External', checked: false },
+			],
+			'broken',
+		);
+
+		expect(controls.filter?.type?.options).toEqual([
+			{ value: 'broken', label: 'Broken', checked: true },
+			{ value: 'external', label: 'External', checked: false },
+		]);
+	});
+});

--- a/packages/@nitpicker/viewer/web/components/create-table-controls.ts
+++ b/packages/@nitpicker/viewer/web/components/create-table-controls.ts
@@ -115,7 +115,10 @@ export function addRadioFilter(
 	defaultValue = '',
 ) {
 	controls.filter ??= {};
-	const current = context.params.get(key) ?? defaultValue;
+	const current =
+		context.params.get(key) ??
+		options.find((option) => option.checked)?.value ??
+		defaultValue;
 	controls.filter[columnId] = {
 		label,
 		kind: 'radio',

--- a/packages/@nitpicker/viewer/web/routes/isolated-clusters-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/isolated-clusters-view.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { useIsolatedCluster } from '../api/use-isolated-cluster.js';
 import { useIsolatedClustersInfinite } from '../api/use-isolated-clusters-infinite.js';
 import { usePagedQuery } from '../api/use-paged-query.js';
+import { buildStatusFilterOptions } from '../components/build-status-filter-options.js';
 import {
 	addRadioFilter,
 	addSort,
@@ -66,8 +67,11 @@ function ClusterListPane({
 	const { t } = useI18n();
 	const { params, updateMany } = useUrlFilter();
 	const { mode, pageSize, currentPage, setPage, setPageSize } = useListPagination();
+	const status = params.get('status');
+	const statusValue = status == null ? undefined : Number(status);
 	const filter = {
 		urlPattern: params.get('urlPattern') ?? undefined,
+		status: Number.isFinite(statusValue) ? statusValue : undefined,
 		sortBy: params.get('sortBy') ?? undefined,
 		sortOrder: params.get('sortOrder') ?? undefined,
 	};
@@ -79,7 +83,7 @@ function ClusterListPane({
 		['isolated-clusters-paged', filter, pageSize, currentPage],
 		{ enabled: mode === 'mpa' },
 	);
-	const infinite = useIsolatedClustersInfinite({ enabled: mode === 'virtual' });
+	const infinite = useIsolatedClustersInfinite(filter, { enabled: mode === 'virtual' });
 	const infiniteRows = useMemo(
 		() => infinite.data?.pages.flatMap((page) => page.items) ?? [],
 		[infinite.data],
@@ -144,8 +148,21 @@ function ClusterListPane({
 			'urlPattern',
 			t('views.pages.filterUrlPattern'),
 		);
+		addRadioFilter(
+			controls,
+			context,
+			'representativeStatus',
+			'status',
+			t('views.isolatedClusters.status'),
+			buildStatusFilterOptions(
+				paged.data?.items,
+				(item) => item.representativeStatus,
+				status,
+				t('common.all'),
+			),
+		);
 		return controls;
-	}, [params, t, updateMany]);
+	}, [paged.data?.items, params, status, t, updateMany]);
 
 	return (
 		<div className="view">
@@ -210,8 +227,11 @@ function ClusterDetailPane({
 	const { params, updateMany } = useUrlFilter();
 	const { mode, pageSize, currentPage, setPage, setPageSize } = useListPagination();
 	const offset = (currentPage - 1) * pageSize;
+	const status = params.get('status');
+	const statusValue = status == null ? undefined : Number(status);
 	const filter = {
 		urlPattern: params.get('urlPattern') ?? undefined,
+		status: Number.isFinite(statusValue) ? statusValue : undefined,
 		source: params.get('source') ?? undefined,
 		sortBy: params.get('sortBy') ?? undefined,
 		sortOrder: params.get('sortOrder') ?? undefined,
@@ -269,6 +289,19 @@ function ClusterDetailPane({
 			'urlPattern',
 			t('views.pages.filterUrlPattern'),
 		);
+		addRadioFilter(
+			controls,
+			context,
+			'status',
+			'status',
+			t('views.isolatedClusters.status'),
+			buildStatusFilterOptions(
+				data?.members,
+				(item) => item.status,
+				status,
+				t('common.all'),
+			),
+		);
 		addRadioFilter(controls, context, 'source', 'source', t('common.source'), [
 			{ value: '', label: t('common.all'), checked: false },
 			{ value: 'crawled', label: 'crawled', checked: false },
@@ -276,7 +309,7 @@ function ClusterDetailPane({
 			{ value: 'inventory-discovered', label: 'inventory-discovered', checked: false },
 		]);
 		return controls;
-	}, [params, t, updateMany]);
+	}, [data?.members, params, status, t, updateMany]);
 
 	const members = data?.members ?? [];
 	const total = data?.size ?? members.length;

--- a/packages/@nitpicker/viewer/web/routes/isolated-pages-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/isolated-pages-view.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 
 import { useIsolatedPagesInfinite } from '../api/use-isolated-pages-infinite.js';
 import { usePagedQuery } from '../api/use-paged-query.js';
+import { buildStatusFilterOptions } from '../components/build-status-filter-options.js';
 import {
 	addRadioFilter,
 	addSort,
@@ -29,8 +30,11 @@ export function IsolatedPagesView() {
 	const { t } = useI18n();
 	const { params, updateMany } = useUrlFilter();
 	const { mode, pageSize, currentPage, setPage, setPageSize } = useListPagination();
+	const status = params.get('status');
+	const statusValue = status == null ? undefined : Number(status);
 	const filter = {
 		urlPattern: params.get('urlPattern') ?? undefined,
+		status: Number.isFinite(statusValue) ? statusValue : undefined,
 		source: params.get('source') ?? undefined,
 		sortBy: params.get('sortBy') ?? undefined,
 		sortOrder: params.get('sortOrder') ?? undefined,
@@ -43,7 +47,7 @@ export function IsolatedPagesView() {
 		['isolated-pages-paged', filter, pageSize, currentPage],
 		{ enabled: mode === 'mpa' },
 	);
-	const infinite = useIsolatedPagesInfinite({ enabled: mode === 'virtual' });
+	const infinite = useIsolatedPagesInfinite(filter, { enabled: mode === 'virtual' });
 	const infiniteRows = useMemo(
 		() => infinite.data?.pages.flatMap((page) => page.items) ?? [],
 		[infinite.data],
@@ -96,6 +100,19 @@ export function IsolatedPagesView() {
 			'urlPattern',
 			t('views.pages.filterUrlPattern'),
 		);
+		addRadioFilter(
+			controls,
+			context,
+			'status',
+			'status',
+			t('views.isolatedPages.status'),
+			buildStatusFilterOptions(
+				paged.data?.items,
+				(item) => item.status,
+				status,
+				t('common.all'),
+			),
+		);
 		addRadioFilter(controls, context, 'source', 'source', t('common.source'), [
 			{ value: '', label: t('common.all'), checked: false },
 			{ value: 'crawled', label: 'crawled', checked: false },
@@ -103,7 +120,7 @@ export function IsolatedPagesView() {
 			{ value: 'inventory-discovered', label: 'inventory-discovered', checked: false },
 		]);
 		return controls;
-	}, [params, t, updateMany]);
+	}, [paged.data?.items, params, status, t, updateMany]);
 
 	return (
 		<div className="view">

--- a/packages/@nitpicker/viewer/web/routes/links-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/links-view.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo } from 'react';
 
 import { useLinksInfinite } from '../api/use-links-infinite.js';
 import { usePagedQuery } from '../api/use-paged-query.js';
+import { buildStatusFilterOptions } from '../components/build-status-filter-options.js';
 import {
 	addRadioFilter,
 	addSort,
@@ -48,6 +49,14 @@ export function LinksView() {
 	const { mode, pageSize, currentPage, setPage, setPageSize } = useListPagination();
 	const rawType = params.get('type') as LinkType | null;
 	const type: LinkType = rawType !== null && LINK_TYPES.has(rawType) ? rawType : 'broken';
+	const status = params.get('status');
+	const statusValue = status == null ? undefined : Number(status);
+	const filter = {
+		urlPattern: params.get('urlPattern') ?? undefined,
+		status: Number.isFinite(statusValue) ? statusValue : undefined,
+		sortBy: params.get('sortBy') ?? undefined,
+		sortOrder: params.get('sortOrder') ?? undefined,
+	};
 
 	// If the URL was visited with a now-removed `type` (e.g. a bookmarked
 	// `?type=orphaned` from before the retirement of that filter), surface
@@ -67,16 +76,14 @@ export function LinksView() {
 		'/api/links',
 		{
 			type,
-			urlPattern: params.get('urlPattern') ?? undefined,
-			sortBy: params.get('sortBy') ?? undefined,
-			sortOrder: params.get('sortOrder') ?? undefined,
+			...filter,
 			limit: pageSize,
 			offset,
 		},
 		['links-paged', type, params.toString(), pageSize, currentPage],
 		{ enabled: mode === 'mpa' },
 	);
-	const infinite = useLinksInfinite(type, { enabled: mode === 'virtual' });
+	const infinite = useLinksInfinite(type, filter, { enabled: mode === 'virtual' });
 	const infiniteRows = useMemo(
 		() => infinite.data?.pages.flatMap((page) => page.items) ?? [],
 		[infinite.data],
@@ -137,6 +144,19 @@ export function LinksView() {
 			'urlPattern',
 			t('views.pages.filterUrlPattern'),
 		);
+		addRadioFilter(
+			controls,
+			context,
+			'status',
+			'status',
+			t('views.links.colStatus'),
+			buildStatusFilterOptions(
+				paged.data?.items,
+				(item) => item.status,
+				status,
+				t('common.all'),
+			),
+		);
 		addTextFilter(
 			controls,
 			context,
@@ -145,7 +165,7 @@ export function LinksView() {
 			t('views.pages.filterUrlPattern'),
 		);
 		return controls;
-	}, [params, t, updateMany]);
+	}, [paged.data?.items, params, status, t, updateMany]);
 
 	return (
 		<div className="view">

--- a/packages/@nitpicker/viewer/web/routes/page-links-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/page-links-view.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router';
 
 import { usePageLinksInfinite } from '../api/use-page-links-infinite.js';
 import { usePagedQuery } from '../api/use-paged-query.js';
+import { buildStatusFilterOptions } from '../components/build-status-filter-options.js';
 import {
 	addRadioFilter,
 	addSort,
@@ -30,9 +31,12 @@ export function PageLinksView() {
 	const { t } = useI18n();
 	const { mode, pageSize, currentPage, setPage, setPageSize } = useListPagination();
 	const scope = params.get('isExternal') ?? 'false';
+	const status = params.get('status');
+	const statusValue = status == null ? undefined : Number(status);
 	const filter = {
 		isExternal: scope === 'all' ? undefined : scope === 'true',
 		urlPattern: params.get('urlPattern') ?? undefined,
+		status: Number.isFinite(statusValue) ? statusValue : undefined,
 		contentType: params.get('contentType') ?? undefined,
 		hasResponseHeaders:
 			params.get('hasResponseHeaders') == null
@@ -157,6 +161,19 @@ export function PageLinksView() {
 			'urlPattern',
 			t('views.pageLinks.filterUrlPattern'),
 		);
+		addRadioFilter(
+			controls,
+			context,
+			'status',
+			'status',
+			t('views.pageLinks.colStatus'),
+			buildStatusFilterOptions(
+				paged.data?.items,
+				(item) => item.status,
+				status,
+				t('common.all'),
+			),
+		);
 		addTextFilter(
 			controls,
 			context,
@@ -190,7 +207,7 @@ export function PageLinksView() {
 			],
 		);
 		return controls;
-	}, [params, t, updateMany]);
+	}, [paged.data?.items, params, status, t, updateMany]);
 
 	return (
 		<div className="view">

--- a/packages/@nitpicker/viewer/web/routes/resources-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/resources-view.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 
 import { usePagedQuery } from '../api/use-paged-query.js';
 import { useResourcesInfinite } from '../api/use-resources-infinite.js';
+import { buildStatusFilterOptions } from '../components/build-status-filter-options.js';
 import {
 	addRadioFilter,
 	addSort,
@@ -28,7 +29,11 @@ export function ResourcesView() {
 	const { t } = useI18n();
 	const { mode, pageSize, currentPage, setPage, setPageSize } = useListPagination();
 	const scope = params.get('isExternal') ?? 'false';
+	const status = params.get('status');
+	const statusValue = status == null ? undefined : Number(status);
 	const filter = {
+		urlPattern: params.get('urlPattern') ?? undefined,
+		status: Number.isFinite(statusValue) ? statusValue : undefined,
 		contentType: params.get('contentType') ?? undefined,
 		isExternal: scope === 'all' ? undefined : scope === 'true',
 		sortBy: params.get('sortBy') ?? undefined,
@@ -101,7 +106,6 @@ export function ResourcesView() {
 		const context = { params, updateMany };
 		const controls = createTableControls(context);
 		for (const key of [
-			'url',
 			'status',
 			'statusText',
 			'contentType',
@@ -111,12 +115,26 @@ export function ResourcesView() {
 		]) {
 			addSort(controls, context, key, key);
 		}
+		addSort(controls, context, 'url', 'url', 'asc');
 		addTextFilter(
 			controls,
 			context,
 			'url',
 			'urlPattern',
 			t('views.pages.filterUrlPattern'),
+		);
+		addRadioFilter(
+			controls,
+			context,
+			'status',
+			'status',
+			t('views.resources.colStatus'),
+			buildStatusFilterOptions(
+				paged.data?.items,
+				(item) => item.status,
+				status,
+				t('common.all'),
+			),
 		);
 		addTextFilter(
 			controls,
@@ -126,12 +144,12 @@ export function ResourcesView() {
 			t('views.resources.filterContentType'),
 		);
 		addRadioFilter(controls, context, 'isExternal', 'isExternal', t('common.type'), [
-			{ value: 'all', label: t('common.all'), checked: false },
-			{ value: 'false', label: t('common.internal'), checked: false },
-			{ value: 'true', label: t('common.external'), checked: false },
+			{ value: 'all', label: t('common.all'), checked: scope === 'all' },
+			{ value: 'false', label: t('common.internal'), checked: scope === 'false' },
+			{ value: 'true', label: t('common.external'), checked: scope === 'true' },
 		]);
 		return controls;
-	}, [params, t, updateMany]);
+	}, [paged.data?.items, params, scope, status, t, updateMany]);
 
 	return (
 		<div className="view">

--- a/packages/@nitpicker/viewer/web/routes/unused-resources-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/unused-resources-view.tsx
@@ -4,6 +4,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { useMemo } from 'react';
 
 import { usePagedQuery } from '../api/use-paged-query.js';
+import { buildStatusFilterOptions } from '../components/build-status-filter-options.js';
 import {
 	addRadioFilter,
 	addSort,
@@ -29,8 +30,11 @@ export function UnusedResourcesView() {
 	const { t } = useI18n();
 	const { params, updateMany } = useUrlFilter();
 	const { pageSize, currentPage, setPage, setPageSize } = useListPagination();
+	const status = params.get('status');
+	const statusValue = status == null ? undefined : Number(status);
 	const filter = {
 		urlPattern: params.get('urlPattern') ?? undefined,
+		status: Number.isFinite(statusValue) ? statusValue : undefined,
 		contentType: params.get('contentType') ?? undefined,
 		source: params.get('source') ?? undefined,
 		sortBy: params.get('sortBy') ?? undefined,
@@ -90,6 +94,19 @@ export function UnusedResourcesView() {
 			'urlPattern',
 			t('views.pages.filterUrlPattern'),
 		);
+		addRadioFilter(
+			controls,
+			context,
+			'status',
+			'status',
+			t('views.unusedResources.status'),
+			buildStatusFilterOptions(
+				paged.data?.items,
+				(item) => item.status,
+				status,
+				t('common.all'),
+			),
+		);
 		addTextFilter(
 			controls,
 			context,
@@ -103,7 +120,7 @@ export function UnusedResourcesView() {
 			{ value: 'inventory-seed', label: 'inventory-seed', checked: false },
 		]);
 		return controls;
-	}, [params, t, updateMany]);
+	}, [paged.data?.items, params, status, t, updateMany]);
 
 	return (
 		<div className="view">


### PR DESCRIPTION
## Summary

- unify table filter and sort behavior across viewer tables outside `pages`
- add shared `status` filter support in the query and viewer layers
- fix default radio selection and default URL sort behavior in `resources`
- sync the already-merged viewer table-control work from `main` into `dev`

## Why

viewer の一覧ごとに filter / sort の挙動が揃っていませんでした。

例:
- `pages` には status の radio filter があるのに、他の一覧では揃っていない
- `resources` の URL sort の既定値が `pages` と一致していない
- URL に query param がないとき、radio filter の初期選択が view の意図どおりにならない

## Root Cause

- query layer で、関連する一覧 endpoint に共通の `status` filter 契約が揃っていなかった
- viewer 側でも route / hook / table control ごとに status filter の扱いがばらついていた
- `addRadioFilter` が pre-checked な option を既定値として尊重していなかった

## Changes

- `@nitpicker/query` の関連一覧 API に `status` filter を追加
- viewer route と infinite query hook に `status` parameter を通した
- 共通の status filter option builder を追加
- `resources` の URL sort 既定値を昇順に統一
- `addRadioFilter` が pre-checked option を尊重するよう修正
- 既定 radio state の spec を追加

## Validation

- `yarn lint`
- `yarn build`
- `yarn test`
