### PR TITLE
fix(query,viewer): sort viewer URLs with an external merge sort to fix startup OOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,10 @@ packages/
 >
 > **scope-out**: `/api/links?type=broken` 20s / `/api/duplicates` 12s / `/api/images` 14s は本 PR で改善せず accept、denorm 列 (`canonicalId` / pre-aggregate) 無しでは詰まらない別 issue 候補。`/api/summary` cold 26s も I/O bound (10GB DB に対して 64MB cache)、index でこれ以上は詰まらない。
 
+> **Note (viewer 起動時 URL ソートの外部マージソート化)**: 11 GB / 約 157 万 URL 規模のアーカイブで viewer 起動時に JS ヒープ不足クラッシュ（起動時ソートが全 URL を `ExURL` としてメモリ展開していたことが原因）。`packages/@nitpicker/query/src/external-url-sort.ts` の外部マージソート（`pages`/`resources` を id キーセットページネーションでチャンク読み込み → チャンクごとに軽量な `UrlSortKey` へパース・ソートし一時ファイルへ spill → K-way マージで統合）に置き換え、ピークメモリをチャンクサイズに抑える（処理時間は伸びるがメモリを優先）。K-way マージの重複排除が `original` 文字列の完全一致を使う理由（`compareUrlSortKeys(...) === 0` ではない — 別 URL でも 0 を返しうる natural-sort comparator の特性で誤って握り潰すため）と、`viewer_url_sort_keys` への INSERT が `onConflict('url').ignore()` を使う理由（同 comparator が推移律を保証しないことへの fail-safe）は `merge-sorted-url-chunks.ts` / `url-sort-temp-table.ts` の JSDoc を正とする。
+>
+> ソート結果は archive の tar-cache ディレクトリ配下 `precomputed/url-sort-ranks.jsonl` に JSON Lines でストリーミング永続化し、Ctrl-C / viewer 再起動後の再ソートを避ける（`packages/@nitpicker/viewer/src/url-sort-cache.ts`）。既存の `getOrComputeOnDisk`（一括 JSON 化、summary / isolated-clusters cache が使用）を流用しない理由（157 万件規模では読み書き時に再度全展開しメモリ効率化の意味が薄れるため専用にストリーミング実装）、stub mode での bypass 方針は同ファイルの JSDoc を正とする。起動時進捗は `@d-zero/dealer` の `Lanes` で表示し、`pages`+`resources` の総行数を事前 `COUNT(*)` して読み込み・マージ両フェーズで % 表示する。
+
 > **Note (ページネーションモード)**: リスト系ビューは MPA ページネーション（`PagedTable` + `?page=` + `?pageSize=`、デフォルト）と仮想スクロール（`VirtualTable` + `useInfiniteQuery`、opt-in）の 2 モードを TopBar のトグルで切替えられる。`DataTable` がモードに応じて dispatch し、`usePagedQuery` / `use-*-infinite` を `enabled` フラグで切替えるため backend は無改修。**page と pageSize は URL クエリが正**（deep-link / 共有が成立するため両方が URL に乗らないと意味がない、`?pageSize=` 無しで `?page=5` を共有しても受け手の窓サイズが違うと別の行が見える）。デフォルト値（page=1, pageSize=100）は URL から省略してクリーンに保つ。localStorage は `nitpicker-pagination-mode`（モード本体）と `nitpicker-page-size`（**新規タブ初回の hint**）のみ。MPA がデフォルトな理由は deep-link / URL 共有 / 戻る進むが効くため。仮想スクロールは 10 万行規模の探索性が要るとき opt-in。詳細は ARCHITECTURE.md の `@nitpicker/viewer` 節「設計注意（ページネーション...）」を正とする。
 
 ## CLI コマンド

--- a/packages/@nitpicker/query/src/compare-url-sort-keys.spec.ts
+++ b/packages/@nitpicker/query/src/compare-url-sort-keys.spec.ts
@@ -1,0 +1,62 @@
+import { pathComparator } from '@d-zero/shared/sort/path';
+import { describe, expect, it } from 'vitest';
+
+import { compareUrlSortKeys } from './compare-url-sort-keys.js';
+import { toUrlSortKey } from './to-url-sort-key.js';
+
+/**
+ * URL fixtures chosen to exercise every branch of `pathComparator`: numeric
+ * basenames (natural sort), `index` special-casing, differing extensions,
+ * differing query/hash, differing hosts, differing protocols, and duplicate
+ * hrefs that only differ in original casing/encoding.
+ */
+const URLS = [
+	'https://example.com/image-10.jpg',
+	'https://example.com/image-2.jpg',
+	'https://example.com/image-1.jpg',
+	'https://example.com/',
+	'https://example.com/index.html',
+	'https://example.com/about/',
+	'https://example.com/about/index.html',
+	'https://example.com/about/team.html',
+	'https://example.com/file.jpg',
+	'https://example.com/file.png',
+	'https://example.com/page?query=1',
+	'https://example.com/page?query=2',
+	'https://example.com/page#section-1',
+	'https://example.com/page#section-2',
+	'https://a.example.com/',
+	'https://b.example.com/',
+	'http://example.com/insecure',
+	'https://example.com/insecure',
+	'https://example.com/dir-10/file.html',
+	'https://example.com/dir-2/file.html',
+	'https://example.com/nested/dir-10/page-3.html',
+	'https://example.com/nested/dir-2/page-30.html',
+];
+
+describe('compareUrlSortKeys', () => {
+	it('sorts UrlSortKeys in the same order pathComparator sorts the equivalent URLs', () => {
+		const expected = [...URLS].toSorted(pathComparator);
+
+		const keys = URLS.map((url) => toUrlSortKey(url));
+		const actual = keys.toSorted(compareUrlSortKeys).map((key) => key.original);
+
+		expect(actual).toEqual(expected);
+	});
+
+	it('treats two distinct href-equal inputs via the original-string tiebreak, same as pathComparator', () => {
+		const inputs = ['https://example.com/Page', 'https://example.com/page'];
+		const expected = [...inputs].toSorted(pathComparator);
+
+		const keys = inputs.map((url) => toUrlSortKey(url));
+		const actual = keys.toSorted(compareUrlSortKeys).map((key) => key.original);
+
+		expect(actual).toEqual(expected);
+	});
+
+	it('returns 0 for identical keys', () => {
+		const key = toUrlSortKey('https://example.com/same');
+		expect(compareUrlSortKeys(key, { ...key })).toBe(0);
+	});
+});

--- a/packages/@nitpicker/query/src/compare-url-sort-keys.ts
+++ b/packages/@nitpicker/query/src/compare-url-sort-keys.ts
@@ -1,0 +1,62 @@
+import type { UrlSortKey } from './types.js';
+
+import { alphabeticalComparator } from '@d-zero/shared/sort/alphabetical';
+import { dirComparator } from '@d-zero/shared/sort/dir';
+import { numericalComparator } from '@d-zero/shared/sort/numerical';
+
+/**
+ * Compares two {@link UrlSortKey} values in the same order as
+ * `@d-zero/shared/sort/path`'s `pathComparator`.
+ *
+ * The branch structure mirrors `pathComparator` exactly (host → path
+ * hierarchy → basename, with `index` sorted first → extension → query →
+ * hash → protocol → href) so that sorting `UrlSortKey`s never disagrees with
+ * sorting the `ExURL`s they were extracted from. Only the comparison
+ * primitives (`alphabeticalComparator` / `dirComparator` /
+ * `numericalComparator`) are reused directly from `@d-zero/shared` — nothing
+ * about how URLs compare is reimplemented here, only the field lookups
+ * change from `ExURL` properties to `UrlSortKey` properties.
+ * @param a - The first key to compare.
+ * @param b - The second key to compare.
+ * @returns A negative number if `a` sorts before `b`, positive if after, `0` if equal.
+ * @example
+ * const sorted = keys.toSorted(compareUrlSortKeys);
+ */
+export function compareUrlSortKeys(a: UrlSortKey, b: UrlSortKey): number {
+	if (a.href === b.href) {
+		return alphabeticalComparator(a.original, b.original);
+	}
+	const rHost = alphabeticalComparator(a.hostname, b.hostname);
+	if (rHost) {
+		return rHost;
+	}
+	const rPaths = dirComparator(a.paths, b.paths);
+	if (rPaths) {
+		return rPaths;
+	}
+	if (a.basename !== b.basename) {
+		if (a.isIndex) return -1;
+		if (b.isIndex) return 1;
+		const rBasename = numericalComparator(a.basename, b.basename);
+		if (rBasename) {
+			return rBasename;
+		}
+	}
+	const rExt = numericalComparator(a.extname, b.extname);
+	if (rExt) {
+		return rExt;
+	}
+	const rSearch = numericalComparator(a.search, b.search);
+	if (rSearch) {
+		return rSearch;
+	}
+	const rHash = numericalComparator(a.hash, b.hash);
+	if (rHash) {
+		return rHash;
+	}
+	const rProtocol = alphabeticalComparator(a.protocol, b.protocol);
+	if (rProtocol) {
+		return rProtocol;
+	}
+	return numericalComparator(a.href, b.href);
+}

