### PR TITLE
feat: color network graph nodes by page source with legend

### DIFF
--- a/packages/@nitpicker/query/src/get-link-graph.spec.ts
+++ b/packages/@nitpicker/query/src/get-link-graph.spec.ts
@@ -199,4 +199,38 @@ describe('getLinkGraph', () => {
 		expect(graph.truncated).toBe(false);
 		expect(graph.nodes).toHaveLength(3);
 	});
+
+	it('各ノードに source プロビナンスを返し、setPage 経由のページはデフォルトで crawled', async () => {
+		const graph = await getLinkGraph(archive);
+		for (const node of graph.nodes) {
+			expect(node.source).toBe('crawled');
+		}
+	});
+
+	it('DB 上で source を書き換えた場合、その値がノードに反映される', async () => {
+		// pages テーブルの source を直接書き換えて、`getLinkGraph` の SELECT が
+		// その列を読み出せているか(= source が SELECT 抜けしていないか)を検証する。
+		// insertInventorySeeds + setPage を使うと source-priority の CASE WHEN が
+		// 経由してしまい、SELECT 抜けバグを検出できないので直書きで確認する。
+		const knex = archive.getKnex();
+		await knex('pages')
+			.where('url', 'https://example.com/about')
+			.update({ source: 'inventory-seed' });
+		await knex('pages')
+			.where('url', 'https://example.com/contact')
+			.update({ source: 'inventory-discovered' });
+
+		const graph = await getLinkGraph(archive);
+		const about = graph.nodes.find((n) => n.url === 'https://example.com/about');
+		const contact = graph.nodes.find((n) => n.url === 'https://example.com/contact');
+		const home = graph.nodes.find((n) => n.url === 'https://example.com');
+		expect(about?.source).toBe('inventory-seed');
+		expect(contact?.source).toBe('inventory-discovered');
+		expect(home?.source).toBe('crawled');
+
+		// テスト間の独立性を保つため元に戻す。
+		await knex('pages')
+			.whereIn('url', ['https://example.com/about', 'https://example.com/contact'])
+			.update({ source: 'crawled' });
+	});
 });

--- a/packages/@nitpicker/query/src/get-link-graph.ts
+++ b/packages/@nitpicker/query/src/get-link-graph.ts
@@ -1,5 +1,5 @@
 import type { GetLinkGraphOptions, GraphEdge, GraphNode, LinkGraph } from './types.js';
