### PR TITLE
feat(crawler): add phase 6-a ref and header staging tables

### DIFF
--- a/packages/@nitpicker/crawler/src/archive/create-phase6a-ref-tables.ts
+++ b/packages/@nitpicker/crawler/src/archive/create-phase6a-ref-tables.ts
@@ -1,0 +1,198 @@
+import type { Knex } from 'knex';
+
+/**
+ * Creates the 10 Phase 6-A staging tables (issue #190) and their index.
+ *
+ * These are the ref / header dictionary tables that will become the durable
+ * write-model under Phase 6-B/6-C/…: `url_refs`, `content_type_refs`,
+ * `text_refs`, `json_refs`, `blob_refs`, `header_name_refs`,
+ * `header_value_refs`, `header_sets` (+ `idx_header_sets_stable`),
+ * `header_set_entries`, `header_flags`.
+ *
+ * The DDL is shared between fresh-archive provisioning ({@link initSchema}
+ * calls this on a brand new DB) and the lazy migration path
+ * ({@link migratePhase6ARefTables} calls it on archives created before this
+ * branch shipped). Keeping the schema in one function guarantees that both
+ * origin points produce byte-identical tables — a divergence would silently
+ * break the Phase 6-B population step, which relies on the exact UNIQUE
+ * constraints and CHECK clauses declared here.
+ *
+ * Hash columns store 32-byte BLAKE3 as `BLOB`, matching `page_html_blobs.hash`.
+ * `blob_refs` intentionally uses a regular integer rowid PK (unlike
+ * `page_html_blobs`) because `image_items.src_blob_id` (added in Phase 6-C)
+ * needs a plain integer FK and auto-increment is incompatible with WITHOUT
+ * ROWID; `UNIQUE(hash)` still enforces content-addressable dedup.
+ *
+ * `header_set_entries` is WITHOUT ROWID because the composite PK
+ * `(header_set_id, name_id, occurrence)` is the natural clustering key and
+ * every column is small — the same reasoning as `page_html_blobs`.
+ *
+ * `header_sets.raw_json_hash` is a temporary column used only by the
+ * Phase 6-D migration for lookups against the legacy `responseHeaders` JSON;
+ * a follow-up cleanup migration drops it after Phase 6-H merges.
+ * @param instance - The Knex query builder instance connected to the database.
+ */
+export async function createPhase6ARefTables(instance: Knex): Promise<void> {
+	// Unified URL dictionary. `url` is the natural unique key; scheme /
+	// host / port / path / query_hash / fragment are pre-decomposed columns
+	// filled by the Phase 6-B population step so filters like
+	// "same-host resources" avoid re-parsing the URL string per row.
+	// `query_hash` is BLAKE3 of the raw query string — storing query strings
+	// inline would defeat dedup on tracker URLs.
+	await instance.raw(`
+		CREATE TABLE url_refs (
+			id         INTEGER PRIMARY KEY,
+			url        TEXT NOT NULL UNIQUE,
+			scheme     TEXT,
+			host       TEXT,
+			port       INTEGER,
+			path       TEXT,
+			query_hash BLOB,
+			fragment   TEXT
+		)
+	`);
+
+	// Content-type dictionary. `raw` is the wire value (unique).
+	// `normalized` is the lowercase MIME with parameters stripped;
+	// `category` is the coarse bucket used by viewer filters ('html',
+	// 'image', ...). Populated in Phase 6-B by `classifyContentType`.
+	await instance.raw(`
+		CREATE TABLE content_type_refs (
+			id         INTEGER PRIMARY KEY,
+			raw        TEXT NOT NULL UNIQUE,
+			normalized TEXT NOT NULL,
+			category   TEXT NOT NULL
+		)
+	`);
+
+	// Short-text dictionary. Covers anchor textContent, image alt, page
+	// meta strings, and dom_path. The `(hash, text)` composite UNIQUE
+	// mirrors `analysis_text_refs` so lookups prefix-seek on `hash`. The
+	// two dictionaries stay separate because merging would require
+	// re-keying every existing `analysis_violations` row (out of Phase
+	// 6-A scope; revisit in a later cleanup pass).
+	await instance.raw(`
+		CREATE TABLE text_refs (
+			id   INTEGER PRIMARY KEY,
+			hash BLOB NOT NULL,
+			text TEXT NOT NULL,
+			UNIQUE(hash, text)
+		)
+	`);
+
+	// Large JSON payload dictionary. Covers `pages.meta_extras`. `hash` is
+	// BLAKE3 of the pre-compression JSON bytes; `codec` records whether
+	// `json_text` is zstd-compressed. Sizes are stored so consumers can
+	// estimate savings without decompressing.
+	await instance.raw(`
+		CREATE TABLE json_refs (
+			id          INTEGER PRIMARY KEY,
+			hash        BLOB NOT NULL UNIQUE,
+			json_text   BLOB NOT NULL,
+			codec       TEXT NOT NULL CHECK(codec IN ('zstd', 'none')),
+			size_raw    INTEGER NOT NULL,
+			size_stored INTEGER NOT NULL
+		)
+	`);
+
+	// Large binary payload dictionary. Covers `data:` URIs longer than
+	// 512 bytes attached to `<img>` src / currentSrc. Well-formed http(s)
+	// URLs virtually never exceed 512 chars, so this threshold routes all
+	// data URIs here without misclassifying URLs.
+	await instance.raw(`
+		CREATE TABLE blob_refs (
+			id          INTEGER PRIMARY KEY,
+			hash        BLOB NOT NULL UNIQUE,
+			body        BLOB NOT NULL,
+			codec       TEXT NOT NULL CHECK(codec IN ('zstd', 'none')),
+			size_raw    INTEGER NOT NULL,
+			size_stored INTEGER NOT NULL
+		)
+	`);
+
+	// Response-header decomposition tables. `responseHeaders` on the old
+	// `pages` / `resources` tables was a JSON blob whose raw hash barely
+	// deduped (99.4 % distinct on the reference archive) because volatile
+	// headers like `Date` / `ETag` / `CF-Ray` change every response. The
+	// five tables below split header sets into (name, value, occurrence)
+	// tuples so a stable-only hash can achieve real dedup, and expose the
+	// commonly-checked security flags as pre-computed booleans in
+	// `header_flags` so `checkHeaders` no longer needs a per-row LIKE
+	// scan.
+	await instance.raw(`
+		CREATE TABLE header_name_refs (
+			id   INTEGER PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE
+		)
+	`);
+
+	await instance.raw(`
+		CREATE TABLE header_value_refs (
+			id    INTEGER PRIMARY KEY,
+			hash  BLOB NOT NULL,
+			value TEXT NOT NULL,
+			UNIQUE(hash, value)
+		)
+	`);
+
+	// `raw_json_hash` is BLAKE3 of the raw `responseHeaders` JSON string
+	// exactly as stored in the old tables — kept only so the Phase 6-D
+	// migration can look up an existing `header_sets.id` without calling
+	// any SQL function (SQLite has no built-in BLAKE3). Scheduled for drop
+	// in a follow-up cleanup migration after Phase 6-H.
+	// `raw_hash` is BLAKE3 of the sorted `name=value` pairs of every
+	// header (stable + volatile); `stable_hash` is BLAKE3 of the sorted
+	// `name=value` pairs of stable headers only.
+	// Both `raw_json_hash` and `raw_hash` are UNIQUE so a JS-side upsert
+	// can guarantee dedup — duplicate raw JSON strings map to the same
+	// row and same PK.
+	// `idx_header_sets_stable` accelerates the "how many pages share this
+	// stable header profile" lookup that Phase 6-F readers use.
+	await instance.raw(`
+		CREATE TABLE header_sets (
+			id                 INTEGER PRIMARY KEY,
+			raw_json_hash      BLOB NOT NULL UNIQUE,
+			raw_hash           BLOB NOT NULL UNIQUE,
+			stable_hash        BLOB NOT NULL,
+			volatile_hash      BLOB,
+			entry_count        INTEGER NOT NULL,
+			stable_entry_count INTEGER NOT NULL
+		)
+	`);
+	await instance.raw('CREATE INDEX idx_header_sets_stable ON header_sets(stable_hash)');
+
+	// `occurrence` is the 1-based index among entries sharing the same
+	// `(header_set_id, name_id)` pair. HTTP allows a header name to appear
+	// multiple times in one response (e.g. multiple `Set-Cookie` lines);
+	// the composite PK preserves all values without truncation.
+	await instance.raw(`
+		CREATE TABLE header_set_entries (
+			header_set_id INTEGER NOT NULL REFERENCES header_sets(id),
+			name_id       INTEGER NOT NULL REFERENCES header_name_refs(id),
+			occurrence    INTEGER NOT NULL,
+			value_id      INTEGER NOT NULL REFERENCES header_value_refs(id),
+			is_volatile   INTEGER NOT NULL,
+			PRIMARY KEY(header_set_id, name_id, occurrence)
+		) WITHOUT ROWID
+	`);
+
+	// Pre-computed booleans for the security / caching header checks that
+	// `checkHeaders` currently expresses as per-row LIKE predicates over
+	// `responseHeaders`. Populated in Phase 6-B by reusing
+	// `headerPresenceExpression`'s logic so the flag rules stay in one
+	// place. `cache_policy` is a short summary string captured for display;
+	// nullable when the header is absent.
+	await instance.raw(`
+		CREATE TABLE header_flags (
+			header_set_id              INTEGER PRIMARY KEY REFERENCES header_sets(id),
+			has_csp                    INTEGER NOT NULL,
+			has_x_frame_options        INTEGER NOT NULL,
+			has_x_content_type_options INTEGER NOT NULL,
+			has_hsts                   INTEGER NOT NULL,
+			has_referrer_policy        INTEGER NOT NULL,
+			has_permissions_policy     INTEGER NOT NULL,
+			has_set_cookie             INTEGER NOT NULL,
+			cache_policy               TEXT
+		)
+	`);
+}

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -58,6 +58,7 @@ import { migrateInfoRoots } from './migrate-info-roots.js';
 import { migrateInventoryRuns } from './migrate-inventory-runs.js';
 import { migratePageErrors } from './migrate-page-errors.js';
 import { migratePagesResourcesSource } from './migrate-pages-resources-source.js';