--- a/packages/@nitpicker/query/src/external-url-sort.spec.ts
+++ b/packages/@nitpicker/query/src/external-url-sort.spec.ts
@@ -1,0 +1,234 @@
+/* eslint-disable @typescript-eslint/require-await -- onRow callbacks are async to match externalSortUrls' signature but only push into a synchronous results array. */
+import path from 'node:path';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { pathComparator } from '@d-zero/shared/sort/path';
+import { Archive } from '@nitpicker/crawler';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { externalSortUrls } from './external-url-sort.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_external_url_sort__');
+
+const META = {
+	lang: null,
+	title: null,
+	description: null,
+	keywords: null,
+	noindex: false,
+	nofollow: false,
+	noarchive: false,
+	canonical: null,
+	alternate: null,
+	'og:type': null,
+	'og:title': null,
+	'og:site_name': null,
+	'og:description': null,
+	'og:url': null,
+	'og:image': null,
+	'twitter:card': null,
+};
+
+/**
+ * Minimal config so {@link Archive.create} has a valid `info` row.
+ * @returns A config object accepted by `Archive.setConfig`.
+ */
+function baseConfig() {
+	return {
+		baseUrl: 'https://example.com',
+		name: 'test',
+		version: '0.10.0',
+		recursive: true,
+		interval: 0,
+		image: false,
+		fetchExternal: true,
+		parallels: 1,
+		roots: ['https://example.com'],
+		excludes: [],
+		excludeKeywords: [],
+		excludeUrls: [],
+		maxExcludedDepth: 0,
+		retry: 3,
+		fromList: false,
+		disableQueries: false,
+		userAgent: 'test',
+		ignoreRobots: false,
+	};
+}
+
+/**
+ * Adds a minimal internal HTML page to the archive.
+ * @param archive - The archive to write to.
+ * @param url - The page URL.
+ */
+async function addPage(archive: InstanceType<typeof Archive>, url: string) {
+	await archive.setPage({
+		url: parseUrl(url)!,
+		redirectPaths: [],
+		isExternal: false,
+		isTarget: true,
+		status: 200,
+		statusText: 'OK',
+		contentType: 'text/html',
+		contentLength: 100,
+		responseHeaders: {},
+		html: '',
+		meta: META,
+		anchorList: [],
+		imageList: [],
+		isSkipped: false,
+	});
+}
+
+describe('externalSortUrls', () => {
+	let archive: InstanceType<typeof Archive> | undefined;
+
+	afterEach(async () => {
+		if (archive) {
+			await archive.close();
+			archive = undefined;
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('ranks pages+resources URLs in natural order even when forced across many small chunks', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'sort.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		const pageUrls = [
+			'https://example.com/image-10.jpg',
+			'https://example.com/image-2.jpg',
+			'https://example.com/about/',
+		];
+		for (const url of pageUrls) {
+			await addPage(archive, url);
+		}
+		await archive.setResources({
+			url: parseUrl('https://example.com/style.css')!,
+			isExternal: false,
+			isError: false,
+			status: 200,
+			statusText: 'OK',
+			contentType: 'text/css',
+			contentLength: 100,
+			compress: false,
+			cdn: false,
+			headers: null,
+		});
+
+		const results: { url: string; rank: number }[] = [];
+		// chunkSize=1 forces every single row into its own chunk file,
+		// exercising the split + K-way merge path with 4 chunk files.
+		await externalSortUrls(
+			archive,
+			async (url, rank) => {
+				results.push({ url, rank });
+			},
+			{ readChunkSize: 1 },
+		);
+
+		const expectedOrder = [...pageUrls, 'https://example.com/style.css'].toSorted(
+			pathComparator,
+		);
+		expect(results.map((r) => r.url)).toEqual(expectedOrder);
+		// Ranks are 0-based and strictly increasing.
+		expect(results.map((r) => r.rank)).toEqual(expectedOrder.map((_, index) => index));
+	});
+
+	it('emits each distinct URL exactly once when the same URL exists in both pages and resources', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'dedup.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		// pages.url and resources.url both have a UNIQUE constraint per table,
+		// but the same literal URL can appear in both tables (e.g. a page that
+		// is also linked as a sub-resource target elsewhere).
+		await addPage(archive, 'https://example.com/shared');
+		await archive.setResources({
+			url: parseUrl('https://example.com/shared')!,
+			isExternal: false,
+			isError: false,
+			status: 200,
+			statusText: 'OK',
+			contentType: 'text/html',
+			contentLength: 100,
+			compress: false,
+			cdn: false,
+			headers: null,
+		});
+
+		const results: { url: string; rank: number }[] = [];
+		await externalSortUrls(
+			archive,
+			async (url, rank) => {
+				results.push({ url, rank });
+			},
+			{ readChunkSize: 1 },
+		);
+
+		expect(results).toEqual([{ url: 'https://example.com/shared', rank: 0 }]);
+	});
+
+	it('produces no output and leaves no temp directory for an archive with no pages or resources', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'empty.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		const results: { url: string; rank: number }[] = [];
+		await externalSortUrls(archive, async (url, rank) => {
+			results.push({ url, rank });
+		});
+
+		expect(results).toEqual([]);
+		// The scratch dir is `mkdtemp`'d (a random `url-sort-tmp-XXXXXX`
+		// suffix, not a fixed name) so concurrent callers on the same
+		// accessor never collide — assert no such directory survives instead
+		// of checking one exact name.
+		const { readdirSync } = await import('node:fs');
+		expect(
+			readdirSync(archive.tmpDir).some((name) => name.startsWith('url-sort-tmp-')),
+		).toBe(false);
+	});
+
+	it('cleans up the temp directory even when onRow throws', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'cleanup-on-error.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/');
+
+		await expect(
+			externalSortUrls(archive, () => {
+				throw new Error('boom');
+			}),
+		).rejects.toThrow('boom');
+
+		// The scratch dir is `mkdtemp`'d (a random `url-sort-tmp-XXXXXX`
+		// suffix, not a fixed name) so concurrent callers on the same
+		// accessor never collide — assert no such directory survives instead
+		// of checking one exact name.
+		const { readdirSync } = await import('node:fs');
+		expect(
+			readdirSync(archive.tmpDir).some((name) => name.startsWith('url-sort-tmp-')),
+		).toBe(false);
+	});
+});

--- a/packages/@nitpicker/query/src/external-url-sort.ts
+++ b/packages/@nitpicker/query/src/external-url-sort.ts
@@ -1,0 +1,129 @@
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { mergeSortedUrlChunks } from './merge-sorted-url-chunks.js';
+import { readUrlChunks } from './read-url-chunks.js';
+import { writeSortedUrlChunk } from './write-sorted-url-chunk.js';
+
+/** Rows read from `pages`/`resources` per chunk during the split phase. */
+const READ_CHUNK_SIZE = 50_000;
+
+/** How often (in merged rows) to report merge-phase progress. */
+const MERGE_PROGRESS_INTERVAL = 100_000;
+
+/**
+ * Options for {@link externalSortUrls}.
+ */
+export interface ExternalSortUrlsOptions {
+	/**
+	 * Rows read per `pages`/`resources` chunk. Exposed for tests that need to
+	 * force multiple chunks (and therefore exercise the K-way merge) without
+	 * needing archive-scale fixtures; production callers should omit it and
+	 * use the default.
+	 */
+	readChunkSize?: number;
+	/**
+	 * Called with a human-readable status line as the sort progresses. On a
+	 * million-plus-URL archive the split + merge phases can each take
+	 * multiple minutes with no other observable output, so callers running
+	 * this from a CLI/viewer startup path should wire this to `console.log`
+	 * — otherwise the process looks hung.
+	 */
+	onProgress?: (message: string) => void;
+}
+
+/**
+ * Sorts every distinct URL across `pages` and `resources` into natural URL
+ * order using an external merge sort, without holding more than one
+ * read-chunk's worth of parsed URLs in memory at a time.
+ *
+ * Archives with a million-plus URLs make an in-memory "parse everything,
+ * then sort" pass expensive enough to exhaust the default V8 heap (observed
+ * on an 11 GB / ~1.5M URL archive — the whole-archive version this replaced
+ * OOM'd at startup). Splitting the read into `id`-keyset chunks, sorting and
+ * spilling each chunk to a temp file, then K-way merging the sorted files
+ * keeps peak memory bounded by chunk size instead of archive size, at the
+ * cost of extra disk I/O and wall-clock time.
+ * @param accessor - The opened archive accessor.
+ * @param onRow - Called once per distinct URL, in ascending natural-sort
+ *   order, with its 0-based rank. The caller is expected to batch these into
+ *   the destination (e.g. grouped `INSERT`s) rather than collecting them all
+ *   first — that would defeat the point of the external sort.
+ * @param options - See {@link ExternalSortUrlsOptions}.
+ * @example
+ * let rank = 0;
+ * await externalSortUrls(
+ *   accessor,
+ *   async (url) => { await insertRankedRow(url, rank++); },
+ *   { onProgress: (message) => console.log(message) },
+ * );
+ */
+export async function externalSortUrls(
+	accessor: ArchiveAccessor,
+	onRow: (url: string, rank: number) => Promise<void>,
+	options: ExternalSortUrlsOptions = {},
+): Promise<void> {
+	const { readChunkSize = READ_CHUNK_SIZE, onProgress } = options;
+	// `mkdtemp` (not a fixed `<tmpDir>/url-sort-tmp` path) so two concurrent
+	// callers on the same non-read-only accessor — e.g. `listPages` and
+	// `listExternalLinks` both default to `sortBy: 'url'` and can race before
+	// `ensureUrlSortTempTable`'s `preparedConnections` guard has been
+	// populated — get distinct scratch directories instead of interleaving
+	// writes into (and one prematurely `rm -rf`-ing) the other's chunk files.
+	const tmpDir = accessor.readOnly
+		? await fs.mkdtemp(path.join(os.tmpdir(), 'nitpicker-url-sort-'))
+		: await fs.mkdtemp(path.join(accessor.tmpDir, 'url-sort-tmp-'));
+
+	try {
+		// A row-count estimate up front — cheap even on a multi-GB archive,
+		// since `COUNT(*)` on SQLite is a single index-only scan — is what
+		// turns the progress lines below into an actual percentage instead of
+		// a raw counter with no sense of how much work remains.
+		const knex = accessor.getKnex();
+		const [pagesCount, resourcesCount] = await Promise.all([
+			knex('pages').count<{ count: number }[]>({ count: '*' }),
+			knex('resources').count<{ count: number }[]>({ count: '*' }),
+		]);
+		const totalRows =
+			Number(pagesCount[0]?.count ?? 0) + Number(resourcesCount[0]?.count ?? 0);
+		const percentOf = (done: number): number =>
+			totalRows > 0 ? Math.min(100, Math.floor((done / totalRows) * 100)) : 100;
+
+		const chunkFiles: string[] = [];
+		let rowsReadSoFar = 0;
+		for (const table of ['pages', 'resources'] as const) {
+			let tableRows = 0;
+			for await (const urls of readUrlChunks(accessor, table, readChunkSize)) {
+				chunkFiles.push(await writeSortedUrlChunk(urls, tmpDir, chunkFiles.length));
+				tableRows += urls.length;
+				rowsReadSoFar += urls.length;
+				onProgress?.(
+					`Sorting URLs: reading ${table} — ${tableRows.toLocaleString()} rows ` +
+						`(${percentOf(rowsReadSoFar)}% overall, ${chunkFiles.length} chunk file(s) so far)`,
+				);
+			}
+		}
+		onProgress?.(`Sorting URLs: merging ${chunkFiles.length} chunk file(s)…`);
+
+		let rank = 0;
+		let rowsMergedSoFar = 0;
+		for await (const key of mergeSortedUrlChunks(chunkFiles, () => {
+			rowsMergedSoFar++;
+		})) {
+			await onRow(key.original, rank);
+			rank++;
+			if (rank % MERGE_PROGRESS_INTERVAL === 0) {
+				onProgress?.(
+					`Sorting URLs: merging — ${rank.toLocaleString()} distinct URLs so far ` +
+						`(${percentOf(rowsMergedSoFar)}%)`,
+				);
+			}
+		}
+		onProgress?.(`Sorting URLs: done — ${rank.toLocaleString()} distinct URLs ranked`);
+	} finally {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	}
+}

