### PR TITLE
feat(viewer): link Connection Failures sample URLs to Page Detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ npx @nitpicker/cli viewer <file-or-stub-dir> [--port 9000] [--no-open]
 
 ### Connection Failures ビュー
 
-`query error-kinds` と同じ集計をブラウザで表示する。他の一覧ビュー（Pages / Resources / Isolated Clusters 等）と同じ DataTable 一覧＋詳細ページの構成で、host×kind（1 host × 1 kind = 1 行）の一覧をソート・kind 列フィルタでき、行を選ぶとその host×kind のサンプル URL 詳細にドリルダウンする。「違反」「重複」「不一致」（いずれもクロールに成功したページの中身・メタデータの問題）とは異なり、このビューは HTTP レスポンス自体が得られなかった失敗（DNS 未解決・TLS 失敗・接続拒否・タイムアウト）だけを扱う。サンプル URL は（解決失敗・接続拒否など本来開けない URL なので）リンクではなく診断用のテキストとして表示する。ルーティング（`/errors`）と API（`/api/error-kinds`）は互換性のため変更していない。
+`query error-kinds` と同じ集計をブラウザで表示する。他の一覧ビュー（Pages / Resources / Isolated Clusters 等）と同じ DataTable 一覧＋詳細ページの構成で、host×kind（1 host × 1 kind = 1 行）の一覧をソート・kind 列フィルタでき、行を選ぶとその host×kind のサンプル URL 詳細にドリルダウンする。「違反」「重複」「不一致」（いずれもクロールに成功したページの中身・メタデータの問題）とは異なり、このビューは HTTP レスポンス自体が得られなかった失敗（DNS 未解決・TLS 失敗・接続拒否・タイムアウト）だけを扱う。サンプル URL 自体は（解決失敗・接続拒否など本来開けない URL なので）直接開けないが、Page Detail 画面（`/pages/detail?url=`）へのリンクになっており、そのURLへの被リンク元（inbound links）を確認できる。ルーティング（`/errors`）と API（`/api/error-kinds`）は互換性のため変更していない。
 
 ### HTML スナップショットプレビュー
 

--- a/packages/@nitpicker/viewer/web/routes/errors-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/errors-view.tsx
@@ -2,6 +2,7 @@ import type { ErrorKind, ErrorKindEntry } from '@nitpicker/query';
 import type { ColumnDef } from '@tanstack/react-table';
 
 import { useMemo } from 'react';
+import { Link } from 'react-router';
 
 import { useErrorKinds } from '../api/use-error-kinds.js';
 import {
@@ -243,13 +244,22 @@ function ErrorDetailPane({
 				<p className="state">{t('views.errors.notFound')}</p>
 			)}
 			{!isLoading && !isError && entry != null && (
-				// Plain, selectable text rather than links: these URLs failed to
-				// crawl (DNS failure, refused, cert error, …), so a link would just
-				// open a dead tab. They exist to be read and copied for diagnosis.
+				// The failing URL itself can't be opened (that's the whole point of
+				// this view), but a `<Link>` — a real `<a>` element, unlike a
+				// `<button>` — still lets the URL text be selected/copied for manual
+				// diagnosis (curl, dig, …) while also navigating to Page Detail on
+				// click. Most of these URLs have a `pages` row (anchor discovery
+				// pre-inserts a stub before the anchor row is written), so this
+				// usually surfaces who links to the failing URL; a URL with no
+				// matching row (e.g. one carrying a hash fragment or userinfo, which
+				// isn't preserved in `pages.url`) falls through to Page Detail's
+				// "Page not found" state instead of failing silently.
 				<ul className="url-list">
 					{entry.sampleUrls.map((url, index) => (
 						<li key={`${url}-${index}`}>
-							<code>{url}</code>
+							<Link to={`/pages/detail?url=${encodeURIComponent(url)}`}>
+								<code>{url}</code>
+							</Link>
 						</li>
 					))}
 				</ul>


### PR DESCRIPTION
## Summary

- Connection Failures 詳細ペインのサンプルURLを Page Detail 画面（`/pages/detail?url=...`）へのリンクにし、そのURLへの被リンク元（inbound links）を確認できるようにした。`<button>+navigate` ではなく `<Link>`（実体は `<a>` 要素）を使い、`page-detail-view.tsx` の inbound/outbound リンク一覧と同じパターンに揃えている。これにより URL テキストの選択・コピー（curl/dig 等での手動診断用）も維持される。
- ほとんどのサンプルURLは対応する `pages` 行を持つ（アンカー発見時に先行してstub行が作られる設計のため）が、ハッシュフラグメントや認証情報を含むURLなど稀に一致しない場合は Page Detail 側の既存の "Page not found" 表示にグレースフルに落ちる。
- README.md の「サンプル URL はリンクではなくテキストとして表示する」という、今回の変更と矛盾する記述を更新した。

## Test plan

- [x] `yarn build` — 全14パッケージがビルドできる
- [x] `yarn lint` — ESLint / Stylelint / Markuplint / Prettier / textlint / cspell すべて通過
- [x] `yarn test` — 2160件パス（5件は既存のskip）
- [x] xhigh code-review / qa-engineer / product-manager / doc レビューを実施し、指摘（診断用テキスト選択機能の維持、404グレースフルデグレードの前提の正確性、READMEの矛盾）を反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)