+import { migratePhase6ARefTables } from './migrate-phase6a-ref-tables.js';
 import { redirectTable } from './redirect-table.js';
 import { resolveRedirectChain } from './resolve-redirect-chain.js';
 
@@ -2447,6 +2448,7 @@ export class Database extends EventEmitter<DatabaseEvent> {
 		await migrateAnalysisViolations(this.#instance);
 		await migratePagesResourcesSource(this.#instance);
 		await migrateInventoryRuns(this.#instance);
+		await migratePhase6ARefTables(this.#instance);
 	}
 
 	/**

--- a/packages/@nitpicker/crawler/src/archive/init-schema.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.spec.ts
@@ -23,6 +23,19 @@ describe('initSchema', () => {
 			'resources-referrers',
 			'page_html_blobs',
 			'page_html_ref',
+			// Phase 6-A staging tables (issue #190). Additive only —
+			// present on every fresh archive but not read/written by
+			// any consumer until later Phase 6 sub-issues land.
+			'url_refs',
+			'content_type_refs',
+			'text_refs',
+			'json_refs',
+			'blob_refs',
+			'header_name_refs',
+			'header_value_refs',
+			'header_sets',
+			'header_set_entries',
+			'header_flags',
 		];
 		for (const table of tables) {
 			const exists = await db.schema.hasTable(table);
@@ -151,6 +164,313 @@ describe('initSchema', () => {
 			"PRAGMA index_list('page_html_ref')",
 		);
 		expect(indexes.some((i) => i.name === 'idx_page_html_ref_hash')).toBe(true);
+
+		await db.destroy();
+	});
+
+	it('enforces UNIQUE on content_type_refs.raw', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		await db.raw(
+			"INSERT INTO content_type_refs (raw, normalized, category) VALUES ('text/html; charset=utf-8', 'text/html', 'html')",
+		);
+		await expect(
+			db.raw(
+				"INSERT INTO content_type_refs (raw, normalized, category) VALUES ('text/html; charset=utf-8', 'text/html', 'html')",
+			),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('enforces UNIQUE on header_name_refs.name and header_value_refs(hash, value)', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		await db.raw("INSERT INTO header_name_refs (name) VALUES ('content-type')");
+		await expect(
+			db.raw("INSERT INTO header_name_refs (name) VALUES ('content-type')"),
+		).rejects.toThrow();
+
+		const hash = Buffer.from('aa'.repeat(16), 'hex');
+		await db.raw('INSERT INTO header_value_refs (hash, value) VALUES (?, ?)', [
+			hash,
+			'text/html',
+		]);
+		await expect(
+			db.raw('INSERT INTO header_value_refs (hash, value) VALUES (?, ?)', [
+				hash,
+				'text/html',
+			]),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('enforces UNIQUE on header_sets.raw_json_hash and header_sets.raw_hash', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const rawJsonHashA = Buffer.from('aa'.repeat(16), 'hex');
+		const rawJsonHashB = Buffer.from('bb'.repeat(16), 'hex');
+		const rawHashA = Buffer.from('cc'.repeat(16), 'hex');
+		const rawHashB = Buffer.from('dd'.repeat(16), 'hex');
+		const stableHash = Buffer.from('ee'.repeat(16), 'hex');
+		await db.raw(
+			'INSERT INTO header_sets (raw_json_hash, raw_hash, stable_hash, entry_count, stable_entry_count) VALUES (?, ?, ?, 0, 0)',
+			[rawJsonHashA, rawHashA, stableHash],
+		);
+		await expect(
+			db.raw(
+				'INSERT INTO header_sets (raw_json_hash, raw_hash, stable_hash, entry_count, stable_entry_count) VALUES (?, ?, ?, 0, 0)',
+				[rawJsonHashA, rawHashB, stableHash],
+			),
+		).rejects.toThrow();
+		await expect(
+			db.raw(
+				'INSERT INTO header_sets (raw_json_hash, raw_hash, stable_hash, entry_count, stable_entry_count) VALUES (?, ?, ?, 0, 0)',
+				[rawJsonHashB, rawHashA, stableHash],
+			),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('creates url_refs with the expected columns and URL uniqueness', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const columns = await db.raw("PRAGMA table_info('url_refs')");
+		const names = columns.map((c: { name: string }) => c.name);
+		expect(names).toEqual([
+			'id',
+			'url',
+			'scheme',
+			'host',
+			'port',
+			'path',
+			'query_hash',
+			'fragment',
+		]);
+
+		await db.raw("INSERT INTO url_refs (url) VALUES ('https://example.com/')");
+		await expect(
+			db.raw("INSERT INTO url_refs (url) VALUES ('https://example.com/')"),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('creates text_refs with a (hash, text) composite UNIQUE', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const indexes: { name: string; unique: number }[] = await db.raw(
+			"PRAGMA index_list('text_refs')",
+		);
+		const uniqueIndexes = indexes.filter((i) => i.unique === 1);
+		expect(uniqueIndexes.length).toBeGreaterThan(0);
+
+		const hashA = Buffer.from('0123456789abcdef0123456789abcdef', 'hex');
+		const hashB = Buffer.from('fedcba9876543210fedcba9876543210', 'hex');
+		await db.raw('INSERT INTO text_refs (hash, text) VALUES (?, ?)', [hashA, 'foo']);
+		await db.raw('INSERT INTO text_refs (hash, text) VALUES (?, ?)', [hashA, 'bar']);
+		await db.raw('INSERT INTO text_refs (hash, text) VALUES (?, ?)', [hashB, 'foo']);
+		await expect(
+			db.raw('INSERT INTO text_refs (hash, text) VALUES (?, ?)', [hashA, 'foo']),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('creates blob_refs with a regular rowid PK and UNIQUE hash', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const [{ sql }] = await db.raw(
+			"SELECT sql FROM sqlite_master WHERE type='table' AND name='blob_refs'",
+		);
+		expect(sql).not.toMatch(/WITHOUT ROWID/i);
+
+		const hash = Buffer.from('00112233445566778899aabbccddeeff', 'hex');
+		const body = Buffer.from('body-bytes');
+		await db.raw(
+			"INSERT INTO blob_refs (hash, body, codec, size_raw, size_stored) VALUES (?, ?, 'none', ?, ?)",
+			[hash, body, body.length, body.length],
+		);
+		await expect(
+			db.raw(
+				"INSERT INTO blob_refs (hash, body, codec, size_raw, size_stored) VALUES (?, ?, 'none', ?, ?)",
+				[hash, body, body.length, body.length],
+			),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('rejects an invalid codec for json_refs / blob_refs', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const hash = Buffer.from('aa'.repeat(16), 'hex');
+		await expect(
+			db.raw(
+				"INSERT INTO json_refs (hash, json_text, codec, size_raw, size_stored) VALUES (?, ?, 'gzip', 0, 0)",
+				[hash, Buffer.from('{}')],
+			),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('creates header_set_entries as WITHOUT ROWID', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const [{ sql }] = await db.raw(
+			"SELECT sql FROM sqlite_master WHERE type='table' AND name='header_set_entries'",
+		);
+		expect(sql).toMatch(/WITHOUT ROWID/i);
+
+		await db.destroy();
+	});
+
+	it('creates idx_header_sets_stable on header_sets(stable_hash)', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const indexes: { name: string }[] = await db.raw("PRAGMA index_list('header_sets')");
+		expect(indexes.some((i) => i.name === 'idx_header_sets_stable')).toBe(true);
+
+		const info: { name: string }[] = await db.raw(
+			"PRAGMA index_info('idx_header_sets_stable')",
+		);
+		expect(info.map((c) => c.name)).toEqual(['stable_hash']);
+
+		await db.destroy();
+	});
+
+	it('enforces the header_set_entries FK chain when PRAGMA foreign_keys = ON', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+		// initSchema does not enable foreign_keys by itself (that lives in
+		// applyConnectionPragmas). Enable it here so the REFERENCES clauses
+		// on header_set_entries actually reject dangling parents — otherwise
+		// a typo in the FK column name would silently pass the DDL tests.
+		await db.raw('PRAGMA foreign_keys = ON');
+
+		await expect(
+			db.raw(
+				'INSERT INTO header_set_entries (header_set_id, name_id, occurrence, value_id, is_volatile) VALUES (?, ?, ?, ?, ?)',
+				[999, 1, 1, 1, 0],
+			),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('creates header_flags keyed by header_set_id', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		const columns = await db.raw("PRAGMA table_info('header_flags')");
+		const names = columns.map((c: { name: string }) => c.name);
+		expect(names).toEqual([
+			'header_set_id',
+			'has_csp',
+			'has_x_frame_options',
+			'has_x_content_type_options',
+			'has_hsts',
+			'has_referrer_policy',
+			'has_permissions_policy',
+			'has_set_cookie',
+			'cache_policy',
+		]);
+
+		await db.destroy();
+	});
+
+	it('does not modify existing pages / resources / images / anchors / resources-referrers schema', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await initSchema(db);
+
+		// Sanity check the Phase 6-A DDL did not accidentally re-declare
+		// any column on the legacy write-model tables. The exact column
+		// lists here are pinned so a future accidental additive edit
+		// (dropping a column, renaming, changing null-ability by
+		// re-creating the table) would surface as a test failure.
+		const pagesInfo = await db.raw("PRAGMA table_info('pages')");
+		const pagesColumns = pagesInfo.map((c: { name: string }) => c.name);
+		expect(pagesColumns).toContain('responseHeaders');
+		expect(pagesColumns).not.toContain('url_id');
+		expect(pagesColumns).not.toContain('header_set_id');
+
+		const resourcesInfo = await db.raw("PRAGMA table_info('resources')");
+		const resourcesColumns = resourcesInfo.map((c: { name: string }) => c.name);
+		expect(resourcesColumns).toContain('responseHeaders');
+		expect(resourcesColumns).not.toContain('url_id');
+		expect(resourcesColumns).not.toContain('header_set_id');
 
 		await db.destroy();
 	});

--- a/packages/@nitpicker/crawler/src/archive/init-schema.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.ts
@@ -1,5 +1,7 @@
 import type { Knex } from 'knex';
 
+import { createPhase6ARefTables } from './create-phase6a-ref-tables.js';
+
 /**
  * Applies the connection-level PRAGMAs that govern foreign-key enforcement
  * and BLOB-read performance. These are **per-connection** settings (libsql
@@ -69,6 +71,18 @@ export async function applyConnectionPragmas(instance: Knex): Promise<void> {
  *   from v1. zstd-compressed BLOBs keyed by SHA-256 for content-addressable
  *   dedup. WITHOUT ROWID via raw SQL because knex's schema builder cannot
  *   express it.
+ * - **Phase 6-A write-model staging tables** (issue #190, part of epic #103):
+ *   `url_refs`, `content_type_refs`, `text_refs`, `json_refs`, `blob_refs`,
+ *   `header_name_refs`, `header_value_refs`, `header_sets`,
+ *   `header_set_entries`, `header_flags`. Additive DDL only — the tables are
+ *   created on every fresh archive but remain **completely unused** by
+ *   current readers and writers. Later Phase 6-B / 6-C / … sub-issues will
+ *   populate them and migrate the consumer code paths. No existing table or
+ *   index is modified by their presence. See
+ *   {@link createPhase6ARefTables} for the DDL, column-level rationale, and
+ *   the reason `blob_refs` uses a regular rowid PK instead of WITHOUT ROWID.
+ *   Existing archives get the same tables added by
+ *   {@link migratePhase6ARefTables} at open time.
  * - **PRAGMA `page_size` and `journal_mode`** are set BEFORE any
  *   `CREATE TABLE` because SQLite only honors `page_size` changes against
  *   an empty database, and `journal_mode = WAL` is persistent. Other
@@ -452,6 +466,13 @@ export async function initSchema(instance: Knex) {
 		) WITHOUT ROWID
 	`);
 	await instance.raw('CREATE INDEX idx_page_html_ref_hash ON page_html_ref(hash)');
+
+	// Phase 6-A ref / header staging tables (issue #190).
+	// DDL + column-level rationale lives in {@link createPhase6ARefTables}
+	// so `migratePhase6ARefTables` can call the same DDL on existing
+	// archives — a divergence between the two paths would silently break
+	// the Phase 6-B population step's UNIQUE / CHECK contract.
+	await createPhase6ARefTables(instance);
 
 	// Composite covering index for the default Pages-view filter + url-ordered
 	// scan. Without it, `listPages` on a 400k-row archive runs ~15s per page

--- a/packages/@nitpicker/crawler/src/archive/migrate-phase6a-ref-tables.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-phase6a-ref-tables.spec.ts
@@ -1,0 +1,92 @@
+import knex from 'knex';
+import { describe, it, expect } from 'vitest';
+
+import { LibsqlDialect } from './libsql-dialect.js';
+import { migratePhase6ARefTables } from './migrate-phase6a-ref-tables.js';
+
+/**
+ * Simulates the shape of a pre-Phase-6A archive: only the write-model
+ * tables that predate this branch exist. Kept minimal — the migration
+ * only checks for `pages`, not the full legacy schema.
+ * @param db - Knex instance already connected to an empty in-memory DB.
+ */
+async function seedLegacyArchive(db: ReturnType<typeof knex>): Promise<void> {
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+	});
+}
+
+describe('migratePhase6ARefTables', () => {
+	const PHASE_6A_TABLES = [
+		'url_refs',
+		'content_type_refs',
+		'text_refs',
+		'json_refs',
+		'blob_refs',
+		'header_name_refs',
+		'header_value_refs',
+		'header_sets',
+		'header_set_entries',
+		'header_flags',
+	];
+
+	it('creates all 10 Phase 6-A tables on a legacy archive', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await seedLegacyArchive(db);
+
+		for (const table of PHASE_6A_TABLES) {
+			expect(await db.schema.hasTable(table), `${table} should be absent before`).toBe(
+				false,
+			);
+		}
+
+		await migratePhase6ARefTables(db);
+
+		for (const table of PHASE_6A_TABLES) {
+			expect(await db.schema.hasTable(table), `${table} should exist after`).toBe(true);
+		}
+
+		await db.destroy();
+	});
+
+	it('is idempotent (running twice does not error)', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await seedLegacyArchive(db);
+
+		await migratePhase6ARefTables(db);
+		await migratePhase6ARefTables(db);
+
+		for (const table of PHASE_6A_TABLES) {
+			expect(await db.schema.hasTable(table)).toBe(true);
+		}
+
+		await db.destroy();
+	});
+
+	it('is a no-op on an empty archive (no pages table)', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await migratePhase6ARefTables(db);
+
+		for (const table of PHASE_6A_TABLES) {
+			expect(await db.schema.hasTable(table)).toBe(false);
+		}
+
+		await db.destroy();
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/migrate-phase6a-ref-tables.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-phase6a-ref-tables.ts
@@ -1,0 +1,41 @@
+import type { Knex } from 'knex';
+
+import { createPhase6ARefTables } from './create-phase6a-ref-tables.js';
+
+/**
+ * Adds the Phase 6-A staging tables (issue #190) to archives created before
+ * this branch shipped.
+ *
+ * These are the 10 ref / header dictionary tables that will become the
+ * durable write-model under Phase 6-B/6-C/…. Fresh archives get them via
+ * `initSchema`; this migration handles the "existing archive re-opened by
+ * `crawl --append` / `--retry-failed` / analyze" path — the same pattern used
+ * by `migrateCrawlErrors`, `migrateHtmlBlobTables`, etc.
+ *
+ * The migration is intentionally table-only. It does not back-fill any data
+ * from `pages` / `resources` / `anchors` / `images` into the ref tables — that
+ * is the job of the Phase 6-B population step, which reads from the legacy
+ * tables and writes the ref rows in a single WAL transaction with `.bak`
+ * protection. This migration only guarantees the empty tables exist so
+ * consumers don't crash with `SQLITE_ERROR: no such table: url_refs`.
+ *
+ * Idempotent: presence of `url_refs` is used as the phase marker (all 10
+ * tables are created together, so any one of them can serve as the sentinel).
+ * On read-only connections the migration is skipped upstream, so this
+ * function only ever runs against writer connections.
+ * @param instance - The Knex query builder instance connected to the database.
+ */
+export async function migratePhase6ARefTables(instance: Knex): Promise<void> {
+	const hasUrlRefs = await instance.schema.hasTable('url_refs');
+	if (hasUrlRefs) {
+		return;
+	}
+	const hasPages = await instance.schema.hasTable('pages');
+	if (!hasPages) {
+		// Empty archive; the regular initSchema path will create the tables.
+		return;
+	}
+	await createPhase6ARefTables(instance);
+	// eslint-disable-next-line no-console
+	console.error('[migrate] Phase 6-A ref/header tables created');
+}


### PR DESCRIPTION
Part of #103. Implements #190.

## Summary

Adds the 10 ref / header dictionary tables defined by the write-model refactor plan as **additive DDL**. Existing tables and indexes are untouched; both old and new tables coexist after this PR merges.

Tables:

- `url_refs`, `content_type_refs`, `text_refs`, `json_refs`, `blob_refs`
- `header_name_refs`, `header_value_refs`, `header_sets`, `header_set_entries`, `header_flags`
- `idx_header_sets_stable` index on `header_sets(stable_hash)`

Fresh archives get the tables via `initSchema`. Existing archives get them via `migratePhase6ARefTables` at `Database.connect` time, mirroring the pattern used by `migrateCrawlErrors` / `migrateInventoryRuns`.

The DDL is factored into `createPhase6ARefTables` so both entry points share a single source of truth for column definitions, UNIQUE and CHECK constraints.

## Scope

- **In**: additive DDL for 10 tables + 1 migration function
- **Out**: populating the tables, migrating readers/writers, dropping legacy tables (belong to later sub-issues #191, #192, ...)

## Test plan

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] `yarn test` — 401 test files / 2941 tests pass, 5 skipped
- [x] New unit tests cover: existence of all 10 tables, UNIQUE constraints on url/name/hash/raw_json_hash/raw_hash, CHECK on codec, WITHOUT ROWID on header_set_entries, FK enforcement, index presence, header_flags column shape, and that legacy `pages`/`resources` schemas are unchanged
- [x] Migration function has dedicated spec covering fresh, idempotent, and no-op-on-empty-archive paths