--- a/packages/@nitpicker/query/src/merge-sorted-url-chunks.spec.ts
+++ b/packages/@nitpicker/query/src/merge-sorted-url-chunks.spec.ts
@@ -1,0 +1,116 @@
+import path from 'node:path';
+
+import { pathComparator } from '@d-zero/shared/sort/path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { mergeSortedUrlChunks } from './merge-sorted-url-chunks.js';
+import { writeSortedUrlChunk } from './write-sorted-url-chunk.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_merge_sorted_url_chunks__');
+
+describe('mergeSortedUrlChunks', () => {
+	afterEach(async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('merges multiple sorted chunk files into one ascending stream', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+
+		const allUrls = [
+			'https://example.com/image-10.jpg',
+			'https://example.com/image-2.jpg',
+			'https://example.com/image-1.jpg',
+			'https://example.com/about/',
+			'https://b.example.com/',
+		];
+		// Split arbitrarily across three chunk files — the merge must still
+		// produce the same global order as sorting everything at once.
+		const chunkFiles = await Promise.all([
+			writeSortedUrlChunk([allUrls[0]!, allUrls[3]!], workingDir, 0),
+			writeSortedUrlChunk([allUrls[1]!], workingDir, 1),
+			writeSortedUrlChunk([allUrls[2]!, allUrls[4]!], workingDir, 2),
+		]);
+
+		const merged: string[] = [];
+		for await (const key of mergeSortedUrlChunks(chunkFiles)) {
+			merged.push(key.original);
+		}
+
+		expect(merged).toEqual([...allUrls].toSorted(pathComparator));
+	});
+
+	it('collapses a URL present in more than one chunk to a single entry', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+
+		const chunkFiles = await Promise.all([
+			writeSortedUrlChunk(
+				['https://example.com/dup', 'https://example.com/a'],
+				workingDir,
+				0,
+			),
+			writeSortedUrlChunk(
+				['https://example.com/dup', 'https://example.com/b'],
+				workingDir,
+				1,
+			),
+		]);
+
+		const merged: string[] = [];
+		for await (const key of mergeSortedUrlChunks(chunkFiles)) {
+			merged.push(key.original);
+		}
+
+		expect(merged).toEqual([
+			'https://example.com/a',
+			'https://example.com/b',
+			'https://example.com/dup',
+		]);
+	});
+
+	it('keeps two distinct URLs separate even when compareUrlSortKeys treats them as tied', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+
+		// numericalComparator("007", "7") treats both basenames as the numeral
+		// 7, so compareUrlSortKeys(a, b) === 0 for these two distinct URLs. If
+		// dedup were keyed on that comparison result instead of `original`
+		// string equality, one of these two pages would be silently dropped —
+		// see mergeSortedUrlChunks' JSDoc on why dedup uses `original`.
+		const chunkFiles = await Promise.all([
+			writeSortedUrlChunk(['https://example.com/007'], workingDir, 0),
+			writeSortedUrlChunk(['https://example.com/7'], workingDir, 1),
+		]);
+
+		const merged: string[] = [];
+		for await (const key of mergeSortedUrlChunks(chunkFiles)) {
+			merged.push(key.original);
+		}
+
+		expect(merged).toHaveLength(2);
+		expect(merged).toEqual(
+			expect.arrayContaining(['https://example.com/007', 'https://example.com/7']),
+		);
+	});
+
+	it('returns nothing when all chunk files are empty', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+
+		const chunkFiles = await Promise.all([
+			writeSortedUrlChunk([], workingDir, 0),
+			writeSortedUrlChunk([], workingDir, 1),
+		]);
+
+		const merged: string[] = [];
+		for await (const key of mergeSortedUrlChunks(chunkFiles)) {
+			merged.push(key.original);
+		}
+
+		expect(merged).toEqual([]);
+	});
+});

--- a/packages/@nitpicker/query/src/merge-sorted-url-chunks.ts
+++ b/packages/@nitpicker/query/src/merge-sorted-url-chunks.ts
@@ -1,0 +1,117 @@
+import type { UrlSortKey } from './types.js';
+
+import { createReadStream } from 'node:fs';
+import readline from 'node:readline';
+
+import { compareUrlSortKeys } from './compare-url-sort-keys.js';
+
+/**
+ * A chunk file's read position — the next unread line's parsed key, or
+ * `null` once the file is exhausted.
+ */
+interface ChunkCursor {
+	/** The chunk file's line iterator. */
+	lines: AsyncIterator<string>;
+	/** The next unread key, or `null` when the file has no more lines. */
+	next: UrlSortKey | null;
+}
+
+/**
+ * Advances one cursor to its next line.
+ * @param cursor - The cursor to advance.
+ */
+async function advance(cursor: ChunkCursor): Promise<void> {
+	const { value, done } = await cursor.lines.next();
+	cursor.next = done ? null : (JSON.parse(value) as UrlSortKey);
+}
+
+/**
+ * K-way merges the sorted chunk files produced by
+ * {@link import('./write-sorted-url-chunk.js').writeSortedUrlChunk} into a
+ * single ascending stream, without loading more than one line per chunk into
+ * memory at a time.
+ *
+ * Duplicate `original` URL strings (the same URL present in both `pages` and
+ * `resources`) are collapsed to one entry — mirroring the `Set`-based dedup
+ * the previous whole-archive-in-memory implementation did. Every cursor
+ * whose head has the same `original` string as the round's winner is
+ * drained together, not just the winner's own cursor — the same URL is
+ * often the current head of more than one chunk file at once (e.g. once
+ * from a `pages` chunk, once from a `resources` chunk), and advancing only
+ * one of them would leave the other sitting unconsumed as a false "still
+ * pending" duplicate. Dedup is intentionally keyed on `original` string
+ * equality rather than `compareUrlSortKeys(...) === 0`: the comparator can
+ * legitimately return `0` for two *different* URLs (e.g. basenames `"007"`
+ * and `"7"` both parse to the numeral `7` under `numericalComparator`'s
+ * natural-sort rules), and collapsing those would silently drop a distinct
+ * URL instead of only deduplicating true repeats.
+ *
+ * This is necessary but not sufficient for a hard duplicate-free guarantee:
+ * `compareUrlSortKeys` inherits `@d-zero/shared`'s `numericalComparator`,
+ * a common-prefix-strip natural-sort comparator that is not guaranteed
+ * transitive. A non-transitive comparator can make `Array.prototype.sort`
+ * (used per-chunk in {@link
+ * import('./write-sorted-url-chunk.js').writeSortedUrlChunk}) produce a
+ * chunk file that is not globally consistent with another chunk's ordering,
+ * which on rare, large real-world archives can still surface the same URL
+ * at non-adjacent positions across chunks. That residual risk is the reason
+ * {@link import('./url-sort-temp-table.js').prepareUrlSortTempTable} inserts
+ * with `onConflict('url').ignore()` rather than a plain `insert` — this
+ * function reduces how often a duplicate reaches that fail-safe, it doesn't
+ * replace it.
+ * @param chunkFilePaths - Paths to the sorted chunk files, in any order.
+ * @param onLineConsumed - Called once per raw line read from any chunk file
+ *   (before dedup), so callers can report merge progress as a percentage of
+ *   the total rows written across every chunk — the yielded count alone
+ *   undercounts whenever duplicates are collapsed.
+ * @yields {UrlSortKey} Each distinct URL's sort key, in ascending `compareUrlSortKeys` order.
+ * @example
+ * for await (const key of mergeSortedUrlChunks(chunkFiles)) {
+ *   console.log(key.original);
+ * }
+ */
+export async function* mergeSortedUrlChunks(
+	chunkFilePaths: readonly string[],
+	onLineConsumed?: () => void,
+): AsyncGenerator<UrlSortKey> {
+	const cursors: ChunkCursor[] = chunkFilePaths.map((filePath) => {
+		const lines = readline.createInterface({
+			input: createReadStream(filePath, 'utf8'),
+			crlfDelay: Infinity,
+		});
+		return { lines: lines[Symbol.asyncIterator](), next: null };
+	});
+	const advanceAndReport = async (cursor: ChunkCursor): Promise<void> => {
+		await advance(cursor);
+		if (cursor.next !== null) {
+			onLineConsumed?.();
+		}
+	};
+	await Promise.all(cursors.map((cursor) => advanceAndReport(cursor)));
+
+	for (;;) {
+		let minIndex = -1;
+		for (const [index, cursor] of cursors.entries()) {
+			if (cursor.next === null) {
+				continue;
+			}
+			if (
+				minIndex === -1 ||
+				compareUrlSortKeys(cursor.next, cursors[minIndex]!.next!) < 0
+			) {
+				minIndex = index;
+			}
+		}
+		if (minIndex === -1) {
+			return;
+		}
+
+		const winner = cursors[minIndex]!.next!;
+		for (const cursor of cursors) {
+			if (cursor.next !== null && cursor.next.original === winner.original) {
+				await advanceAndReport(cursor);
+			}
+		}
+		yield winner;
+	}
+}

--- a/packages/@nitpicker/query/src/read-url-chunks.spec.ts
+++ b/packages/@nitpicker/query/src/read-url-chunks.spec.ts
@@ -1,0 +1,131 @@
+import path from 'node:path';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { Archive } from '@nitpicker/crawler';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { readUrlChunks } from './read-url-chunks.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_read_url_chunks__');
+
+const META = {
+	lang: null,
+	title: null,
+	description: null,
+	keywords: null,
+	noindex: false,
+	nofollow: false,
+	noarchive: false,
+	canonical: null,
+	alternate: null,
+	'og:type': null,
+	'og:title': null,
+	'og:site_name': null,
+	'og:description': null,
+	'og:url': null,
+	'og:image': null,
+	'twitter:card': null,
+};
+
+/**
+ * Minimal config so {@link Archive.create} has a valid `info` row.
+ * @returns A config object accepted by `Archive.setConfig`.
+ */
+function baseConfig() {
+	return {
+		baseUrl: 'https://example.com',
+		name: 'test',
+		version: '0.10.0',
+		recursive: true,
+		interval: 0,
+		image: false,
+		fetchExternal: true,
+		parallels: 1,
+		roots: ['https://example.com'],
+		excludes: [],
+		excludeKeywords: [],
+		excludeUrls: [],
+		maxExcludedDepth: 0,
+		retry: 3,
+		fromList: false,
+		disableQueries: false,
+		userAgent: 'test',
+		ignoreRobots: false,
+	};
+}
+
+describe('readUrlChunks', () => {
+	let archive: InstanceType<typeof Archive> | undefined;
+
+	afterEach(async () => {
+		if (archive) {
+			await archive.close();
+			archive = undefined;
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('splits pages into multiple chunks of the requested size, in id order', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'chunks.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		const urls = [
+			'https://example.com/1',
+			'https://example.com/2',
+			'https://example.com/3',
+		];
+		for (const url of urls) {
+			await archive.setPage({
+				url: parseUrl(url)!,
+				redirectPaths: [],
+				isExternal: false,
+				isTarget: true,
+				status: 200,
+				statusText: 'OK',
+				contentType: 'text/html',
+				contentLength: 100,
+				responseHeaders: {},
+				html: '',
+				meta: META,
+				anchorList: [],
+				imageList: [],
+				isSkipped: false,
+			});
+		}
+
+		const chunks: string[][] = [];
+		for await (const chunk of readUrlChunks(archive, 'pages', 2)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toEqual([
+			['https://example.com/1', 'https://example.com/2'],
+			['https://example.com/3'],
+		]);
+	});
+
+	it('returns no chunks for an empty table', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'empty.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		const chunks: string[][] = [];
+		for await (const chunk of readUrlChunks(archive, 'resources', 50)) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks).toEqual([]);
+	});
+});