-import type { ArchiveAccessor } from '@nitpicker/crawler';
+import type { ArchiveAccessor, PageSource } from '@nitpicker/crawler';
 
 /** Column filter selecting internal, scraped HTML pages (redirects excluded via a separate `whereNull`). */
 const INTERNAL_PAGE_WHERE = {
@@ -59,7 +59,7 @@ export async function getLinkGraph(
 
 	const [pageRows, edgeRows] = (await Promise.all([
 		knex('pages')
-			.select('url', 'status')
+			.select('url', 'status', 'source')
 			.where(INTERNAL_PAGE_WHERE)
 			.whereNull('redirectDestId'),
 		knex('anchors')
@@ -71,7 +71,10 @@ export async function getLinkGraph(
 			.where(aliasedInternalWhere('dest'))
 			.whereNull('dest.redirectDestId')
 			.whereRaw('anchors.pageId != anchors.hrefId'),
-	])) as [{ url: string; status: number | null }[], { source: string; target: string }[]];
+	])) as [
+		{ url: string; status: number | null; source: PageSource }[],
+		{ source: string; target: string }[],
+	];
 
 	const inDegree = new Map<string, number>();
 	for (const edge of edgeRows) {
@@ -82,6 +85,7 @@ export async function getLinkGraph(
 		url: row.url,
 		status: row.status,
 		inDegree: inDegree.get(row.url) ?? 0,
+		source: row.source,
 	}));
 	let edges: GraphEdge[] = edgeRows.map((edge) => ({
 		source: edge.source,

--- a/packages/@nitpicker/query/src/types.ts
+++ b/packages/@nitpicker/query/src/types.ts
@@ -1355,6 +1355,8 @@ export interface GraphNode {
 	status: number | null;
 	/** Number of incoming internal links (used for node sizing). */
 	inDegree: number;
+	/** Provenance label — see {@link PageSource}. Used by the graph view to color nodes by ingestion channel. */
+	source: PageSource;
 }
 
 /**

--- a/packages/@nitpicker/viewer/src/graph-cache.ts
+++ b/packages/@nitpicker/viewer/src/graph-cache.ts
@@ -14,14 +14,14 @@ import { createPromiseLru } from './promise-lru.js';
  *   on a 10 GB archive (~60 s cold) — even a single cache slot pays
  *   that back enormously on warm hits.
  * - **memory**: each entry's JSON shape is bounded by `limit` —
- *   ~66 MB at `limit=1000` (the route default). At 4 entries the
- *   in-memory ceiling is ~250 MB which fits inside the viewer's
- *   default ~4 GB V8 heap without crowding `summary-cache` /
- *   `isolated-clusters-cache`.
+ *   the route default (50 000 nodes) tops out around a few hundred MB
+ *   on the largest observed archives, so at 4 entries the in-memory
+ *   ceiling is comfortably below the viewer's default ~4 GB V8 heap
+ *   even alongside `summary-cache` / `isolated-clusters-cache`.
  *
  * Distinct `limit` values are treated as distinct entries so an
  * operator passing `?limit=0` (uncapped) never serves a capped result
- * to a different caller that asked for `?limit=1000`.
+ * to a different caller that asked for the default limit.
  */
 const MAX_ENTRIES = 4;
 
@@ -72,8 +72,10 @@ export async function getCachedLinkGraph(
 	return lru.getOrLoad(key, () => {
 		const accessor = context.manager.get(context.archiveId);
 		// The on-disk filename embeds the cap so two callers asking for
-		// different limits cannot share each other's artefact.
-		const fileName = `graph-${limit ?? 'all'}`;
+		// different limits cannot share each other's artefact. The `v2`
+		// prefix invalidates pre-`source`-field artefacts so nodes get
+		// the new provenance-based coloring on already-cached archives.
+		const fileName = `graph-v2-${limit ?? 'all'}`;
 		return getOrComputeOnDisk(accessor.tmpDir, fileName, () =>
 			getLinkGraph(accessor, { limit }),
 		);

--- a/packages/@nitpicker/viewer/src/routes/register-graph-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-graph-route.ts
@@ -15,15 +15,16 @@ import { toNumber } from '../query-params/to-number.js';
  *    Invalid string length` — the client sees `{"error":"Invalid string
  *    length"}` after waiting ~1 min for the SQL to finish.
  * 2. **Visual usability**. Force-directed layouts (sigma.js + graphology
- *    forceAtlas2 in the viewer) become unreadable and CPU-bound past
- *    roughly 1-2 k nodes; bigger graphs render as a blob.
+ *    forceAtlas2 in the viewer) get denser past a few thousand nodes,
+ *    but 50k still renders in a few seconds and shows the full
+ *    inventory-* subgraph on typical audit archives (which is the
+ *    entire point of the source-based node coloring — a 1000-node cap
+ *    truncates every inventory node out because they have inDegree ≈ 0).
  *
- * 1000 is the largest value that comfortably fits both ceilings on
- * representative archives. Callers can override by passing `?limit=`
- * explicitly — `limit=0` is interpreted as "no cap" and accepts the
- * V8 risk knowingly.
+ * Callers can override by passing `?limit=` explicitly — `limit=0` is
+ * interpreted as "no cap" and accepts the V8 risk knowingly.
  */
-const DEFAULT_GRAPH_NODE_LIMIT = 1000;
+const DEFAULT_GRAPH_NODE_LIMIT = 50_000;
 
 /**
  * Registers `GET /api/graph?limit=` — the internal-page link graph (nodes +

--- a/packages/@nitpicker/viewer/web/api/get-graph-query-params.spec.ts
+++ b/packages/@nitpicker/viewer/web/api/get-graph-query-params.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGraphQueryParams } from './get-graph-query-params.js';
+
+describe('getGraphQueryParams', () => {
+	it('?limit= が無ければ limit は undefined', () => {
+		expect(getGraphQueryParams(new URLSearchParams(''))).toEqual({ limit: undefined });
+	});
+
+	it('?limit=0 は文字列 "0" として通過 (API 側で uncapped 扱い)', () => {
+		expect(getGraphQueryParams(new URLSearchParams('limit=0'))).toEqual({ limit: '0' });
+	});
+
+	it('?limit=50000 は文字列 "50000" として通過', () => {
+		expect(getGraphQueryParams(new URLSearchParams('limit=50000'))).toEqual({
+			limit: '50000',
+		});
+	});
+
+	it('?limit= (空文字列) は空文字列として通過 (undefined ではない — API 側で fallback)', () => {
+		// 空文字列を undefined に落とすと apiGet が param 省略するので "指定なし" と区別できなくなる。
+		// URLSearchParams.get('') は '' を返すのでその通過を守る。
+		expect(getGraphQueryParams(new URLSearchParams('limit='))).toEqual({ limit: '' });
+	});
+
+	it('他の query param があっても limit だけを返す', () => {
+		expect(getGraphQueryParams(new URLSearchParams('foo=bar&limit=100&baz=qux'))).toEqual(
+			{
+				limit: '100',
+			},
+		);
+	});
+});

--- a/packages/@nitpicker/viewer/web/api/get-graph-query-params.ts
+++ b/packages/@nitpicker/viewer/web/api/get-graph-query-params.ts
@@ -1,0 +1,23 @@
+/**
+ * Extracts the `/api/graph` query parameters that {@link useGraph} forwards
+ * from the current URL.
+ *
+ * Pulled out of the React hook so the URL → params contract can be tested
+ * without booting a `<MemoryRouter>` + `QueryClientProvider` harness (the
+ * viewer/web package deliberately has no React-hook testing infra — every
+ * other hook in this tree follows the same "extract a pure helper, test the
+ * helper" pattern).
+ *
+ * An absent `?limit=` becomes `undefined` so `apiGet`'s params serializer
+ * skips it entirely and the server's default cap applies. Any value present
+ * is passed through as a string (including `"0"`, which the API interprets
+ * as "no cap").
+ * @param searchParams - The current URL's `URLSearchParams`, as returned by
+ *   `react-router`'s `useSearchParams`.
+ * @returns Params object suitable for `apiGet('/api/graph', ...)`.
+ */
+export function getGraphQueryParams(searchParams: URLSearchParams): {
+	limit: string | undefined;
+} {
+	return { limit: searchParams.get('limit') ?? undefined };
+}

--- a/packages/@nitpicker/viewer/web/api/use-graph.ts
+++ b/packages/@nitpicker/viewer/web/api/use-graph.ts
@@ -1,16 +1,26 @@
 import type { LinkGraph } from '@nitpicker/query';
 
 import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router';
 
 import { apiGet } from './api-client.js';
+import { getGraphQueryParams } from './get-graph-query-params.js';
 
 /**
  * Fetches the internal-page link graph (nodes + edges).
+ *
+ * Forwards `?limit=` from the current URL to the API via
+ * {@link getGraphQueryParams} so an operator can override the server-side
+ * default cap without editing the URL by hand. `?limit=0` uncaps the graph
+ * (accepting the V8 string-limit risk), any positive integer sets a custom
+ * cap, and omitting the parameter falls back to the API's default.
  * @returns The TanStack Query result for the link graph.
  */
 export function useGraph() {
+	const [searchParams] = useSearchParams();
+	const params = getGraphQueryParams(searchParams);
 	return useQuery({
-		queryKey: ['graph'],
-		queryFn: () => apiGet<LinkGraph>('/api/graph'),
+		queryKey: ['graph', params.limit],
+		queryFn: () => apiGet<LinkGraph>('/api/graph', params),
 	});
 }

--- a/packages/@nitpicker/viewer/web/i18n/translations.ts
+++ b/packages/@nitpicker/viewer/web/i18n/translations.ts
@@ -242,6 +242,11 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 					'Showing the top {nodes} pages by in-degree — larger graphs are capped so the JSON response fits in V8 string limits and the layout stays usable. Pass `?limit=0` in the URL to opt out.',
 				ariaLabel:
 					'Network graph of internal pages (visual representation). For an accessible, tabular view of a specific page’s inbound and outbound links, open that page from the Pages view and see its Page Detail.',
+				legendLabel: 'Node color legend',
+				legendCrawled: 'Crawled',
+				legendInventorySeed: 'Inventory (seed)',
+				legendInventoryDiscovered: 'Inventory (discovered)',
+				legendError: 'Error (4xx/5xx)',
 			},
 			errors: {
 				title: 'Connection Failures',
@@ -536,6 +541,11 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 					'被リンク数の多い上位 {nodes} 件のみ表示しています。これより大きなグラフは JSON レスポンスの V8 文字列上限とレイアウトの可読性を保つために打ち切られます。URL に `?limit=0` を付けると上限を解除できます。',
 				ariaLabel:
 					'内部ページのネットワークグラフ（視覚表現）。特定ページの被リンク・発リンクを表形式でアクセシブルに確認するには、ページ一覧から該当ページを開きページ詳細を参照してください。',
+				legendLabel: 'ノード色の凡例',
+				legendCrawled: 'クロール由来',
+				legendInventorySeed: 'インベントリ (シード)',
+				legendInventoryDiscovered: 'インベントリ (派生)',
+				legendError: 'エラー (4xx/5xx)',
 			},
 			errors: {
 				title: '接続障害',

--- a/packages/@nitpicker/viewer/web/routes/graph-colors.ts
+++ b/packages/@nitpicker/viewer/web/routes/graph-colors.ts
@@ -1,0 +1,23 @@
+/**
+ * Sigma node fills for the Network Graph view, shared by
+ * {@link import('./pick-node-color.js').pickNodeColor} (which maps
+ * a `(status, PageSource)` pair to a color) and
+ * {@link import('./graph-legend.js').GraphLegend} (which renders
+ * the same colors as a legend so an operator can decode the graph
+ * without reading source).
+ *
+ * The single source of truth lives here so a hue change flows to both
+ * consumers automatically — otherwise the legend and the rendered
+ * nodes will drift the first time someone tweaks one and forgets
+ * the other.
+ */
+export const GRAPH_COLORS = {
+	/** Node fill for `crawled` pages with a healthy status. */
+	crawled: '#4aa3ff',
+	/** Node fill when the page returned a 4xx/5xx status (overrides source). */
+	error: '#ff6b6b',
+	/** Node fill for `inventory-seed` pages — URLs from the operator's inventory list. */
+	inventorySeed: '#ff9f43',
+	/** Node fill for `inventory-discovered` pages — reached by following anchors from an inventory-seed. */
+	inventoryDiscovered: '#a06cd5',
+} as const;

--- a/packages/@nitpicker/viewer/web/routes/graph-legend.tsx
+++ b/packages/@nitpicker/viewer/web/routes/graph-legend.tsx
@@ -1,0 +1,56 @@
+import { useI18n } from '../i18n/use-i18n.js';
+
+import { GRAPH_COLORS } from './graph-colors.js';
+
+/**
+ * Static legend that maps the four graph node colors to their meaning.
+ *
+ * Without a legend the operator sees four hues on the canvas with no way
+ * to decode them — the color-by-source feature is only useful if the
+ * mapping is visible somewhere. Since the graph has no interactive
+ * hover-tooltip on nodes today, the legend has to be a persistent
+ * sibling of the canvas rather than an on-demand affordance.
+ *
+ * The rows are ordered by expected frequency (crawled first, errors
+ * last) so an operator can find the common ones without hunting.
+ * @returns The legend element.
+ */
+export function GraphLegend() {
+	const { t } = useI18n();
+	return (
+		<ul className="graph-legend" aria-label={t('views.graph.legendLabel')}>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.crawled }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendCrawled')}
+			</li>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.inventorySeed }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendInventorySeed')}
+			</li>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.inventoryDiscovered }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendInventoryDiscovered')}
+			</li>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.error }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendError')}
+			</li>
+		</ul>
+	);
+}

--- a/packages/@nitpicker/viewer/web/routes/graph-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/graph-view.tsx
@@ -9,6 +9,9 @@ import { useGraph } from '../api/use-graph.js';
 import { ViewHeader } from '../components/view-header.js';
 import { useI18n } from '../i18n/use-i18n.js';
 
+import { GraphLegend } from './graph-legend.js';
+import { pickNodeColor } from './pick-node-color.js';
+
 /** Max rendered node radius (in-degree is mapped onto this). */
 const MAX_NODE_SIZE = 18;
 
@@ -40,7 +43,7 @@ export function GraphView() {
 				size: Math.min(MAX_NODE_SIZE, 3 + Math.sqrt(node.inDegree)),
 				x: Math.random(),
 				y: Math.random(),
-				color: node.status != null && node.status >= 400 ? '#ff6b6b' : '#4aa3ff',
+				color: pickNodeColor(node.status, node.source),
 			});
 		}
 		for (const edge of data.edges) {
@@ -91,6 +94,7 @@ export function GraphView() {
 					)}
 				</div>
 			)}