--- a/packages/@nitpicker/query/src/read-url-chunks.ts
+++ b/packages/@nitpicker/query/src/read-url-chunks.ts
@@ -1,0 +1,40 @@
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+/**
+ * Reads a table's `url` column in fixed-size chunks using `id`-based keyset
+ * pagination (`WHERE id > :last ORDER BY id LIMIT :size`) instead of
+ * `OFFSET`, so each read is a direct index seek rather than an
+ * O(offset) scan.
+ *
+ * Both `pages` and `resources` use `t.increments('id')` as their primary
+ * key, which SQLite implements as a `rowid` alias — a plain integer
+ * comparison, no extra index needed.
+ * @param accessor - The opened archive accessor.
+ * @param table - The table to read URLs from.
+ * @param chunkSize - Maximum rows per chunk.
+ * @yields {string[]} Each chunk's `url` column values, at most `chunkSize` long.
+ * @example
+ * for await (const urls of readUrlChunks(accessor, 'pages', 50_000)) {
+ *   // urls.length <= 50_000
+ * }
+ */
+export async function* readUrlChunks(
+	accessor: ArchiveAccessor,
+	table: 'pages' | 'resources',
+	chunkSize: number,
+): AsyncGenerator<string[]> {
+	const knex = accessor.getKnex();
+	let lastId = 0;
+	for (;;) {
+		const rows = (await knex(table)
+			.select('id', 'url')
+			.where('id', '>', lastId)
+			.orderBy('id', 'asc')
+			.limit(chunkSize)) as { id: number; url: string }[];
+		if (rows.length === 0) {
+			return;
+		}
+		lastId = rows.at(-1)!.id;
+		yield rows.map((row) => row.url);
+	}
+}

--- a/packages/@nitpicker/query/src/to-url-sort-key.spec.ts
+++ b/packages/@nitpicker/query/src/to-url-sort-key.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { toUrlSortKey } from './to-url-sort-key.js';
+
+describe('toUrlSortKey', () => {
+	it('extracts the comparison fields from a parsable URL', () => {
+		const key = toUrlSortKey('https://example.com/about/team.html?query=1#section');
+
+		expect(key).toEqual({
+			original: 'https://example.com/about/team.html?query=1#section',
+			href: 'https://example.com/about/team.html?query=1#section',
+			hostname: 'example.com',
+			paths: ['about', 'team.html'],
+			basename: 'team',
+			isIndex: false,
+			extname: '.html',
+			search: 'query=1',
+			hash: '#section',
+			protocol: 'https:',
+		});
+	});
+
+	it('marks an index page as isIndex', () => {
+		const key = toUrlSortKey('https://example.com/');
+		expect(key.isIndex).toBe(true);
+	});
+
+	it('returns a fallback key instead of null for a URL tryParseUrl cannot parse', () => {
+		const key = toUrlSortKey('not a url');
+
+		// The fallback must never be null: a dropped row here means the
+		// underlying pages/resources row gets no viewer_url_sort_keys entry
+		// at all, and orderByUrlRank's scalar subquery sorts a NULL rank
+		// ahead of every real one — see this function's JSDoc.
+		expect(key).toEqual({
+			original: 'not a url',
+			href: 'not a url',
+			hostname: '',
+			paths: [],
+			basename: '',
+			isIndex: false,
+			extname: '',
+			search: '',
+			hash: '',
+			protocol: '',
+		});
+	});
+
+	it('gives two identical unparsable strings the same fallback href, so they still dedup', () => {
+		const a = toUrlSortKey('not a url');
+		const b = toUrlSortKey('not a url');
+		expect(a.href).toBe(b.href);
+		expect(a.original).toBe(b.original);
+	});
+});

--- a/packages/@nitpicker/query/src/to-url-sort-key.ts
+++ b/packages/@nitpicker/query/src/to-url-sort-key.ts
@@ -1,0 +1,59 @@
+import type { UrlSortKey } from './types.js';
+
+import { tryParseUrl } from '@d-zero/shared/parse-url';
+
+/**
+ * Parses `url` once and extracts only the fields
+ * {@link import('./compare-url-sort-keys.js').compareUrlSortKeys} needs.
+ *
+ * The parsed `ExURL` itself is not returned, so it becomes eligible for
+ * garbage collection as soon as this function returns — the caller only
+ * retains the lightweight {@link UrlSortKey}, which matters when this runs
+ * for every URL in an archive with a million+ rows.
+ *
+ * Always returns a key, even when `url` is not a parsable HTTP URL: the
+ * `pages`/`resources` row that URL came from must still get a
+ * `viewer_url_sort_keys` rank, or `orderByUrlRank`'s scalar subquery finds
+ * no match and SQLite sorts that row's `NULL` rank ahead of every real one,
+ * bunching every unparsable URL at the very top of every URL-sorted view
+ * (the previous whole-archive-in-memory sort avoided this by giving every
+ * raw URL a fallback rank via `rankByUrl.get(url) ?? fallbackRank`). The
+ * fallback key uses `url` itself as `href` so identical unparsable strings
+ * still dedup correctly in {@link
+ * import('./merge-sorted-url-chunks.js').mergeSortedUrlChunks} (which keys
+ * on `original`/`href` equality), and empty `hostname`/`paths` so it sorts
+ * before real hostnames rather than colliding with one.
+ * @param url - The URL string to parse.
+ * @returns The comparison key. Never `null` — see fallback behavior above.
+ * @example
+ * const key = toUrlSortKey('https://example.com/image-2.jpg');
+ */
+export function toUrlSortKey(url: string): UrlSortKey {
+	const parsed = tryParseUrl(url);
+	if (!parsed) {
+		return {
+			original: url,
+			href: url,
+			hostname: '',
+			paths: [],
+			basename: '',
+			isIndex: false,
+			extname: '',
+			search: '',
+			hash: '',
+			protocol: '',
+		};
+	}
+	return {
+		original: url,
+		href: parsed.href,
+		hostname: parsed.hostname,
+		paths: parsed.paths,
+		basename: parsed.basename ?? '',
+		isIndex: parsed.isIndex,
+		extname: parsed.extname ?? '',
+		search: parsed.query ?? '',
+		hash: parsed.hash ?? '',
+		protocol: parsed.protocol,
+	};
+}

--- a/packages/@nitpicker/query/src/types.ts
+++ b/packages/@nitpicker/query/src/types.ts
@@ -1469,3 +1469,34 @@ export interface ErrorKindsResult {
 	/** Archive-wide totals, unaffected by `host`/`kind` filters. */
 	facets: ErrorKindFacets;
 }
+
+/**
+ * The subset of {@link import('@d-zero/shared/parse-url').ExURL} fields that
+ * {@link import('./compare-url-sort-keys.js').compareUrlSortKeys} needs,
+ * extracted immediately after parsing so the full `ExURL` (which carries
+ * several fields the comparator never reads, e.g. `username`/`password`/
+ * `port`/`depth`/`dirname`/`stem`) is not retained for every URL in a
+ * large archive.
+ */
+export interface UrlSortKey {
+	/** The original input URL string, used for the equal-`href` tiebreak and for the final `url` → rank lookup. */
+	original: string;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.href}. */
+	href: string;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.hostname}. */
+	hostname: string;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.paths}. */
+	paths: string[];
+	/** {@link import('@d-zero/shared/parse-url').ExURL.basename}, defaulted to `''`. */
+	basename: string;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.isIndex}. */
+	isIndex: boolean;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.extname}, defaulted to `''`. */
+	extname: string;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.query}, defaulted to `''`. */
+	search: string;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.hash}, defaulted to `''`. */
+	hash: string;
+	/** {@link import('@d-zero/shared/parse-url').ExURL.protocol}. */
+	protocol: string;
+}

--- a/packages/@nitpicker/query/src/url-sort-temp-table.spec.ts
+++ b/packages/@nitpicker/query/src/url-sort-temp-table.spec.ts
@@ -156,6 +156,96 @@ describe('prepareUrlSortTempTable / ensureUrlSortTempTable / orderByUrlRank', ()
 		]);
 	});
 
+	it('survives a duplicate URL insert against the already-prepared table without throwing', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'dup-insert.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/page');
+
+		await prepareUrlSortTempTable(archive);
+
+		// Reproduces the crash observed on an 11 GB / ~1.5M-URL archive: the
+		// natural-sort comparator behind the external merge sort
+		// (`@d-zero/shared`'s `numericalComparator`) is not guaranteed
+		// transitive, which can occasionally let the same URL reach this
+		// insert twice with different ranks. `onConflict('url').ignore()` in
+		// `prepareUrlSortTempTable` must turn that into a no-op, not a
+		// `UNIQUE constraint failed` crash — this exercises the exact insert
+		// shape it uses against the exact table it built.
+		const knex = archive.getKnex();
+		const existing = await knex(URL_SORT_TEMP_TABLE).select('url', 'rank').first();
+		await expect(
+			knex(URL_SORT_TEMP_TABLE)
+				.insert([{ url: existing.url, rank: existing.rank + 999 }])
+				.onConflict('url')
+				.ignore(),
+		).resolves.not.toThrow();
+
+		const row = await knex(URL_SORT_TEMP_TABLE).where({ url: existing.url }).first();
+		expect(row.rank).toBe(existing.rank);
+	});
+
+	it('onRanked reports every row externalSortUrls ranks, in the same order as the insert', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'on-ranked.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/image-10.jpg');
+		await addPage(archive, 'https://example.com/image-2.jpg');
+
+		const ranked: { url: string; rank: number }[] = [];
+		await prepareUrlSortTempTable(archive, {
+			onRanked: (url, rank) => ranked.push({ url, rank }),
+		});
+
+		expect(ranked).toEqual([
+			{ url: 'https://example.com/image-2.jpg', rank: 0 },
+			{ url: 'https://example.com/image-10.jpg', rank: 1 },
+		]);
+	});
+
+	it('rankedUrls replays a caller-supplied source instead of running externalSortUrls', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'ranked-urls-source.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		// Not sorted, and not even a real URL under this archive — proves the
+		// replay path trusts the supplied source verbatim rather than falling
+		// back to (or cross-checking against) `pages`/`resources`.
+		/**
+		 * Fixture ranked-URL source. Must be an async generator to satisfy
+		 * `rankedUrls: AsyncIterable<...>`, even though the fixture data is
+		 * available synchronously.
+		 * @yields {{url: string, rank: number}} A fixed, out-of-natural-order pair.
+		 */
+		// eslint-disable-next-line @typescript-eslint/require-await -- async generator required by the AsyncIterable type; fixture body is synchronous.
+		async function* source() {
+			yield { url: 'https://cached.example.com/b', rank: 0 };
+			yield { url: 'https://cached.example.com/a', rank: 1 };
+		}
+
+		await prepareUrlSortTempTable(archive, { rankedUrls: source() });
+
+		const rows = await archive
+			.getKnex()(URL_SORT_TEMP_TABLE)
+			.select('url', 'rank')
+			.orderBy('rank', 'asc');
+		expect(rows).toEqual([
+			{ url: 'https://cached.example.com/b', rank: 0 },
+			{ url: 'https://cached.example.com/a', rank: 1 },
+		]);
+	});
+
 	it('ensureUrlSortTempTable only prepares the table once per connection', async () => {
 		const { mkdirSync } = await import('node:fs');
 		mkdirSync(workingDir, { recursive: true });

--- a/packages/@nitpicker/query/src/url-sort-temp-table.spec.ts
+++ b/packages/@nitpicker/query/src/url-sort-temp-table.spec.ts
@@ -1,0 +1,179 @@
+import path from 'node:path';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { Archive } from '@nitpicker/crawler';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+	ensureUrlSortTempTable,
+	orderByUrlRank,
+	prepareUrlSortTempTable,
+	URL_SORT_TEMP_TABLE,
+} from './url-sort-temp-table.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_url_sort_temp_table__');
+
+const META = {
+	lang: null,
+	title: null,
+	description: null,
+	keywords: null,
+	noindex: false,
+	nofollow: false,
+	noarchive: false,
+	canonical: null,
+	alternate: null,
+	'og:type': null,
+	'og:title': null,
+	'og:site_name': null,
+	'og:description': null,
+	'og:url': null,
+	'og:image': null,
+	'twitter:card': null,
+};
+
+/**
+ * Minimal config so {@link Archive.create} has a valid `info` row.
+ * @returns A config object accepted by `Archive.setConfig`.
+ */
+function baseConfig() {
+	return {
+		baseUrl: 'https://example.com',
+		name: 'test',
+		version: '0.10.0',
+		recursive: true,
+		interval: 0,
+		image: false,
+		fetchExternal: true,
+		parallels: 1,
+		roots: ['https://example.com'],
+		excludes: [],
+		excludeKeywords: [],
+		excludeUrls: [],
+		maxExcludedDepth: 0,
+		retry: 3,
+		fromList: false,
+		disableQueries: false,
+		userAgent: 'test',
+		ignoreRobots: false,
+	};
+}
+
+/**
+ * Adds a minimal internal HTML page to the archive.
+ * @param archive - The archive to write to.
+ * @param url - The page URL.
+ */
+async function addPage(archive: InstanceType<typeof Archive>, url: string) {
+	await archive.setPage({
+		url: parseUrl(url)!,
+		redirectPaths: [],
+		isExternal: false,
+		isTarget: true,
+		status: 200,
+		statusText: 'OK',
+		contentType: 'text/html',
+		contentLength: 100,
+		responseHeaders: {},
+		html: '',
+		meta: META,
+		anchorList: [],
+		imageList: [],
+		isSkipped: false,
+	});
+}
+
+describe('prepareUrlSortTempTable / ensureUrlSortTempTable / orderByUrlRank', () => {
+	let archive: InstanceType<typeof Archive> | undefined;
+
+	afterEach(async () => {
+		if (archive) {
+			await archive.close();
+			archive = undefined;
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('ranks pages and resources URLs in natural sort order, deduplicated', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'rank.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		await addPage(archive, 'https://example.com/image-10.jpg');
+		await addPage(archive, 'https://example.com/image-2.jpg');
+		// Same URL as a page above — must be deduplicated to one ranked row,
+		// not appear twice or shift the other ranks.
+		await archive.setResources({
+			url: parseUrl('https://example.com/image-2.jpg')!,
+			isExternal: false,
+			isError: false,
+			status: 200,
+			statusText: 'OK',
+			contentType: 'image/jpeg',
+			contentLength: 500,
+			compress: false,
+			cdn: false,
+			headers: null,
+		});
+
+		await prepareUrlSortTempTable(archive);
+
+		const rows = await archive
+			.getKnex()(URL_SORT_TEMP_TABLE)
+			.select('url', 'rank')
+			.orderBy('rank', 'asc');
+		expect(rows).toEqual([
+			{ url: 'https://example.com/image-2.jpg', rank: 0 },
+			{ url: 'https://example.com/image-10.jpg', rank: 1 },
+		]);
+	});
+
+	it('orderByUrlRank sorts a query by natural URL order via the temp table', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'order.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+
+		await addPage(archive, 'https://example.com/image-10.jpg');
+		await addPage(archive, 'https://example.com/image-2.jpg');
+
+		await prepareUrlSortTempTable(archive);
+		const knex = archive.getKnex();
+		const rows = await orderByUrlRank(knex('pages').select('url'), knex, '"pages"."url"');
+		expect(rows.map((r: { url: string }) => r.url)).toEqual([
+			'https://example.com/image-2.jpg',
+			'https://example.com/image-10.jpg',
+		]);
+	});
+
+	it('ensureUrlSortTempTable only prepares the table once per connection', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'ensure.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/');
+
+		await ensureUrlSortTempTable(archive);
+		// A page added after the first prepare must NOT appear once the
+		// connection is already marked prepared — otherwise every list query
+		// would silently re-pay the full scan-and-sort cost on every call.
+		await addPage(archive, 'https://example.com/late');
+		await ensureUrlSortTempTable(archive);
+
+		const rows = await archive.getKnex()(URL_SORT_TEMP_TABLE).select('url');
+		expect(rows.map((r: { url: string }) => r.url)).toEqual(['https://example.com']);
+	});
+});

--- a/packages/@nitpicker/query/src/url-sort-temp-table.ts
+++ b/packages/@nitpicker/query/src/url-sort-temp-table.ts
@@ -1,7 +1,37 @@
 import type { ArchiveAccessor } from '@nitpicker/crawler';
 import type { Knex } from 'knex';
 
-import { sortUrl } from '@d-zero/shared/sort-url';
+import { externalSortUrls } from './external-url-sort.js';
+
+/**
+ * Options for {@link prepareUrlSortTempTable}.
+ */
+export interface PrepareUrlSortTempTableOptions {
+	/**
+	 * Forwarded to {@link externalSortUrls} — see
+	 * {@link import('./external-url-sort.js').ExternalSortUrlsOptions.onProgress}.
+	 * Ignored when {@link PrepareUrlSortTempTableOptions.rankedUrls} is given,
+	 * since {@link externalSortUrls} does not run in that case.
+	 */
+	onProgress?: (message: string) => void;
+	/**
+	 * Skips {@link externalSortUrls} entirely and inserts from this source
+	 * instead. For callers that persisted a prior external-sort run's output
+	 * (e.g. `@nitpicker/viewer`'s on-disk URL-sort cache) and want to replay
+	 * it without re-paying the read-chunk-sort-merge cost on every process
+	 * restart.
+	 */
+	rankedUrls?: AsyncIterable<{ url: string; rank: number }>;
+	/**
+	 * Called once per ranked row as it is written to the TEMP TABLE, in
+	 * addition to the insert itself. Lets a caller persist a fresh
+	 * {@link externalSortUrls} run's output (e.g. to the on-disk cache
+	 * `rankedUrls` later replays) without a second full pass over the
+	 * archive. Not called when `rankedUrls` is given — there is nothing new
+	 * to persist in that case.
+	 */
+	onRanked?: (url: string, rank: number) => void;
+}
 
 /**
  * Shared table name for the connection-local URL sort cache.
@@ -13,33 +43,75 @@ import { sortUrl } from '@d-zero/shared/sort-url';
  */
 export const URL_SORT_TEMP_TABLE = 'viewer_url_sort_keys';
 
-const CHUNK_SIZE = 500;
+/** Rows per `INSERT` batch while draining the external sort's output. */
+const INSERT_CHUNK_SIZE = 500;
 const preparedConnections = new WeakSet<Knex>();
 
 /**
  * Builds the connection-local URL natural-sort TEMP table used by viewer list
  * queries. The table is intentionally temporary: archive files and crawl stubs
  * are never mutated with viewer-only sort metadata.
+ *
+ * Ranking is done via {@link externalSortUrls} (external merge sort) rather
+ * than an in-memory parse-everything-then-sort pass, so a million-plus-URL
+ * archive doesn't need to hold every parsed URL in memory at once.
+ *
+ * Inserts use `onConflict('url').ignore()` rather than a plain `insert` as a
+ * fail-safe, not the primary dedup mechanism: {@link
+ * import('./merge-sorted-url-chunks.js').mergeSortedUrlChunks} already
+ * drains every chunk-file cursor tied with the current winner so the same
+ * URL (present in both a `pages` and a `resources` chunk) is emitted once.
+ * That relies on `compareUrlSortKeys` being a consistent total order, which
+ * it inherits from `@d-zero/shared`'s `numericalComparator` — a
+ * common-prefix-strip natural-sort comparator that is not guaranteed
+ * transitive. If it ever disagrees with itself on a huge archive, `ignore()`
+ * turns what would otherwise be a hard `UNIQUE` constraint crash into a
+ * silently-skipped duplicate rank. The rank sequence ends up with a gap
+ * where that happens, but {@link orderByUrlRank} only needs rank to be
+ * monotonic, not contiguous.
  * @param accessor - The opened archive accessor.
+ * @param options - See {@link PrepareUrlSortTempTableOptions}.
  * @example
  * await prepareUrlSortTempTable(accessor);
  * const firstPage = await listPages(accessor, { sortBy: 'url' });
  */