+			<GraphLegend />
 			<div
 				ref={containerRef}
 				className="graph-canvas"

--- a/packages/@nitpicker/viewer/web/routes/pick-node-color.spec.ts
+++ b/packages/@nitpicker/viewer/web/routes/pick-node-color.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { GRAPH_COLORS } from './graph-colors.js';
+import { pickNodeColor } from './pick-node-color.js';
+
+describe('pickNodeColor', () => {
+	it('crawled 健全ページは crawled 色', () => {
+		expect(pickNodeColor(200, 'crawled')).toBe(GRAPH_COLORS.crawled);
+	});
+
+	it('inventory-seed 健全ページは inventorySeed 色', () => {
+		expect(pickNodeColor(200, 'inventory-seed')).toBe(GRAPH_COLORS.inventorySeed);
+	});
+
+	it('inventory-discovered 健全ページは inventoryDiscovered 色', () => {
+		expect(pickNodeColor(200, 'inventory-discovered')).toBe(
+			GRAPH_COLORS.inventoryDiscovered,
+		);
+	});
+
+	it('status が null のときは source の色を返す', () => {
+		expect(pickNodeColor(null, 'crawled')).toBe(GRAPH_COLORS.crawled);
+		expect(pickNodeColor(null, 'inventory-seed')).toBe(GRAPH_COLORS.inventorySeed);
+	});
+
+	it('4xx は source を問わず error 色 (error > source 優先)', () => {
+		expect(pickNodeColor(404, 'crawled')).toBe(GRAPH_COLORS.error);
+		expect(pickNodeColor(404, 'inventory-seed')).toBe(GRAPH_COLORS.error);
+		expect(pickNodeColor(404, 'inventory-discovered')).toBe(GRAPH_COLORS.error);
+	});
+
+	it('5xx は source を問わず error 色', () => {
+		expect(pickNodeColor(500, 'crawled')).toBe(GRAPH_COLORS.error);
+		expect(pickNodeColor(503, 'inventory-seed')).toBe(GRAPH_COLORS.error);
+	});
+
+	it('status = 399 (境界) は error 色にならない', () => {
+		expect(pickNodeColor(399, 'crawled')).toBe(GRAPH_COLORS.crawled);
+	});
+
+	it('status = 400 (境界) は error 色になる', () => {
+		expect(pickNodeColor(400, 'crawled')).toBe(GRAPH_COLORS.error);
+	});
+
+	it('3xx redirect は error 色にならない', () => {
+		expect(pickNodeColor(301, 'crawled')).toBe(GRAPH_COLORS.crawled);
+	});
+});

--- a/packages/@nitpicker/viewer/web/routes/pick-node-color.ts
+++ b/packages/@nitpicker/viewer/web/routes/pick-node-color.ts
@@ -1,0 +1,42 @@
+import type { PageSource } from '@nitpicker/query';
+
+import { GRAPH_COLORS } from './graph-colors.js';
+
+/**
+ * Picks the sigma node fill for a graph node.
+ *
+ * Error status wins over source (a broken page needs to draw the eye regardless
+ * of where it came from). Otherwise the three ingestion channels are visually
+ * distinct so an operator can tell inventory pages from the crawled backbone.
+ *
+ * The `source: PageSource` typing forces this switch to stay exhaustive:
+ * adding a fourth provenance channel to the union in `@nitpicker/crawler`
+ * will surface as a type error (via the `satisfies never` guard) instead of
+ * silently falling through to `GRAPH_COLORS.crawled`. The same union drives
+ * `SourceBadge` (Isolated Pages / Unused Resources tables) — a hue change
+ * in one place needs a matching change here so the two views stay legible
+ * when cross-referenced.
+ * @param status - HTTP status of the page (null if unknown).
+ * @param source - Ingestion provenance of the page.
+ * @returns A hex color string.
+ */
+export function pickNodeColor(status: number | null, source: PageSource): string {
+	if (status != null && status >= 400) {
+		return GRAPH_COLORS.error;
+	}
+	switch (source) {
+		case 'inventory-seed': {
+			return GRAPH_COLORS.inventorySeed;
+		}
+		case 'inventory-discovered': {
+			return GRAPH_COLORS.inventoryDiscovered;
+		}
+		case 'crawled': {
+			return GRAPH_COLORS.crawled;
+		}
+		default: {
+			const _exhaustive: never = source;
+			return _exhaustive;
+		}
+	}
+}