-export async function prepareUrlSortTempTable(accessor: ArchiveAccessor): Promise<void> {
+export async function prepareUrlSortTempTable(
+	accessor: ArchiveAccessor,
+	options: PrepareUrlSortTempTableOptions = {},
+): Promise<void> {
 	const knex = accessor.getKnex();
 	await knex.schema.raw(
 		`CREATE TEMP TABLE IF NOT EXISTS ${URL_SORT_TEMP_TABLE} (url TEXT PRIMARY KEY, rank INTEGER NOT NULL)`,
 	);
 	await knex(URL_SORT_TEMP_TABLE).delete();
 
-	const pageRows = (await knex('pages').select('url')) as { url: string }[];
-	const resourceRows = (await knex('resources').select('url')) as { url: string }[];
-	const urls = [...new Set([...pageRows, ...resourceRows].map((row) => row.url))];
-	const ranked = buildUrlRanks(urls);
+	let batch: { url: string; rank: number }[] = [];
+	const insertRow = async (url: string, rank: number): Promise<void> => {
+		batch.push({ url, rank });
+		if (batch.length >= INSERT_CHUNK_SIZE) {
+			await knex(URL_SORT_TEMP_TABLE).insert(batch).onConflict('url').ignore();
+			batch = [];
+		}
+	};
 
-	for (let index = 0; index < ranked.length; index += CHUNK_SIZE) {
-		await knex(URL_SORT_TEMP_TABLE).insert(ranked.slice(index, index + CHUNK_SIZE));
+	if (options.rankedUrls) {
+		for await (const { url, rank } of options.rankedUrls) {
+			await insertRow(url, rank);
+		}
+	} else {
+		await externalSortUrls(
+			accessor,
+			async (url, rank) => {
+				await insertRow(url, rank);
+				options.onRanked?.(url, rank);
+			},
+			{ onProgress: options.onProgress },
+		);
 	}
+	if (batch.length > 0) {
+		await knex(URL_SORT_TEMP_TABLE).insert(batch).onConflict('url').ignore();
+	}
+
 	preparedConnections.add(knex);
 }
 
@@ -81,28 +153,4 @@ export function orderByUrlRank(
 	return query
 		.orderBy(rankExpression, direction)
 		.orderByRaw(`${qualifiedUrlColumn} ${direction}`);
-}
-
-/**
- * Parses and sorts `urls` exactly once (a large archive can carry hundreds of
- * thousands of URLs, so calling `sortUrl` — a full parse + natural sort — a
- * second time here previously doubled the peak memory this function needed).
- * @param urls
- */
-function buildUrlRanks(urls: readonly string[]): { url: string; rank: number }[] {
-	const sorted = sortUrl([...urls]);
-	const rankByUrl = new Map<string, number>();
-	for (const [rank, parsed] of sorted.entries()) {
-		const candidates = [parsed.href, parsed.withoutHashAndAuth];
-		for (const candidate of candidates) {
-			if (!rankByUrl.has(candidate)) {
-				rankByUrl.set(candidate, rank);
-			}
-		}
-	}
-
-	return urls.map((url, fallbackRank) => ({
-		url,
-		rank: rankByUrl.get(url) ?? fallbackRank,
-	}));
 }

--- a/packages/@nitpicker/query/src/url-sort-temp-table.ts
+++ b/packages/@nitpicker/query/src/url-sort-temp-table.ts
@@ -84,16 +84,12 @@ export function orderByUrlRank(
 }
 
 /**
- *
+ * Parses and sorts `urls` exactly once (a large archive can carry hundreds of
+ * thousands of URLs, so calling `sortUrl` — a full parse + natural sort — a
+ * second time here previously doubled the peak memory this function needed).
  * @param urls
  */
 function buildUrlRanks(urls: readonly string[]): { url: string; rank: number }[] {
-	const parsedByCandidate = new Map<string, string>();
-	for (const parsed of sortUrl([...urls])) {
-		parsedByCandidate.set(parsed.href, parsed.href);
-		parsedByCandidate.set(parsed.withoutHashAndAuth, parsed.href);
-	}
-
 	const sorted = sortUrl([...urls]);
 	const rankByUrl = new Map<string, number>();
 	for (const [rank, parsed] of sorted.entries()) {
@@ -107,9 +103,6 @@ function buildUrlRanks(urls: readonly string[]): { url: string; rank: number }[]
 
 	return urls.map((url, fallbackRank) => ({
 		url,
-		rank:
-			rankByUrl.get(url) ??
-			rankByUrl.get(parsedByCandidate.get(url) ?? '') ??
-			fallbackRank,
+		rank: rankByUrl.get(url) ?? fallbackRank,
 	}));
 }

--- a/packages/@nitpicker/query/src/write-sorted-url-chunk.spec.ts
+++ b/packages/@nitpicker/query/src/write-sorted-url-chunk.spec.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+
+import { pathComparator } from '@d-zero/shared/sort/path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { writeSortedUrlChunk } from './write-sorted-url-chunk.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_write_sorted_url_chunk__');
+
+describe('writeSortedUrlChunk', () => {
+	afterEach(async () => {
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('writes URLs to a JSON-Lines file, sorted in natural URL order', async () => {
+		const { mkdirSync, readFileSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+
+		const urls = [
+			'https://example.com/image-10.jpg',
+			'https://example.com/image-2.jpg',
+			'https://example.com/image-1.jpg',
+		];
+		const filePath = await writeSortedUrlChunk(urls, workingDir, 0);
+
+		const lines = readFileSync(filePath, 'utf8').trim().split('\n');
+		const written = lines.map(
+			(line) => (JSON.parse(line) as { original: string }).original,
+		);
+
+		expect(written).toEqual([...urls].toSorted(pathComparator));
+	});
+
+	it('keeps URLs that fail to parse as a fallback row instead of dropping them', async () => {
+		const { mkdirSync, readFileSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+
+		// A dropped row would leave that page/resource with no
+		// `viewer_url_sort_keys` entry at all, which — per `orderByUrlRank`'s
+		// scalar-subquery `ORDER BY` — sorts its NULL rank ahead of every
+		// real one, bunching unparsable URLs at the top of every URL-sorted
+		// view instead of just landing somewhere (anywhere) in the output.
+		const filePath = await writeSortedUrlChunk(
+			['not a url', 'https://example.com/'],
+			workingDir,
+			0,
+		);
+
+		const lines = readFileSync(filePath, 'utf8').trim().split('\n');
+		const written = lines.map(
+			(line) => (JSON.parse(line) as { original: string }).original,
+		);
+		expect(written).toEqual(['not a url', 'https://example.com/']);
+	});
+
+	it('writes an empty file for an empty input', async () => {
+		const { mkdirSync, readFileSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+
+		const filePath = await writeSortedUrlChunk([], workingDir, 0);
+		expect(readFileSync(filePath, 'utf8')).toBe('');
+	});
+});

--- a/packages/@nitpicker/query/src/write-sorted-url-chunk.ts
+++ b/packages/@nitpicker/query/src/write-sorted-url-chunk.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { compareUrlSortKeys } from './compare-url-sort-keys.js';
+import { toUrlSortKey } from './to-url-sort-key.js';
+
+/**
+ * Parses, sorts, and persists one chunk of URLs to a JSON-Lines temp file —
+ * the "split" half of an external merge sort.
+ *
+ * Only this chunk's `UrlSortKey`s are held in memory at once; the caller is
+ * expected to let `urls` and the return value's closure go out of scope
+ * before reading the next chunk, so a multi-million-URL archive never has
+ * more than one chunk's worth of parsed URLs live at the same time.
+ * @param urls - The chunk's raw URL strings.
+ * @param tmpDir - Directory to write the chunk file into (must already exist).
+ * @param chunkIndex - Used to build a unique, order-independent filename.
+ * @returns The path to the written chunk file.
+ * @example
+ * const file = await writeSortedUrlChunk(urls, tmpDir, 0);
+ */
+export async function writeSortedUrlChunk(
+	urls: readonly string[],
+	tmpDir: string,
+	chunkIndex: number,
+): Promise<string> {
+	const keys = urls.map((url) => toUrlSortKey(url)).toSorted(compareUrlSortKeys);
+
+	const filePath = path.join(tmpDir, `chunk-${chunkIndex}.jsonl`);
+	const content = keys.map((key) => JSON.stringify(key)).join('\n');
+	await fs.writeFile(filePath, content.length > 0 ? `${content}\n` : '', 'utf8');
+	return filePath;
+}

--- a/packages/@nitpicker/viewer/package.json
+++ b/packages/@nitpicker/viewer/package.json
@@ -33,6 +33,7 @@
 		"test:e2e:stub": "node ./e2e/generate-stub-fixture.mjs && playwright test --config playwright.stub.config.ts"
 	},
 	"dependencies": {
+		"@d-zero/dealer": "1.9.4",
 		"@hono/node-server": "2.0.6",
 		"@nitpicker/query": "0.12.0",
 		"@tanstack/react-query": "5.101.1",

--- a/packages/@nitpicker/viewer/src/start-viewer.ts
+++ b/packages/@nitpicker/viewer/src/start-viewer.ts
@@ -2,16 +2,20 @@ import type { ViewerOptions } from './types.js';
 
 import path from 'node:path';
 
+import { Lanes } from '@d-zero/dealer';
 import { serve } from '@hono/node-server';
-import { prepareUrlSortTempTable } from '@nitpicker/query';
 
 import { createArchiveContext } from './archive-context.js';
 import { createApp } from './create-app.js';
 import { findFreePort } from './find-free-port.js';
 import { openBrowser } from './open-browser.js';
+import { prepareCachedUrlSortTempTable } from './url-sort-cache.js';
 
 /** Default port the viewer prefers before falling back to an ephemeral one. */
 const DEFAULT_PORT = 4324;
+
+/** Lane id for the startup URL-sort progress display. */
+const URL_SORT_LANE = 0;
 
 /**
  * Launches the Viewer: opens the archive, starts the Hono server, optionally
@@ -21,6 +25,15 @@ const DEFAULT_PORT = 4324;
  * resolves until a shutdown signal arrives — so the CLI's trailing
  * `process.exit` is not reached while the server is running. On signal it
  * closes the archive (`closeAll`) and the server, then resolves for a clean exit.
+ *
+ * The SIGINT/SIGTERM listener is installed before the startup URL sort runs,
+ * not after: that sort can take multiple minutes on a million-plus-URL
+ * archive (see `externalSortUrls`' JSDoc) and writes scratch/cache files to
+ * disk, so a Ctrl-C during that window must still close the archive —
+ * otherwise Node's default SIGINT disposition (immediate exit) skips
+ * `externalSortUrls`'/`url-sort-cache.ts`'s `finally`-block cleanup and
+ * leaks chunk-file scratch directories and a stray cache tmp file under the
+ * archive's (never-actively-evicted) tar-cache directory.
  * @param options - Launch options (file path, port, host, open).
  * @returns Resolves only after the server has shut down gracefully.
  */
@@ -31,27 +44,24 @@ export async function startViewer(options: ViewerOptions): Promise<void> {
 	// instead of a post-banner `EADDRINUSE` crash.
 	const port = await findFreePort(options.port ?? DEFAULT_PORT, host);
 	const context = await createArchiveContext(filePath);
-	await prepareUrlSortTempTable(context.manager.get(context.archiveId));
-	const publicDir = path.resolve(import.meta.dirname, 'public');
-	const app = createApp({ context, publicDir });
 
-	const server = serve({ fetch: app.fetch, port, hostname: host });
-	const url = `http://${host}:${port}`;
-	// eslint-disable-next-line no-console
-	console.log(`\n  Nitpicker Viewer\n  ➜  ${url}\n  (Ctrl-C to stop)\n`);
-	if (open) {
-		openBrowser(url);
-	}
-
-	await new Promise<void>((resolve) => {
+	// Assigned exactly once, well after this declaration (once the sort below
+	// completes) — `let` is required because `shutdown` below must close over
+	// it before it exists, so it can still close the server if a signal
+	// arrives after `serve()` runs.
+	// eslint-disable-next-line prefer-const
+	let server: ReturnType<typeof serve> | undefined;
+	let shuttingDown = false;
+	const shutdownPromise = new Promise<void>((resolve) => {
 		const shutdown = () => {
+			shuttingDown = true;
 			void (async () => {
 				try {
 					await context.manager.closeAll();
 				} catch {
 					// Ignore close errors during shutdown — we are exiting anyway.
 				} finally {
-					server.close();
+					server?.close();
 					resolve();
 				}
 			})();
@@ -59,4 +69,45 @@ export async function startViewer(options: ViewerOptions): Promise<void> {
 		process.once('SIGINT', shutdown);
 		process.once('SIGTERM', shutdown);
 	});
+
+	// A million-plus-URL archive's startup sort can take multiple minutes with
+	// no other observable output (see externalSortUrls' JSDoc) — Lanes gives
+	// the operator the same progress display style used by `analyze`/`report`
+	// instead of a silent-looking hang. Cached on disk (see
+	// prepareCachedUrlSortTempTable) so a Ctrl-C / re-open replays the prior
+	// sort instead of re-running it.
+	const sortLanes = new Lanes({ verbose: !process.stdout.isTTY, indent: '  ' });
+	try {
+		await prepareCachedUrlSortTempTable(context, (message) =>
+			sortLanes.update(URL_SORT_LANE, message),
+		);
+	} catch (error) {
+		// A SIGINT/SIGTERM mid-sort closes the archive out from under the
+		// in-flight query, which surfaces here as a DB error — that is the
+		// shutdown path above already in progress, not a real failure.
+		if (shuttingDown) {
+			await shutdownPromise;
+			return;
+		}
+		throw error;
+	} finally {
+		sortLanes.close();
+	}
+	if (shuttingDown) {
+		await shutdownPromise;
+		return;
+	}
+
+	const publicDir = path.resolve(import.meta.dirname, 'public');
+	const app = createApp({ context, publicDir });
+
+	server = serve({ fetch: app.fetch, port, hostname: host });
+	const url = `http://${host}:${port}`;
+	// eslint-disable-next-line no-console
+	console.log(`\n  Nitpicker Viewer\n  ➜  ${url}\n  (Ctrl-C to stop)\n`);
+	if (open) {
+		openBrowser(url);
+	}
+
+	await shutdownPromise;
 }

--- a/packages/@nitpicker/viewer/src/url-sort-cache.spec.ts
+++ b/packages/@nitpicker/viewer/src/url-sort-cache.spec.ts
@@ -1,0 +1,258 @@
+import type { ArchiveContext } from './types.js';
+import type { ArchiveManager } from '@nitpicker/query';
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+import { Archive } from '@nitpicker/crawler';
+import { listPages } from '@nitpicker/query';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { prepareCachedUrlSortTempTable } from './url-sort-cache.js';
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = path.dirname(__filename);
+const workingDir = path.resolve(__dirname, '__test_fixtures_url_sort_cache__');
+
+const META = {
+	lang: null,
+	title: null,
+	description: null,
+	keywords: null,
+	noindex: false,
+	nofollow: false,
+	noarchive: false,
+	canonical: null,
+	alternate: null,
+	'og:type': null,
+	'og:title': null,
+	'og:site_name': null,
+	'og:description': null,
+	'og:url': null,
+	'og:image': null,
+	'twitter:card': null,
+};
+
+/**
+ * Minimal config so {@link Archive.create} has a valid `info` row.
+ * @returns A config object accepted by `Archive.setConfig`.
+ */
+function baseConfig() {
+	return {
+		baseUrl: 'https://example.com',
+		name: 'test',
+		version: '0.10.0',
+		recursive: true,
+		interval: 0,
+		image: false,
+		fetchExternal: true,
+		parallels: 1,
+		roots: ['https://example.com'],
+		excludes: [],
+		excludeKeywords: [],
+		excludeUrls: [],
+		maxExcludedDepth: 0,
+		retry: 3,
+		fromList: false,
+		disableQueries: false,
+		userAgent: 'test',
+		ignoreRobots: false,
+	};
+}
+
+/**
+ * Adds a minimal internal HTML page to the archive.
+ * @param archive - The archive to write to.
+ * @param url - The page URL.
+ */
+async function addPage(archive: InstanceType<typeof Archive>, url: string) {
+	await archive.setPage({
+		url: parseUrl(url)!,
+		redirectPaths: [],
+		isExternal: false,
+		isTarget: true,
+		status: 200,
+		statusText: 'OK',
+		contentType: 'text/html',
+		contentLength: 100,
+		responseHeaders: {},
+		html: '',
+		meta: META,
+		anchorList: [],
+		imageList: [],
+		isSkipped: false,
+	});
+}
+
+/**
+ * Builds a viewer `ArchiveContext` whose manager resolves straight to the
+ * given archive — the cache only calls `context.manager.get(context.archiveId)`
+ * once, so a stub `get` is enough.
+ * @param archive - The archive the context should resolve to.
+ * @param mode - The archive mode to report.
+ * @returns A context shape compatible with the cache module's input.
+ */
+function makeContext(
+	archive: InstanceType<typeof Archive>,
+	mode: ArchiveContext['mode'] = 'archive',
+): ArchiveContext {
+	const manager = {
+		get: () => archive,
+	} as unknown as ArchiveManager;
+	return {
+		manager,
+		archiveId: 'test',
+		filePath: archive.tmpDir,
+		mode,
+		crawlerLockHolder: null,
+	};
+}
+
+describe('prepareCachedUrlSortTempTable', () => {
+	let archive: InstanceType<typeof Archive> | undefined;
+
+	afterEach(async () => {
+		if (archive) {
+			await archive.close();
+			archive = undefined;
+		}
+		const { rmSync } = await import('node:fs');
+		rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it('persists a cache file on first run and replays it on the next call instead of re-sorting', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'cache.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/a');
+
+		const context = makeContext(archive);
+		await prepareCachedUrlSortTempTable(context);
+
+		const cacheFile = path.join(archive.tmpDir, 'precomputed', 'url-sort-ranks.jsonl');
+		expect(existsSync(cacheFile)).toBe(true);
+
+		// `listPages` always returns every `pages` row regardless of whether
+		// it has a TEMP TABLE rank (rows without one just fall back to
+		// alphabetical order), so a page added after caching would still show
+		// up there even on a correct cache hit. Assert directly against the
+		// TEMP TABLE instead: a page added after the cache file was written
+		// must NOT have a ranked row — the only way that's possible is if the
+		// second call read from the cache file instead of re-running the
+		// external sort against the (now-changed) live `pages` table. Table
+		// name matches `@nitpicker/query`'s (unexported) `URL_SORT_TEMP_TABLE`.
+		await addPage(archive, 'https://example.com/b-added-after-cache');
+		await prepareCachedUrlSortTempTable(context);
+
+		const rankedUrls = await archive.getKnex()('viewer_url_sort_keys').select('url');
+		expect(rankedUrls.map((r: { url: string }) => r.url)).toEqual([
+			'https://example.com/a',
+		]);
+	});
+
+	it('bypasses the cache in stub mode, always reflecting the live pages table', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'stub.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/a');
+
+		const context = makeContext(archive, 'stub');
+		await prepareCachedUrlSortTempTable(context);
+
+		const cacheFile = path.join(archive.tmpDir, 'precomputed', 'url-sort-ranks.jsonl');
+		expect(existsSync(cacheFile)).toBe(false);
+
+		await addPage(archive, 'https://example.com/b');
+		await prepareCachedUrlSortTempTable(context);
+
+		const { items } = await listPages(archive, {});
+		expect(items.map((p) => p.url).toSorted()).toEqual([
+			'https://example.com/a',
+			'https://example.com/b',
+		]);
+	});
+
+	it('forwards onProgress messages while sorting on a cache miss', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'progress.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/a');
+
+		const messages: string[] = [];
+		await prepareCachedUrlSortTempTable(makeContext(archive), (message) => {
+			messages.push(message);
+		});
+
+		expect(messages.length).toBeGreaterThan(0);
+	});
+
+	it('reports a distinct progress message when replaying from the cache', async () => {
+		const { mkdirSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'progress-cached.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/a');
+
+		const context = makeContext(archive);
+		await prepareCachedUrlSortTempTable(context);
+
+		const messages: string[] = [];
+		await prepareCachedUrlSortTempTable(context, (message) => {
+			messages.push(message);
+		});
+
+		expect(messages.some((m) => m.toLowerCase().includes('cache'))).toBe(true);
+	});
+
+	it('still builds the TEMP TABLE when the cache write stream fails, and leaves no cache file behind', async () => {
+		// chmod-based permission errors are POSIX-specific and don't reproduce
+		// reliably on Windows.
+		if (process.platform === 'win32') return;
+		const { mkdirSync, chmodSync } = await import('node:fs');
+		mkdirSync(workingDir, { recursive: true });
+		archive = await Archive.create({
+			filePath: path.resolve(workingDir, 'write-failure.nitpicker'),
+			cwd: workingDir,
+		});
+		await archive.setConfig(baseConfig());
+		await addPage(archive, 'https://example.com/a');
+
+		// Make the cache directory read-only so `createWriteStream` inside
+		// `sortAndCache` fails with EACCES — the fail-safe this exercises
+		// (see url-sort-cache.ts's `cacheWritable` handling) must still let
+		// the TEMP TABLE build succeed from the live sort.
+		const precomputedDir = path.join(archive.tmpDir, 'precomputed');
+		mkdirSync(precomputedDir, { recursive: true });
+		chmodSync(precomputedDir, 0o444);
+
+		try {
+			await expect(
+				prepareCachedUrlSortTempTable(makeContext(archive)),
+			).resolves.not.toThrow();
+		} finally {
+			chmodSync(precomputedDir, 0o755);
+		}
+
+		const rankedUrls = await archive.getKnex()('viewer_url_sort_keys').select('url');
+		expect(rankedUrls.map((r: { url: string }) => r.url)).toEqual([
+			'https://example.com/a',
+		]);
+		expect(existsSync(path.join(precomputedDir, 'url-sort-ranks.jsonl'))).toBe(false);
+	});
+});

--- a/packages/@nitpicker/viewer/src/url-sort-cache.ts
+++ b/packages/@nitpicker/viewer/src/url-sort-cache.ts
@@ -1,0 +1,190 @@
+import type { ArchiveContext } from './types.js';
+import type { ArchiveAccessor } from '@nitpicker/crawler';
+
+import { createReadStream, createWriteStream } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import readline from 'node:readline';
+
+import { prepareUrlSortTempTable } from '@nitpicker/query';
+
+/**
+ * Subdirectory inside an archive's tar-cache directory where precomputed
+ * artefacts live — mirrors `precomputed-disk-cache.ts`'s convention so both
+ * caches roll together when the archive's content-hash key changes.
+ */
+const PRECOMPUTED_DIR_NAME = 'precomputed';
+
+/** Filename of the persisted ranked-URL stream. */
+const CACHE_FILE_NAME = 'url-sort-ranks.jsonl';
+
+/**
+ * Prepares the viewer's URL-sort TEMP TABLE, replaying a prior run's output
+ * from disk when available instead of re-running the external merge sort.
+ *
+ * **Why not the existing `getOrComputeOnDisk`**: that helper buffers the
+ * whole artefact as one JSON string before writing/parsing it, which is
+ * fine for a `SummaryResult` or a handful of `IsolatedComponent`s but
+ * defeats the point here — a million-plus-URL archive's rank list is
+ * exactly the payload the external sort ({@link
+ * import('@nitpicker/query').externalSortUrls}) was built to avoid holding
+ * in memory all at once. This cache streams JSON-Lines through
+ * `readline`/`createWriteStream` instead, one row at a time on both the
+ * write and replay paths, so a Ctrl-C / re-open skips the sort without
+ * reintroducing the memory spike it was built to avoid.
+ *
+ * **Stub-mode bypass**: mirrors `summary-cache.ts` / `isolated-clusters-cache.ts`
+ * — a live crawl stub's `pages`/`resources` are still growing, so a cached
+ * rank list would go stale mid-crawl. Stub mode always re-sorts.
+ *
+ * A cache write failure (e.g. disk full) does not fail viewer startup: the
+ * TEMP TABLE is still built from the live sort, only the on-disk replay for
+ * the *next* time is skipped.
+ * @param context - The viewer's per-request archive context.
+ * @param onProgress - Forwarded to {@link prepareUrlSortTempTable} on a cache miss.
+ * @example
+ * await prepareCachedUrlSortTempTable(context, (msg) => lanes.update(0, msg));
+ */
+export async function prepareCachedUrlSortTempTable(
+	context: ArchiveContext,
+	onProgress?: (message: string) => void,
+): Promise<void> {
+	const accessor = context.manager.get(context.archiveId);
+	if (context.mode === 'stub') {
+		await prepareUrlSortTempTable(accessor, { onProgress });
+		return;
+	}
+
+	const cacheFile = path.join(accessor.tmpDir, PRECOMPUTED_DIR_NAME, CACHE_FILE_NAME);
+	if (await fileExists(cacheFile)) {
+		onProgress?.('Sorting URLs: loading cached order from a previous run…');
+		await prepareUrlSortTempTable(accessor, { rankedUrls: readCachedRanks(cacheFile) });
+		return;
+	}
+
+	await sortAndCache(accessor, cacheFile, onProgress);
+}
+
+/**
+ * Checks whether a file exists, without throwing on `ENOENT`.
+ * @param filePath - Path to probe.
+ * @returns Whether the file exists.
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		await fs.access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Streams `{url, rank}` pairs out of a previously persisted cache file.
+ * @param cacheFile - Absolute path to the JSON-Lines cache file.
+ * @yields {{url: string, rank: number}} Each cached ranked row, in file order
+ *   (already ascending rank).
+ */
+async function* readCachedRanks(cacheFile: string): AsyncGenerator<{
+	url: string;
+	rank: number;
+}> {
+	const lines = readline.createInterface({
+		input: createReadStream(cacheFile, 'utf8'),
+		crlfDelay: Infinity,
+	});
+	for await (const line of lines) {
+		if (line.length === 0) continue;
+		yield JSON.parse(line) as { url: string; rank: number };
+	}
+}
+
+/**
+ * Runs a fresh external sort while streaming its output to the cache file,
+ * so a subsequent viewer start can replay it instead of re-sorting.
+ * @param accessor - The opened archive accessor.
+ * @param cacheFile - Absolute path the cache should end up at once complete.
+ * @param onProgress - Forwarded to {@link prepareUrlSortTempTable}.
+ */
+async function sortAndCache(
+	accessor: ArchiveAccessor,
+	cacheFile: string,
+	onProgress?: (message: string) => void,
+): Promise<void> {
+	const dir = path.dirname(cacheFile);
+	await fs.mkdir(dir, { recursive: true });
+	const tmpFile = path.join(dir, `.${path.basename(cacheFile)}.${process.pid}.tmp`);
+	const stream = createWriteStream(tmpFile, 'utf8');
+	// A write-stream error (e.g. disk full) must not take down the sort
+	// itself — the TEMP TABLE the viewer actually needs is built from
+	// `prepareUrlSortTempTable`'s own insert path, independent of this
+	// stream. Once broken, stop writing rather than let further `.write()`
+	// calls throw or silently queue against a dead stream.
+	let cacheWritable = true;
+	// Registered once, up front, rather than raced in only after `.end()`:
+	// Node's `end(callback)` callback can fire before the `'error'` event
+	// does when the failure happens on the final buffered flush (observed
+	// with Node 24), so checking `cacheWritable` only after `await`ing the
+	// `end()` callback can still see a stale `true` and promote a truncated
+	// file. Listening from the start means whichever of `'error'` or
+	// `'finish'` fires first is still correctly observed below.
+	const errorPromise = new Promise<void>((resolve) => {
+		stream.once('error', () => {
+			cacheWritable = false;
+			resolve();
+		});
+	});
+
+	try {
+		await prepareUrlSortTempTable(accessor, {
+			onProgress,
+			onRanked: (url, rank) => {
+				if (cacheWritable) {
+					stream.write(`${JSON.stringify({ url, rank })}\n`);
+				}
+			},
+		});
+	} catch (error) {
+		stream.destroy();
+		await removeQuietly(tmpFile);
+		throw error;
+	}
+
+	if (!cacheWritable) {
+		await removeQuietly(tmpFile);
+		return;
+	}
+	const finishPromise = new Promise<void>((resolve) => {
+		stream.once('finish', () => resolve());
+	});
+	stream.end();
+	await Promise.race([finishPromise, errorPromise]);
+	if (!cacheWritable) {
+		await removeQuietly(tmpFile);
+		return;
+	}
+	try {
+		await fs.rename(tmpFile, cacheFile);
+	} catch {
+		// Persisting the cache is an optimization, not a correctness
+		// requirement — the TEMP TABLE is already built. Next start just
+		// pays the sort cost again, which is the pre-cache baseline.
+		await removeQuietly(tmpFile);
+	}
+}
+
+/**
+ * Removes a file, swallowing any error (missing file, permission denied on
+ * an unwritable cache directory, etc). Cleaning up a scratch file is a
+ * best-effort courtesy, not a correctness requirement — a failure here must
+ * never mask or replace the caller's own success/failure outcome.
+ * @param filePath - Path to remove.
+ */
+async function removeQuietly(filePath: string): Promise<void> {
+	try {
+		await fs.rm(filePath, { force: true });
+	} catch {
+		// Best-effort — see JSDoc.
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,6 +3034,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nitpicker/viewer@workspace:packages/@nitpicker/viewer"
   dependencies:
+    "@d-zero/dealer": "npm:1.9.4"
     "@d-zero/shared": "npm:0.22.2"
     "@hono/node-server": "npm:2.0.6"
     "@nitpicker/crawler": "npm:0.12.0"


### PR DESCRIPTION
## Summary
- An 11 GB / ~1.5M-URL archive OOMs the viewer at startup: URL ranking parsed every `pages`/`resources` URL into an `ExURL` and sorted the whole set in memory. Replaced with an external merge sort (`packages/@nitpicker/query/src/external-url-sort.ts`) — chunked reads, per-chunk sort spilled to a temp file, K-way merge — so peak memory stays bounded by chunk size instead of archive size.
- The K-way merge's dedup keys on `original` string equality rather than `compareUrlSortKeys(...) === 0` (the natural-sort comparator can legitimately return `0` for different URLs, e.g. `"007"` vs `"7"`), and `viewer_url_sort_keys` inserts use `onConflict('url').ignore()` as a fail-safe against the comparator's non-transitivity at scale. `toUrlSortKey` always returns a key (fallback for unparsable URLs) instead of `null`, since a dropped row previously bunched at the top of every URL-sorted view via SQLite's NULL-first ordering.
- Viewer startup now shows progress via `@d-zero/dealer`'s `Lanes` (with a live percentage) instead of hanging silently for minutes, and caches the sort's output as JSON-Lines under the archive's tar-cache directory so a Ctrl-C / restart replays it instead of re-sorting.

## Test plan
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test` (2191 passed, 5 skipped)
- [x] Manually verified against an 11 GB / ~1.5M-URL archive: viewer starts without OOM, progress is visible, and a Ctrl-C + restart reuses the cached sort instead of re-sorting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