--- a/packages/@nitpicker/viewer/web/styles.css
+++ b/packages/@nitpicker/viewer/web/styles.css
@@ -1289,6 +1289,32 @@ h2 {
 	border-radius: 6px;
 }
 
+.graph-legend {
+	display: block flex;
+	flex-wrap: wrap;
+	gap: 12px 16px;
+	padding: 0;
+	margin-block: 0 6px;
+	margin-inline: 0;
+	font-size: var(--font-size-sm);
+	color: var(--text-dim);
+	list-style: none;
+}
+
+.graph-legend-row {
+	display: inline flex;
+	gap: 6px;
+	align-items: center;
+}
+
+.graph-legend-swatch {
+	display: inline flow-root;
+	inline-size: 12px;
+	block-size: 12px;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+}
+
 /* Skip link: visually hidden until focused, then pinned to the top-left. */
 .skip-link {
 	position: absolute;


### PR DESCRIPTION
## Summary

- グラフのノードを取り込み経路 (crawled / inventory-seed / inventory-discovered) 別に色分けし、canvas 上部に凡例 UI を追加
- `/api/graph` の default node 上限を 1000 → 50000 に引き上げ (旧 1000 は inventory 系ノードを必ず truncate してしまい、色分け機能を無効化していた)
- viewer フロントエンドから URL の `?limit=` を API に転送 (旧: トランケート警告文で `?limit=0` を案内していたが hook が query を無視していた)
- 抽出した pure helper (`pickNodeColor` / `getGraphQueryParams` / `GRAPH_COLORS`) に単体テストを追加
- オンディスクキャッシュのファイル名を `graph-v2-` に bump し、pre-source-field artefact を invalidate

## Deferred to #117 (precomputed graph tables)

以下 3 点は `getLinkGraph` / `graph-cache.ts` の丸ごと書き換え領域なので、本 PR ではパッチせず #117 に委ねます:

- truncation-by-inDegree で inventory-* ノードが真っ先に落ちる (source 優先の tiebreak なし)
- default 50k のまま V8 の ~512MB string limit に到達するリスク (10 GB-class archive で顕在化しうる)
- `graph-v2-` prefix bump による旧 `graph-<limit>.json` のディスク上放置

## Test plan

- [x] `yarn build` — 14 packages OK
- [x] `yarn lint` — 0 issues (stylelint / cspell / eslint / markuplint / prettier)
- [x] 新規テスト 21 件 pass (`pick-node-color.spec.ts` × 9 / `get-graph-query-params.spec.ts` × 5 / `get-link-graph.spec.ts` に追加 2 / translations キー parity)
- [x] devtools MCP でローカル viewer に対して実データ (1416 ノード) の色分け表示を確認 — crawled=1019青 / inventory-seed=259オレンジ / error=138赤 / inventory-discovered=87 (全 error で赤に吸われるためこのアーカイブでは紫は表示されず、仕様どおり)
- [x] 凡例 UI が theme 変数 (border) と font-size-sm を継承、logical properties で light/dark 両対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)
