### PR TITLE
feat(crawler): populate Phase 6-B ref and header tables (#191)

### DIFF
--- a/packages/@nitpicker/crawler/src/archive/phase6b/classify-content-type.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/classify-content-type.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+
+import { classifyContentType } from './classify-content-type.js';
+
+describe('classifyContentType', () => {
+	it('classifies HTML from an exact MIME', () => {
+		expect(classifyContentType('text/html')).toBe('html');
+		expect(classifyContentType('application/xhtml+xml')).toBe('html');
+	});
+
+	it('classifies xhtml+xml as html not xml (rule-order precedence)', () => {
+		expect(classifyContentType('application/xhtml+xml')).toBe('html');
+	});
+
+	it('classifies image/svg+xml as image not xml (rule-order precedence)', () => {
+		expect(classifyContentType('image/svg+xml')).toBe('image');
+	});
+
+	it('strips parameters before classifying', () => {
+		expect(classifyContentType('text/html; charset=utf-8')).toBe('html');
+		expect(classifyContentType('application/json; charset=utf-8')).toBe('json');
+	});
+
+	it('lower-cases before matching', () => {
+		expect(classifyContentType('TEXT/HTML')).toBe('html');
+		expect(classifyContentType('Application/JSON')).toBe('json');
+	});
+
+	it('classifies via prefix rules', () => {
+		expect(classifyContentType('image/png')).toBe('image');
+		expect(classifyContentType('image/webp')).toBe('image');
+		expect(classifyContentType('audio/mpeg')).toBe('audio');
+		expect(classifyContentType('video/mp4')).toBe('video');
+		expect(classifyContentType('font/woff2')).toBe('font');
+		expect(classifyContentType('application/font-woff')).toBe('font');
+	});
+
+	it('classifies via suffix rules', () => {
+		expect(classifyContentType('application/ld+json')).toBe('json');
+		expect(classifyContentType('application/atom+xml')).toBe('xml');
+	});
+
+	it('returns unknown for null / empty / blank', () => {
+		expect(classifyContentType(null)).toBe('unknown');
+		expect(classifyContentType('')).toBe('unknown');
+		expect(classifyContentType('   ')).toBe('unknown');
+		expect(classifyContentType(';charset=utf-8')).toBe('unknown');
+	});
+
+	it('returns other for unmatched MIMEs', () => {
+		expect(classifyContentType('application/vnd.custom.thing')).toBe('other');
+	});
+
+	it('treats text/csv as csv not text (rule-order precedence)', () => {
+		expect(classifyContentType('text/csv')).toBe('csv');
+	});
+
+	it('treats generic text/* as text (fall-through prefix rule)', () => {
+		expect(classifyContentType('text/plain')).toBe('text');
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/classify-content-type.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/classify-content-type.ts
@@ -1,0 +1,57 @@
+import type { Phase6BContentTypeCategory } from './types.js';
+
+import { PHASE_6B_CONTENT_TYPE_RULES } from './content-type-rules.js';
+
+/**
+ * Classifies a raw HTTP `Content-Type` header value into the same coarse
+ * categories used by the viewer read-model. The rule table in
+ * `content-type-rules.ts` is evaluated in declared order and the first
+ * matching rule wins (so `application/xhtml+xml` → `html` and
+ * `image/svg+xml` → `image`).
+ *
+ * `null` / empty / whitespace-only inputs map to `'unknown'`; MIMEs that
+ * fail every rule map to `'other'`. Behaviour mirrors
+ * `@nitpicker/query`'s `classifyContentType`; see the type header of
+ * `content-type-rules.ts` for the drift-warning contract.
+ * @param contentType - The raw `Content-Type` header value, or `null`.
+ * @returns The canonical category label.
+ */
+export function classifyContentType(
+	contentType: string | null,
+): Phase6BContentTypeCategory {
+	if (contentType == null) {
+		return 'unknown';
+	}
+	const semi = contentType.indexOf(';');
+	const head = (semi === -1 ? contentType : contentType.slice(0, semi))
+		.trim()
+		.toLowerCase();
+	if (head === '') {
+		return 'unknown';
+	}
+	for (const rule of PHASE_6B_CONTENT_TYPE_RULES) {
+		for (const matcher of rule.matchers) {
+			switch (matcher.kind) {
+				case 'exact': {
+					if (head === matcher.value) {
+						return rule.category;
+					}
+					break;
+				}
+				case 'prefix': {
+					if (head.startsWith(matcher.value)) {
+						return rule.category;
+					}
+					break;
+				}
+				case 'suffix': {
+					if (head.endsWith(matcher.value)) {
+						return rule.category;
+					}
+					break;
+				}
+			}
+		}
+	}
+	return 'other';
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/compute-content-hash.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/compute-content-hash.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeContentHash } from './compute-content-hash.js';
+
+describe('computeContentHash', () => {
+	it('produces a 32-byte Buffer', () => {
+		const hash = computeContentHash('hello');
+		expect(hash).toBeInstanceOf(Buffer);
+		expect(hash.byteLength).toBe(32);
+	});
+
+	it('is deterministic for equal string input', () => {
+		const a = computeContentHash('same input');
+		const b = computeContentHash('same input');
+		expect(a.equals(b)).toBe(true);
+	});
+
+	it('differs across distinct inputs', () => {
+		const a = computeContentHash('a');
+		const b = computeContentHash('b');
+		expect(a.equals(b)).toBe(false);
+	});
+
+	it('treats string and equivalent Uint8Array identically', () => {
+		const value = 'utf-8 test 日本語';
+		const fromString = computeContentHash(value);
+		const fromBytes = computeContentHash(Buffer.from(value, 'utf8'));
+		expect(fromString.equals(fromBytes)).toBe(true);
+	});
+
+	it('matches known SHA-256 vector', () => {
+		// Well-known SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+		expect(computeContentHash('').toString('hex')).toBe(
+			'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+		);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/compute-content-hash.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/compute-content-hash.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Computes a 32-byte content hash for a UTF-8 string or raw byte buffer.
+ *
+ * The Phase 6 plan (`docs/write-model-refactor-plan.md`) refers to the hash
+ * columns on `text_refs`, `json_refs`, `blob_refs`, `header_value_refs`, and
+ * `header_sets` as "BLAKE3" hashes. This implementation uses **SHA-256** for
+ * three reasons:
+ *
+ * 1. **No new dependency**. `@nitpicker/crawler`'s dependency list is small
+ *    and CLAUDE.md's supply-chain rules discourage adding a hash-only lib.
+ * 2. **Consistency**. `page_html_blobs.hash` — the existing content-addressable
+ *    dictionary — is SHA-256 (see `Database.#writePageHtmlBlob`). Using the
+ *    same algorithm keeps every content-hash column in the archive on one
+ *    scheme.
+ * 3. **Column contract is length-only**. Every Phase 6-A hash column is typed
+ *    `BLOB` (32 bytes when populated). SHA-256 satisfies that contract.
+ *
+ * If BLAKE3 is later required for throughput, this single function is the only
+ * edit point — every callsite in Phase 6-B routes through here.
+ * @param value - Value to hash. `string` inputs are encoded as UTF-8.
+ * @returns 32-byte hash as a `Buffer`, ready to insert into a `BLOB` column.
+ */
+export function computeContentHash(value: string | Uint8Array): Buffer {
+	const bytes = typeof value === 'string' ? Buffer.from(value, 'utf8') : value;
+	return createHash('sha256').update(bytes).digest();
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/compute-header-flags.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/compute-header-flags.spec.ts
@@ -1,0 +1,126 @@
+import type { HeaderEntry } from './types.js';
+
+import { describe, it, expect } from 'vitest';
+
+import { computeHeaderFlags } from './compute-header-flags.js';
+
+/**
+ * Builds a `HeaderEntry` shaped for the tests below. Volatility defaults
+ * to `false` — flag detection does not depend on it, only on the name.
+ * @param name - Lower-cased header name.
+ * @param value - Header value.
+ * @returns Entry with `occurrence=1` and `isVolatile=false`.
+ */
+function entry(name: string, value: string): HeaderEntry {
+	return { name, value, occurrence: 1, isVolatile: false };
+}
+
+describe('computeHeaderFlags (header-flags-computation)', () => {
+	it('returns all zeros and null cache_policy for an empty set', () => {
+		const flags = computeHeaderFlags([]);
+		expect(flags).toEqual({
+			has_csp: 0,
+			has_x_frame_options: 0,
+			has_x_content_type_options: 0,
+			has_hsts: 0,
+			has_referrer_policy: 0,
+			has_permissions_policy: 0,
+			has_set_cookie: 0,
+			cache_policy: null,
+		});
+	});
+
+	it('detects content-security-policy', () => {
+		const flags = computeHeaderFlags([
+			entry('content-security-policy', "default-src 'self'"),
+		]);
+		expect(flags.has_csp).toBe(1);
+	});
+
+	it('detects x-frame-options', () => {
+		expect(
+			computeHeaderFlags([entry('x-frame-options', 'DENY')]).has_x_frame_options,
+		).toBe(1);
+	});
+
+	it('detects x-content-type-options', () => {
+		expect(
+			computeHeaderFlags([entry('x-content-type-options', 'nosniff')])
+				.has_x_content_type_options,
+		).toBe(1);
+	});
+
+	it('detects strict-transport-security', () => {
+		expect(
+			computeHeaderFlags([entry('strict-transport-security', 'max-age=31536000')])
+				.has_hsts,
+		).toBe(1);
+	});
+
+	it('detects referrer-policy', () => {
+		expect(
+			computeHeaderFlags([entry('referrer-policy', 'no-referrer')]).has_referrer_policy,
+		).toBe(1);
+	});
+
+	it('detects permissions-policy', () => {
+		expect(
+			computeHeaderFlags([entry('permissions-policy', 'geolocation=()')])
+				.has_permissions_policy,
+		).toBe(1);
+	});
+
+	it('detects set-cookie', () => {
+		expect(computeHeaderFlags([entry('set-cookie', 'session=abc')]).has_set_cookie).toBe(
+			1,
+		);
+	});
+
+	it('captures cache_policy value', () => {
+		expect(computeHeaderFlags([entry('cache-control', 'no-store')]).cache_policy).toBe(
+			'no-store',
+		);
+	});
+
+	it('joins multi-value cache-control entries', () => {
+		const flags = computeHeaderFlags([
+			{ name: 'cache-control', value: 'no-store', occurrence: 1, isVolatile: false },
+			{ name: 'cache-control', value: 'no-cache', occurrence: 2, isVolatile: false },
+		]);
+		expect(flags.cache_policy).toBe('no-store, no-cache');
+	});
+
+	it('does not false-positive on values that mention header names', () => {
+		// A referrer-policy value whose text is "content-security-policy" must
+		// NOT fire has_csp — the flag is computed from names (dict keys), not
+		// substring scans across values.
+		const flags = computeHeaderFlags([
+			entry('referrer-policy', 'content-security-policy'),
+		]);
+		expect(flags.has_csp).toBe(0);
+		expect(flags.has_referrer_policy).toBe(1);
+	});
+
+	it('detects a full security-headers bundle in one pass', () => {
+		const flags = computeHeaderFlags([
+			entry('content-security-policy', "default-src 'self'"),
+			entry('x-frame-options', 'DENY'),
+			entry('x-content-type-options', 'nosniff'),
+			entry('strict-transport-security', 'max-age=31536000'),
+			entry('referrer-policy', 'no-referrer'),
+			entry('permissions-policy', 'geolocation=()'),
+			entry('set-cookie', 'session=abc'),
+			entry('cache-control', 'no-store'),
+		]);
+		expect(flags).toEqual({
+			has_csp: 1,
+			has_x_frame_options: 1,
+			has_x_content_type_options: 1,
+			has_hsts: 1,
+			has_referrer_policy: 1,
+			has_permissions_policy: 1,
+			has_set_cookie: 1,
+			cache_policy: 'no-store',
+		});
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/compute-header-flags.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/compute-header-flags.ts
@@ -1,0 +1,72 @@
+import type { HeaderEntry, HeaderFlagsRow } from './types.js';
+
+/**
+ * Computes the {@link HeaderFlagsRow} for one decomposed header set.
+ *
+ * Each `has_*` boolean is a straight "is this name present" check on the
+ * decomposed entries — semantically equivalent to `checkHeaders` /
+ * `headerPresenceExpression` in `@nitpicker/query`, but expressed in JS
+ * over the already-normalized `HeaderEntry.name` (lower-cased) so no
+ * `LIKE` pattern is needed. This drops the JSON-key-shape false-positive
+ * risk that `headerPresenceExpression`'s SQL guard against (a value that
+ * happens to mention another header's name won't fire here because names
+ * come from the parsed JSON's KEYS, not from a substring scan).
+ * @param entries - Every decomposed entry for one `header_sets` row.
+ * @returns The row-shaped flags to insert into `header_flags`.
+ */
+export function computeHeaderFlags(entries: readonly HeaderEntry[]): HeaderFlagsRow {
+	const cachePolicies: string[] = [];
+	let hasCsp = false;
+	let hasXFrameOptions = false;
+	let hasXContentTypeOptions = false;
+	let hasHsts = false;
+	let hasReferrerPolicy = false;
+	let hasPermissionsPolicy = false;
+	let hasSetCookie = false;
+	for (const entry of entries) {
+		switch (entry.name) {
+			case 'content-security-policy': {
+				hasCsp = true;
+				break;
+			}
+			case 'x-frame-options': {
+				hasXFrameOptions = true;
+				break;
+			}
+			case 'x-content-type-options': {
+				hasXContentTypeOptions = true;
+				break;
+			}
+			case 'strict-transport-security': {
+				hasHsts = true;
+				break;
+			}
+			case 'referrer-policy': {
+				hasReferrerPolicy = true;
+				break;
+			}
+			case 'permissions-policy': {
+				hasPermissionsPolicy = true;
+				break;
+			}
+			case 'set-cookie': {
+				hasSetCookie = true;
+				break;
+			}
+			case 'cache-control': {
+				cachePolicies.push(entry.value);
+				break;
+			}
+		}
+	}
+	return {
+		has_csp: hasCsp ? 1 : 0,
+		has_x_frame_options: hasXFrameOptions ? 1 : 0,
+		has_x_content_type_options: hasXContentTypeOptions ? 1 : 0,
+		has_hsts: hasHsts ? 1 : 0,
+		has_referrer_policy: hasReferrerPolicy ? 1 : 0,
+		has_permissions_policy: hasPermissionsPolicy ? 1 : 0,
+		has_set_cookie: hasSetCookie ? 1 : 0,
+		cache_policy: cachePolicies.length === 0 ? null : cachePolicies.join(', '),
+	};
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/content-type-rules.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/content-type-rules.ts
@@ -1,0 +1,156 @@
+import type { Phase6BContentTypeCategory } from './types.js';
+
+/**
+ * Single matcher slot for a Content-Type rule. See `@nitpicker/query`'s
+ * `content-type-rules.ts` for the wider design discussion — this file only
+ * carries the subset required for JS-side classification (no SQL builders,
+ * which live in `@nitpicker/query`).
+ */
+type Matcher =
+	| { readonly kind: 'exact'; readonly value: string }
+	| { readonly kind: 'prefix'; readonly value: string }
+	| { readonly kind: 'suffix'; readonly value: string };
+
+/**
+ * One row of the classification table: attach a category to a set of
+ * matchers, all of which OR together.
+ */
+interface Rule {
+	readonly category: Exclude<Phase6BContentTypeCategory, 'other' | 'unknown'>;
+	readonly matchers: readonly Matcher[];
+}
+
+/**
+ * Content-Type classification rules, evaluated in array order — first match
+ * wins. Kept in lock-step with the source-of-truth table in
+ * `packages/@nitpicker/query/src/content-type-rules.ts`. Do not reorder
+ * without also editing the query-side copy (a drift would misroute
+ * `image/svg+xml` between `image` and `xml`, etc.).
+ *
+ * A future cleanup can lift the rule table into `@d-zero/shared` so both
+ * `@nitpicker/crawler` and `@nitpicker/query` import a single source of
+ * truth; that migration is out of Phase 6-B's scope.
+ */
+export const PHASE_6B_CONTENT_TYPE_RULES: readonly Rule[] = [
+	{
+		category: 'html',
+		matchers: [
+			{ kind: 'exact', value: 'text/html' },
+			{ kind: 'exact', value: 'application/xhtml+xml' },
+		],
+	},
+	{
+		category: 'pdf',
+		matchers: [{ kind: 'exact', value: 'application/pdf' }],
+	},
+	{
+		category: 'csv',
+		matchers: [
+			{ kind: 'exact', value: 'text/csv' },
+			{ kind: 'exact', value: 'application/csv' },
+			{ kind: 'exact', value: 'application/x-csv' },
+			{ kind: 'exact', value: 'text/tab-separated-values' },
+			{ kind: 'exact', value: 'text/tsv' },
+		],
+	},
+	{
+		category: 'word',
+		matchers: [
+			{ kind: 'exact', value: 'application/msword' },
+			{
+				kind: 'exact',
+				value: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+			},
+		],
+	},
+	{
+		category: 'excel',
+		matchers: [
+			{ kind: 'exact', value: 'application/vnd.ms-excel' },
+			{
+				kind: 'exact',
+				value: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+			},
+		],
+	},
+	{
+		category: 'powerpoint',
+		matchers: [
+			{ kind: 'exact', value: 'application/vnd.ms-powerpoint' },
+			{
+				kind: 'exact',
+				value:
+					'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+			},
+		],
+	},
+	{
+		category: 'image',
+		matchers: [{ kind: 'prefix', value: 'image/' }],
+	},
+	{
+		category: 'audio',
+		matchers: [{ kind: 'prefix', value: 'audio/' }],
+	},
+	{
+		category: 'video',
+		matchers: [{ kind: 'prefix', value: 'video/' }],
+	},
+	{
+		category: 'font',
+		matchers: [
+			{ kind: 'prefix', value: 'font/' },
+			{ kind: 'prefix', value: 'application/font-' },
+			{ kind: 'exact', value: 'application/vnd.ms-fontobject' },
+		],
+	},
+	{
+		category: 'css',
+		matchers: [{ kind: 'exact', value: 'text/css' }],
+	},
+	{
+		category: 'javascript',
+		matchers: [
+			{ kind: 'exact', value: 'text/javascript' },
+			{ kind: 'exact', value: 'application/javascript' },
+			{ kind: 'exact', value: 'application/x-javascript' },
+			{ kind: 'exact', value: 'application/ecmascript' },
+		],
+	},
+	{
+		category: 'json',
+		matchers: [
+			{ kind: 'exact', value: 'application/json' },
+			{ kind: 'exact', value: 'application/yaml' },
+			{ kind: 'exact', value: 'application/x-yaml' },
+			{ kind: 'exact', value: 'text/yaml' },
+			{ kind: 'exact', value: 'text/x-yaml' },
+			{ kind: 'suffix', value: '+json' },
+			{ kind: 'suffix', value: '+yaml' },
+		],
+	},
+	{
+		category: 'xml',
+		matchers: [
+			{ kind: 'exact', value: 'application/xml' },
+			{ kind: 'exact', value: 'text/xml' },
+			{ kind: 'suffix', value: '+xml' },
+		],
+	},
+	{
+		category: 'archive',
+		matchers: [
+			{ kind: 'exact', value: 'application/zip' },
+			{ kind: 'exact', value: 'application/gzip' },
+			{ kind: 'exact', value: 'application/x-gzip' },
+			{ kind: 'exact', value: 'application/x-tar' },
+			{ kind: 'exact', value: 'application/x-7z-compressed' },
+			{ kind: 'exact', value: 'application/x-rar-compressed' },
+			{ kind: 'exact', value: 'application/octet-stream' },
+		],
+	},
+	{
+		category: 'text',
+		matchers: [{ kind: 'prefix', value: 'text/' }],
+	},
+] as const;

--- a/packages/@nitpicker/crawler/src/archive/phase6b/data-uri-url-refs-limit.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/data-uri-url-refs-limit.ts
@@ -1,0 +1,15 @@
+/**
+ * Threshold above which a `data:` URI is treated as a `blob_refs` payload
+ * rather than a `url_refs` URL. Shared between {@link ./populate-url-refs.ts}
+ * (which excludes `> LIMIT` data URIs from `url_refs`) and
+ * {@link ./populate-blob-refs.ts} (which routes them to `blob_refs`).
+ *
+ * The two populators MUST agree on this constant — a mismatch creates a
+ * routing hole where URIs of the disputed length land in neither table.
+ * Keeping the value here as a single-file export makes drift impossible.
+ *
+ * 512 was chosen because well-formed http(s) URLs virtually never exceed
+ * 512 characters in practice, while the smallest observed data URIs are
+ * ~600 bytes.
+ */
+export const DATA_URI_URL_REFS_LIMIT = 512;

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.spec.ts
@@ -1,0 +1,45 @@
+// cSpell:ignore Csvg Fsvg
+import { describe, it, expect } from 'vitest';
+
+import { decodeDataUri } from './decode-data-uri.js';
+
+describe('decodeDataUri', () => {
+	it('decodes base64 data URIs', () => {
+		const uri = 'data:image/png;base64,SGVsbG8='; // 'Hello'
+		const out = decodeDataUri(uri);
+		expect(out).not.toBeNull();
+		expect(out!.bytes.toString('utf8')).toBe('Hello');
+	});
+
+	it('decodes percent-encoded data URIs', () => {
+		const uri = 'data:image/svg+xml,%3Csvg%3E%3C%2Fsvg%3E';
+		const out = decodeDataUri(uri);
+		expect(out).not.toBeNull();
+		expect(out!.bytes.toString('utf8')).toBe('<svg></svg>');
+	});
+
+	it('accepts empty payloads', () => {
+		expect(decodeDataUri('data:,')!.bytes.byteLength).toBe(0);
+		expect(decodeDataUri('data:image/png;base64,')!.bytes.byteLength).toBe(0);
+	});
+
+	it('returns null for non-data URIs', () => {
+		expect(decodeDataUri('https://example.com/foo.png')).toBeNull();
+		expect(decodeDataUri('mailto:x@example.com')).toBeNull();
+	});
+
+	it('returns null for malformed data URIs (no comma)', () => {
+		expect(decodeDataUri('data:image/png;base64_no_comma')).toBeNull();
+	});
+
+	it('returns null for malformed percent encoding', () => {
+		expect(decodeDataUri('data:image/svg+xml,%GG')).toBeNull();
+	});
+
+	it('preserves arbitrary binary bytes in non-base64 percent-encoded payload', () => {
+		const uri = 'data:application/octet-stream,%FF%00%C3%A9';
+		const out = decodeDataUri(uri);
+		expect(out).not.toBeNull();
+		expect([...out!.bytes]).toEqual([0xff, 0x00, 0xc3, 0xa9]);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.spec.ts
@@ -40,6 +40,10 @@ describe('decodeDataUri', () => {
 		const uri = 'data:application/octet-stream,%FF%00%C3%A9';
 		const out = decodeDataUri(uri);
 		expect(out).not.toBeNull();
-		expect([...out!.bytes]).toEqual([0xff, 0x00, 0xc3, 0xa9]);
+		// Decimals rather than hex to sidestep the local prettier vs
+		// unicorn/number-literal-case conflict — prettier lowercases hex
+		// letters, unicorn demands uppercase. 255=0xFF, 0=0x00, 195=0xC3,
+		// 169=0xA9.
+		expect([...out!.bytes]).toEqual([255, 0, 195, 169]);
 	});
 });

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.ts
@@ -1,0 +1,130 @@
+import type { DecodedDataUri } from './types.js';
+
+/**
+ * Attempts to decode a `data:...` URI into its raw payload bytes.
+ *
+ * Supports the two encoding forms in RFC 2397:
+ *
+ * - `data:<mime>;base64,<base64-bytes>` — the base64 tail is decoded via
+ *   `Buffer.from(..., 'base64')`.
+ * - `data:<mime>,<percent-encoded-bytes>` — the tail is percent-decoded
+ *   via `decodeURIComponent(...)`, then re-encoded as UTF-8. This form is
+ *   commonly used for SVG data URIs.
+ *
+ * Returns `null` on any parse / decode failure so the caller can skip the
+ * value without aborting the whole `blob_refs` population step. A single
+ * malformed data URI in a 470 K-row archive should not halt the migration
+ * — the raw `url` string is still preserved in the source `images` row.
+ * @param value - Raw column value; may or may not start with `data:`.
+ * @returns Decoded bytes, or `null` when the value isn't a data URI or
+ *   can't be decoded.
+ */
+export function decodeDataUri(value: string): DecodedDataUri | null {
+	if (!value.startsWith('data:')) {
+		return null;
+	}
+	const commaIndex = value.indexOf(',');
+	if (commaIndex === -1) {
+		return null;
+	}
+	const header = value.slice(5, commaIndex);
+	const payload = value.slice(commaIndex + 1);
+	try {
+		if (/;\s*base64$/i.test(header)) {
+			// `Buffer.from(..., 'base64')` silently strips characters outside
+			// the base64 alphabet — a malformed payload decodes to garbage
+			// instead of throwing. Validate the alphabet + padding shape
+			// first so callers can distinguish "successfully decoded" from
+			// "silently corrupted" and get the promised `null` on malformed
+			// input.
+			if (!isValidBase64(payload)) {
+				return null;
+			}
+			const bytes = Buffer.from(payload, 'base64');
+			return { bytes };
+		}
+		return { bytes: percentDecodeToBytes(payload) };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Standard base64 alphabet + padding, plus one common URL-safe variant
+ * that occasionally appears in `data:` URIs even though RFC 2397 says
+ * only the standard alphabet. `-` / `_` are the URL-safe substitutes
+ * for `+` / `/`.
+ */
+const BASE64_ALPHABET_RE = /^[\w+/-]*={0,2}$/;
+
+/**
+ * Validates whether a base64 payload is well-formed enough that
+ * `Buffer.from(payload, 'base64')` won't need to silently strip
+ * characters. Whitespace-tolerant (RFC 2045 permits internal
+ * whitespace in base64 line-wrapped output).
+ * @param payload - Base64 payload (everything after `,` in the data URI).
+ * @returns `true` when the payload contains only valid base64 characters
+ *   + optional trailing padding.
+ */
+function isValidBase64(payload: string): boolean {
+	const stripped = payload.replaceAll(/\s+/g, '');
+	if (stripped === '') {
+		return true;
+	}
+	if (!BASE64_ALPHABET_RE.test(stripped)) {
+		return false;
+	}
+	// base64 chunks group by 4 characters — a well-formed payload has
+	// length ≡ 0 (mod 4) once padding is applied. Padding-less trailing
+	// chunks of length 2 or 3 are also accepted (Node's decoder tolerates
+	// missing `=`), but length 1 or a padding-only chunk is malformed.
+	const remainder = stripped.length % 4;
+	if (remainder === 1) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Percent-decodes a data-URI payload byte-by-byte, avoiding the round
+ * through `decodeURIComponent` → UTF-8 re-encode that mangles arbitrary
+ * binary payloads (e.g. a `%FF` byte becomes a JS string of code
+ * point U+00FF, then re-encodes to `[0xC3, 0xBF]` — the byte value
+ * changes). RFC 2397's non-base64 form treats the payload as octets,
+ * not as a UTF-8 string, so an octet-preserving decode is the correct
+ * inverse.
+ * @param payload - Raw payload text (everything after the `,`).
+ * @returns Payload bytes.
+ * @throws {URIError} If a `%` escape is malformed (via `URIError`
+ *   propagation from `Buffer.from(hex, 'hex')`); caller catches.
+ */
+function percentDecodeToBytes(payload: string): Buffer {
+	const chunks: Buffer[] = [];
+	let i = 0;
+	while (i < payload.length) {
+		const ch = payload.codePointAt(i)!;
+		if (ch === 0x25 /* % */) {
+			if (i + 2 >= payload.length) {
+				throw new URIError('truncated % escape');
+			}
+			const hex = payload.slice(i + 1, i + 3);
+			if (!/^[\da-f]{2}$/i.test(hex)) {
+				throw new URIError('invalid % escape');
+			}
+			chunks.push(Buffer.from(hex, 'hex'));
+			i += 3;
+			continue;
+		}
+		if (ch > 0x7f) {
+			// A non-ASCII code point in a percent-encoded payload is
+			// unusual (browsers percent-encode outbound), but WHATWG
+			// tolerates it — encode as UTF-8 to preserve the character.
+			chunks.push(Buffer.from(payload[i]!, 'utf8'));
+			i += 1;
+			continue;
+		}
+		chunks.push(Buffer.from([ch]));
+		i += 1;
+	}
+	return Buffer.concat(chunks);
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decode-data-uri.ts
@@ -115,7 +115,7 @@ function percentDecodeToBytes(payload: string): Buffer {
 			i += 3;
 			continue;
 		}
-		if (ch > 0x7f) {
+		if (ch > 127 /* 0x7F, ASCII high-bit boundary */) {
 			// A non-ASCII code point in a percent-encoded payload is
 			// unusual (browsers percent-encode outbound), but WHATWG
 			// tolerates it — encode as UTF-8 to preserve the character.

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decompose-header-set.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decompose-header-set.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeContentHash } from './compute-content-hash.js';
+import { decomposeHeaderSet } from './decompose-header-set.js';
+
+describe('decomposeHeaderSet (header-set-decomposition)', () => {
+	it('returns null for null / empty / no-op inputs', () => {
+		expect(decomposeHeaderSet(null)).toBeNull();
+		expect(decomposeHeaderSet('')).toBeNull();
+		expect(decomposeHeaderSet('null')).toBeNull();
+		expect(decomposeHeaderSet('{}')).toBeNull();
+	});
+
+	it('returns null for malformed JSON', () => {
+		expect(decomposeHeaderSet('{not-json')).toBeNull();
+		expect(decomposeHeaderSet('[]')).toBeNull();
+		expect(decomposeHeaderSet('"a-string"')).toBeNull();
+	});
+
+	it('lower-cases header names', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({ 'Content-Type': 'text/html', 'X-Foo': 'bar' }),
+		);
+		expect(out).not.toBeNull();
+		expect(out!.entries.map((entry) => entry.name)).toEqual(['content-type', 'x-foo']);
+	});
+
+	it('sorts entries by (name, occurrence)', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({
+				'z-last': 'z',
+				'a-first': '1',
+			}),
+		);
+		expect(out!.entries.map((entry) => entry.name)).toEqual(['a-first', 'z-last']);
+	});
+
+	it('expands array values (multiple same-name headers)', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({
+				'set-cookie': ['session=abc', 'csrf=xyz'],
+				'content-type': 'text/html',
+			}),
+		);
+		expect(out).not.toBeNull();
+		expect(out!.entryCount).toBe(3);
+		const cookieEntries = out!.entries.filter((e) => e.name === 'set-cookie');
+		expect(cookieEntries.map((e) => e.occurrence)).toEqual([1, 2]);
+		expect(cookieEntries.map((e) => e.value)).toEqual(['session=abc', 'csrf=xyz']);
+	});
+
+	it('marks known volatile headers as volatile', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({
+				'content-type': 'text/html',
+				date: 'Wed, 21 Oct 2015 07:28:00 GMT',
+				etag: 'W/"abc"',
+			}),
+		);
+		const byName = new Map(out!.entries.map((e) => [e.name, e.isVolatile]));
+		expect(byName.get('content-type')).toBe(false);
+		expect(byName.get('date')).toBe(true);
+		expect(byName.get('etag')).toBe(true);
+	});
+
+	it('produces distinct raw_hash vs stable_hash when volatile headers exist', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({
+				'content-type': 'text/html',
+				date: 'Wed, 21 Oct 2015 07:28:00 GMT',
+			}),
+		);
+		expect(out!.rawHash.equals(out!.stableHash)).toBe(false);
+		expect(out!.volatileHash).not.toBeNull();
+	});
+
+	it('has null volatile_hash and equal stable/raw hashes when only stable headers exist', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({
+				'content-type': 'text/html',
+				'cache-control': 'no-store',
+			}),
+		);
+		expect(out!.volatileHash).toBeNull();
+		expect(out!.rawHash.equals(out!.stableHash)).toBe(true);
+	});
+
+	it('stable_hash is invariant to insertion order', () => {
+		const a = decomposeHeaderSet(
+			JSON.stringify({ 'content-type': 'text/html', 'cache-control': 'no-store' }),
+		);
+		const b = decomposeHeaderSet(
+			JSON.stringify({ 'cache-control': 'no-store', 'content-type': 'text/html' }),
+		);
+		expect(a!.stableHash.equals(b!.stableHash)).toBe(true);
+	});
+
+	it('stable_hash is invariant to volatile-header changes', () => {
+		const a = decomposeHeaderSet(
+			JSON.stringify({
+				'content-type': 'text/html',
+				date: 'Wed, 21 Oct 2015 07:28:00 GMT',
+			}),
+		);
+		const b = decomposeHeaderSet(
+			JSON.stringify({
+				'content-type': 'text/html',
+				date: 'Thu, 22 Oct 2015 07:28:00 GMT',
+			}),
+		);
+		expect(a!.stableHash.equals(b!.stableHash)).toBe(true);
+		// but raw_hash differs
+		expect(a!.rawHash.equals(b!.rawHash)).toBe(false);
+	});
+
+	it('stable_hash trims value whitespace so leading/trailing space does not fork dedup', () => {
+		const a = decomposeHeaderSet(JSON.stringify({ 'content-type': 'text/html' }));
+		const b = decomposeHeaderSet(JSON.stringify({ 'content-type': '  text/html  ' }));
+		expect(a!.stableHash.equals(b!.stableHash)).toBe(true);
+	});
+
+	it('rawJsonHash hashes the exact raw string', () => {
+		const raw = JSON.stringify({ a: 'b' });
+		const out = decomposeHeaderSet(raw);
+		expect(out!.rawJsonHash.equals(computeContentHash(raw))).toBe(true);
+	});
+
+	it('counts entries correctly with multi-value headers', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({
+				'set-cookie': ['a=1', 'b=2', 'c=3'],
+				'content-type': 'text/html',
+			}),
+		);
+		expect(out!.entryCount).toBe(4);
+		// set-cookie is volatile, content-type is stable
+		expect(out!.stableEntryCount).toBe(1);
+	});
+
+	it('drops null / undefined values in arrays', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({ 'set-cookie': ['a=1', null, 'b=2'] }),
+		);
+		expect(out!.entryCount).toBe(2);
+	});
+
+	it('assigns unique occurrence ordinals when JSON has duplicate keys differing only in case', () => {
+		// Non-conforming JSON that Object.entries iterates in insertion order.
+		// Both keys lowercase to 'cookie'; without a per-name occurrence
+		// counter, both would land at occurrence=1 and collide on the
+		// header_set_entries composite PK.
+		const raw = '{"Cookie":"a=1","cookie":["b=2","c=3"]}';
+		const out = decomposeHeaderSet(raw);
+		expect(out).not.toBeNull();
+		const cookieEntries = out!.entries.filter((e) => e.name === 'cookie');
+		expect(cookieEntries).toHaveLength(3);
+		expect(cookieEntries.map((e) => e.occurrence)).toEqual([1, 2, 3]);
+		expect(cookieEntries.map((e) => e.value)).toEqual(['a=1', 'b=2', 'c=3']);
+	});
+
+	it('skips non-string values instead of coercing to "[object Object]"', () => {
+		const out = decomposeHeaderSet(
+			JSON.stringify({
+				'content-type': 'text/html',
+				'x-bad-object': { nested: 'value' },
+				'x-bad-number': 42,
+				'x-bad-array': ['ok', { bad: 'x' }],
+			}),
+		);
+		expect(out!.entryCount).toBe(2);
+		const kept = out!.entries.map((e) => e.name);
+		expect(kept.toSorted()).toEqual(['content-type', 'x-bad-array']);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decompose-header-set.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decompose-header-set.ts
@@ -1,0 +1,165 @@
+import type { DecomposedHeaderSet, HeaderEntry } from './types.js';
+
+import { computeContentHash } from './compute-content-hash.js';
+import { isVolatileHeader } from './header-stability.js';
+
+/**
+ * Parses one raw `responseHeaders` JSON string and produces the derived
+ * data shape required to insert into `header_sets`, `header_set_entries`,
+ * and `header_flags`.
+ *
+ * Behaviour:
+ *
+ * - `null` / `""` / `"null"` / `"{}"` / non-object JSON → returns `null`.
+ *   The caller sets `header_set_id = null` on the referring row.
+ * - Multiple values per header name (JSON arrays, e.g.
+ *   `{ "set-cookie": ["a=1", "b=2"] }`) become multiple
+ *   {@link HeaderEntry} rows with `occurrence` ordinals 1, 2, ... The
+ *   composite PK on `header_set_entries` `(header_set_id, name_id,
+ *   occurrence)` guarantees no truncation.
+ * - Names are lower-cased. Values are trimmed of whitespace only in the
+ *   sorted-hash construction; the raw value is preserved verbatim in
+ *   the emitted `HeaderEntry.value` (and hence in `header_value_refs`).
+ *   Trimming inside hash construction lets `content-type: text/html`
+ *   and `content-type:  text/html ` dedup to one stable set.
+ * - Sort order for hashing is `(name, occurrence)` in binary form —
+ *   deterministic regardless of the input JSON's insertion order or
+ *   how the JSON serializer arranged keys.
+ * @param rawJson - The raw JSON string exactly as stored in
+ *   `pages.responseHeaders` / `resources.responseHeaders`.
+ * @returns Decomposed shape, or `null` when the row has no meaningful
+ *   header set.
+ */
+export function decomposeHeaderSet(rawJson: string | null): DecomposedHeaderSet | null {
+	if (rawJson == null || rawJson === '' || rawJson === 'null' || rawJson === '{}') {
+		return null;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawJson);
+	} catch {
+		return null;
+	}
+	if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		return null;
+	}
+
+	const entries: HeaderEntry[] = [];
+	// `occurrence` runs per (lower-cased name) across ALL sources for that
+	// name, so duplicate JSON keys that differ only in case
+	// (`{"Cookie":"a=1", "cookie":"b=2"}` — non-conforming but legal JSON,
+	// and the crawler stores whatever puppeteer hands it) don't collide on
+	// (name_id, occurrence). Without this counter the second entry would
+	// land at occurrence=1 too, violating the `header_set_entries` PK and
+	// silently getting dropped by INSERT OR IGNORE while `entry_count`
+	// still counted it.
+	const occurrenceByName = new Map<string, number>();
+	for (const [rawName, rawValue] of Object.entries(parsed)) {
+		const name = rawName.toLowerCase();
+		const volatile = isVolatileHeader(name);
+		const nextOccurrence = (): number => {
+			const next = (occurrenceByName.get(name) ?? 0) + 1;
+			occurrenceByName.set(name, next);
+			return next;
+		};
+		if (Array.isArray(rawValue)) {
+			for (const one of rawValue) {
+				if (typeof one !== 'string') {
+					continue;
+				}
+				entries.push({
+					name,
+					value: one,
+					occurrence: nextOccurrence(),
+					isVolatile: volatile,
+				});
+			}
+			continue;
+		}
+		if (typeof rawValue !== 'string') {
+			// parseResponseHeaders's stored shape is `Record<string, string |
+			// string[] | undefined>`, but hand-edited or non-conforming
+			// archives could smuggle in a nested object / number / boolean
+			// — coercing via `String()` would produce "[object Object]" and
+			// pollute `header_value_refs` with a garbage dictionary entry.
+			// Skipping is the conservative choice; the source row's raw
+			// JSON is still preserved via `raw_json_hash`.
+			continue;
+		}
+		entries.push({
+			name,
+			value: rawValue,
+			occurrence: nextOccurrence(),
+			isVolatile: volatile,
+		});
+	}
+
+	if (entries.length === 0) {
+		return null;
+	}
+
+	entries.sort((a, b) => {
+		if (a.name < b.name) return -1;
+		if (a.name > b.name) return 1;
+		return a.occurrence - b.occurrence;
+	});
+
+	// Canonicalize every entry exactly once, then partition the strings —
+	// prior version canonicalized each stable entry twice (once in the
+	// all-entries pass, once in the stable pass) and each volatile entry
+	// twice likewise, which becomes measurable on large archives where a
+	// single response can carry a couple of dozen entries.
+	const canonicalStrings = entries.map(canonicalize);
+	const stableCanonical: string[] = [];
+	const volatileCanonical: string[] = [];
+	let stableEntryCount = 0;
+	for (const [i, entry] of entries.entries()) {
+		if (entry.isVolatile) {
+			volatileCanonical.push(canonicalStrings[i]!);
+		} else {
+			stableCanonical.push(canonicalStrings[i]!);
+			stableEntryCount += 1;
+		}
+	}
+
+	const rawJsonHash = computeContentHash(rawJson);
+	const rawHash = computeContentHash(canonicalStrings.join('\n'));
+	// A response with only volatile headers (tracker endpoints that return
+	// just `Date` / `Set-Cookie` / `Age`) hashes to `computeContentHash('')`
+	// — the canonical "empty stable profile" hash. All all-volatile
+	// responses cluster under this sentinel, which is the intended
+	// semantic (same empty stable profile = same cluster), and Phase 6-A's
+	// DDL declares `stable_hash BLOB NOT NULL` so a `null` sentinel is not
+	// available even if we wanted one. Consumers that need to distinguish
+	// "empty stable set" from "populated stable set" should key off
+	// `stable_entry_count === 0` on the same row, not off the hash.
+	const stableHash = computeContentHash(stableCanonical.join('\n'));
+	const volatileHash =
+		volatileCanonical.length === 0
+			? null
+			: computeContentHash(volatileCanonical.join('\n'));
+
+	return {
+		rawJsonHash,
+		rawHash,
+		stableHash,
+		volatileHash,
+		entries,
+		entryCount: entries.length,
+		stableEntryCount,
+	};
+}
+
+/**
+ * Serializes one entry into the canonical `name/occurrence=value` form
+ * used inside the hash construction. The trailing occurrence keeps
+ * multi-value headers distinguishable while still letting single-value
+ * ones dedup naturally. Values are trimmed so surrounding whitespace
+ * does not fork the dedup key.
+ * @param entry - One decomposed header entry.
+ * @returns Canonical string joined into the hash pre-image.
+ */
+function canonicalize(entry: HeaderEntry): string {
+	return `${entry.name}/${entry.occurrence}=${entry.value.trim()}`;
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decompose-url.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decompose-url.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeContentHash } from './compute-content-hash.js';
+import { decomposeUrl } from './decompose-url.js';
+
+describe('decomposeUrl', () => {
+	it('extracts every component from a canonical https URL', () => {
+		const out = decomposeUrl('https://Example.COM:8443/a/b?q=1#frag');
+		expect(out.scheme).toBe('https');
+		expect(out.host).toBe('example.com');
+		expect(out.port).toBe(8443);
+		expect(out.path).toBe('/a/b');
+		expect(out.fragment).toBe('frag');
+		expect(out.query_hash).not.toBeNull();
+		expect(out.query_hash!.equals(computeContentHash('q=1'))).toBe(true);
+	});
+
+	it('returns null port for scheme-default ports', () => {
+		expect(decomposeUrl('https://example.com/').port).toBeNull();
+		expect(decomposeUrl('http://example.com/').port).toBeNull();
+	});
+
+	it('returns null query_hash / fragment when absent', () => {
+		const out = decomposeUrl('https://example.com/foo');
+		expect(out.query_hash).toBeNull();
+		expect(out.fragment).toBeNull();
+	});
+
+	it('returns empty-column shape for unparseable URLs', () => {
+		const out = decomposeUrl('not-a-url');
+		expect(out).toEqual({
+			scheme: null,
+			host: null,
+			port: null,
+			path: null,
+			query_hash: null,
+			fragment: null,
+		});
+	});
+
+	it('lower-cases hostname', () => {
+		expect(decomposeUrl('HTTPS://EXAMPLE.COM/').host).toBe('example.com');
+	});
+
+	it('handles URLs without authority (mailto)', () => {
+		const out = decomposeUrl('mailto:user@example.com');
+		expect(out.scheme).toBe('mailto');
+		expect(out.host).toBeNull();
+		expect(out.port).toBeNull();
+	});
+
+	it('handles data URIs and leaves path null so the base64 tail does not pollute url_refs.path', () => {
+		const out = decomposeUrl('data:image/png;base64,iVBORw0KGgoAAAA=');
+		expect(out.scheme).toBe('data');
+		expect(out.host).toBeNull();
+		expect(out.path).toBeNull();
+	});
+
+	it('leaves path null for blob: and javascript: schemes as well', () => {
+		expect(decomposeUrl('blob:https://example.com/abc-def').path).toBeNull();
+		expect(decomposeUrl('javascript:void(0)').path).toBeNull();
+	});
+
+	it('preserves path for regular http/https URLs', () => {
+		expect(decomposeUrl('https://example.com/some/nested/path').path).toBe(
+			'/some/nested/path',
+		);
+	});
+
+	it('deduplicates identical query strings via query_hash', () => {
+		const a = decomposeUrl('https://example.com/foo?a=1&b=2');
+		const b = decomposeUrl('https://example.com/bar?a=1&b=2');
+		expect(a.query_hash!.equals(b.query_hash!)).toBe(true);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/decompose-url.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/decompose-url.ts
@@ -1,0 +1,76 @@
+import type { DecomposedUrl } from './types.js';
+
+import { computeContentHash } from './compute-content-hash.js';
+
+/**
+ * URL schemes whose "pathname" is really an in-band opaque payload
+ * (base64-encoded image bytes, javascript source, blob URL fragment,
+ * etc.) rather than a routing key. For these schemes we leave
+ * `DecomposedUrl.path` as `null` so the indexed `url_refs.path` column
+ * does not balloon with per-URL opaque tails and defeat the dedup goal.
+ */
+const OPAQUE_PATH_SCHEMES: ReadonlySet<string> = new Set([
+	'data',
+	'blob',
+	'javascript',
+	'about',
+]);
+
+/**
+ * Extracts `scheme` / `host` / `port` / `path` / `query_hash` / `fragment`
+ * columns from a URL string for `url_refs` population.
+ *
+ * Parsing is done via WHATWG `new URL(...)`. URLs that fail to parse (e.g.
+ * a malformed href scraped from the wild) still round-trip through
+ * `url_refs` — the natural key is the raw `url` string — but every
+ * decomposed column becomes `null` so filters that JOIN on `host` or
+ * `scheme` cleanly skip malformed rows instead of falsely matching.
+ *
+ * `port` is only populated when explicit in the URL. `new URL(...)`
+ * normalises the scheme's default port away (`https://example.com:443/` →
+ * `url.port === ''`), so we never synthesise a default. Two rows differing
+ * only by explicit vs implicit default port must not deduplicate anyway —
+ * `url_refs.url` (the raw string) is the natural key, not the decomposed
+ * columns.
+ *
+ * `query_hash` is the 32-byte content hash of the query string with the
+ * leading `?` stripped. Storing the raw query would defeat dedup on
+ * tracker URLs whose per-request keys explode dictionary size.
+ * @param url - Raw URL string (may be any WHATWG-parseable form, or malformed).
+ * @returns Every column that goes into `url_refs` alongside the raw URL.
+ */
+export function decomposeUrl(url: string): DecomposedUrl {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return {
+			scheme: null,
+			host: null,
+			port: null,
+			path: null,
+			query_hash: null,
+			fragment: null,
+		};
+	}
+
+	const scheme = parsed.protocol.slice(0, -1) || null;
+	const host = parsed.hostname === '' ? null : parsed.hostname.toLowerCase();
+	const port = parsed.port === '' ? null : Number.parseInt(parsed.port, 10);
+	const rawSearch = parsed.search.startsWith('?')
+		? parsed.search.slice(1)
+		: parsed.search;
+	const query_hash = rawSearch === '' ? null : computeContentHash(rawSearch);
+	const fragment = parsed.hash === '' ? null : parsed.hash.slice(1);
+	const path =
+		scheme !== null && OPAQUE_PATH_SCHEMES.has(scheme) ? null : parsed.pathname;
+
+	return {
+		scheme,
+		host,
+		port: port !== null && Number.isFinite(port) ? port : null,
+		path,
+		query_hash,
+		fragment,
+	};
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/header-stability.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/header-stability.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+
+import { isVolatileHeader } from './header-stability.js';
+import { VOLATILE_HEADER_NAMES } from './volatile-header-names.js';
+
+describe('isVolatileHeader', () => {
+	it('classifies known volatile headers as volatile', () => {
+		expect(isVolatileHeader('Date')).toBe(true);
+		expect(isVolatileHeader('etag')).toBe(true);
+		expect(isVolatileHeader('CF-Ray')).toBe(true);
+		expect(isVolatileHeader('Set-Cookie')).toBe(true);
+	});
+
+	it('classifies known stable headers as not-volatile', () => {
+		expect(isVolatileHeader('Content-Type')).toBe(false);
+		expect(isVolatileHeader('Strict-Transport-Security')).toBe(false);
+		expect(isVolatileHeader('cache-control')).toBe(false);
+	});
+
+	it('treats unknown headers as stable (safer default)', () => {
+		expect(isVolatileHeader('X-Made-Up-Header')).toBe(false);
+	});
+
+	it('is case-insensitive', () => {
+		expect(isVolatileHeader('DATE')).toBe(true);
+		expect(isVolatileHeader('date')).toBe(true);
+		expect(isVolatileHeader('Date')).toBe(true);
+	});
+});
+
+describe('VOLATILE_HEADER_NAMES', () => {
+	it('contains lower-cased entries only', () => {
+		for (const name of VOLATILE_HEADER_NAMES) {
+			expect(name).toBe(name.toLowerCase());
+		}
+	});
+
+	it('includes the plan-mandated volatile headers', () => {
+		const expected = [
+			'date',
+			'expires',
+			'last-modified',
+			'etag',
+			'age',
+			'via',
+			'x-cache',
+			'cf-ray',
+			'x-request-id',
+			'set-cookie',
+			'server-timing',
+			'x-amz-request-id',
+		];
+		for (const name of expected) {
+			expect(VOLATILE_HEADER_NAMES.has(name), `${name} missing`).toBe(true);
+		}
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/header-stability.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/header-stability.ts
@@ -1,0 +1,24 @@
+import { VOLATILE_HEADER_NAMES } from './volatile-header-names.js';
+
+/**
+ * Classifies a header name as volatile (excluded from `stable_hash`) or
+ * stable (included). Names are compared case-insensitively (lower-cased
+ * before lookup). Names not in {@link VOLATILE_HEADER_NAMES} default to
+ * **stable** — see the docs on that constant for why this direction is
+ * the safer default.
+ *
+ * The plan (`docs/write-model-refactor-plan.md` §Stable / Volatile
+ * Classification) names the stable list explicitly (`content-type`,
+ * `content-length`, `cache-control`, `content-security-policy`,
+ * `x-frame-options`, `x-content-type-options`, `strict-transport-
+ * security`, `referrer-policy`, `permissions-policy`, `server`, `vary`,
+ * `location`); we deliberately do NOT enumerate that set at runtime —
+ * every non-volatile header is stable by construction, and enumerating
+ * it would create a maintenance surface that the volatile-only lookup
+ * avoids.
+ * @param name - Header name (any case).
+ * @returns `true` when the header is volatile.
+ */
+export function isVolatileHeader(name: string): boolean {
+	return VOLATILE_HEADER_NAMES.has(name.toLowerCase());
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-blob-refs.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-blob-refs.spec.ts
@@ -1,0 +1,101 @@
+import { zstdDecompressSync } from 'node:zlib';
+
+import knex from 'knex';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createPhase6ARefTables } from '../create-phase6a-ref-tables.js';
+import { LibsqlDialect } from '../libsql-dialect.js';
+
+import { populateBlobRefs } from './populate-blob-refs.js';
+
+/**
+ * Minimal in-memory archive with just the `images` table and Phase 6-A
+ * ref tables. `populateBlobRefs` only touches `images.src` /
+ * `images.currentSrc`.
+ * @returns The connected Knex instance; the caller destroys it.
+ */
+async function setup(): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	await db.schema.createTable('images', (t) => {
+		t.increments('id');
+		t.integer('pageId').notNullable();
+		t.text('src').nullable();
+		t.text('currentSrc').nullable();
+	});
+	await createPhase6ARefTables(db);
+	return db;
+}
+
+/**
+ * Builds a data URI whose overall length exceeds the 512-byte threshold
+ * used by `populateBlobRefs`. Padding with base64-friendly `A` chars keeps
+ * the payload bytes deterministic across invocations.
+ * @param sizeBytes - Desired approximate total length of the data URI.
+ * @returns A `data:image/png;base64,` URI padded to about `sizeBytes`.
+ */
+function bigPngUri(sizeBytes: number): string {
+	const prefix = 'data:image/png;base64,';
+	return prefix + 'A'.repeat(Math.max(sizeBytes - prefix.length, 1));
+}
+
+describe('populateBlobRefs', () => {
+	let db: ReturnType<typeof knex>;
+
+	beforeEach(async () => {
+		db = await setup();
+	});
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it('stores decoded, compressed data-URI payloads > 512 bytes', async () => {
+		const uri = bigPngUri(1024);
+		await db('images').insert([{ pageId: 1, src: uri, currentSrc: null }]);
+		await populateBlobRefs(db);
+		const rows = await db('blob_refs').select();
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.codec).toBe('zstd');
+		expect(rows[0]!.size_raw).toBeGreaterThan(0);
+		expect(rows[0]!.size_stored).toBeGreaterThan(0);
+		const decompressed = zstdDecompressSync(Buffer.from(rows[0]!.body));
+		expect(decompressed.length).toBe(rows[0]!.size_raw);
+	});
+
+	it('skips data URIs at or below 512 bytes', async () => {
+		const smallUri = 'data:image/svg+xml;base64,PHN2Zy8+'; // ~30 chars
+		await db('images').insert([{ pageId: 1, src: smallUri, currentSrc: null }]);
+		await populateBlobRefs(db);
+		expect(await db('blob_refs').select()).toHaveLength(0);
+	});
+
+	it('skips non-data URIs', async () => {
+		await db('images').insert([
+			{ pageId: 1, src: 'https://example.com/img.png', currentSrc: null },
+		]);
+		await populateBlobRefs(db);
+		expect(await db('blob_refs').select()).toHaveLength(0);
+	});
+
+	it('deduplicates identical payloads across src and currentSrc', async () => {
+		const uri = bigPngUri(1200);
+		await db('images').insert([
+			{ pageId: 1, src: uri, currentSrc: uri },
+			{ pageId: 2, src: uri, currentSrc: null },
+		]);
+		await populateBlobRefs(db);
+		expect(await db('blob_refs').select()).toHaveLength(1);
+	});
+
+	it('is idempotent', async () => {
+		const uri = bigPngUri(1024);
+		await db('images').insert([{ pageId: 1, src: uri, currentSrc: null }]);
+		await populateBlobRefs(db);
+		await populateBlobRefs(db);
+		const count = await db('blob_refs').count<{ n: number }[]>('id as n');
+		expect(Number(count[0]!.n)).toBe(1);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-blob-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-blob-refs.ts
@@ -1,0 +1,136 @@
+import type { Knex } from 'knex';
+
+import { zstdCompressSync } from 'node:zlib';
+
+import { computeContentHash } from './compute-content-hash.js';
+import { DATA_URI_URL_REFS_LIMIT } from './data-uri-url-refs-limit.js';
+import { decodeDataUri } from './decode-data-uri.js';
+
+/** Rows scanned per `SELECT`. See `populateTextRefs` for chunking rationale. */
+const READ_CHUNK_SIZE = 2000;
+
+/**
+ * Rows written per `INSERT`. blob_refs rows carry a compressed body BLOB
+ * so 100 rows keeps the total payload of a single INSERT statement well
+ * under WAL frame limits even for large SVGs.
+ */
+const INSERT_CHUNK_SIZE = 100;
+
+/**
+ * Populates `blob_refs` from every `images.src` / `images.currentSrc`
+ * value that is a data URI longer than {@link DATA_URI_URL_REFS_LIMIT}
+ * bytes (issue #191 step 6-B-4).
+ *
+ * For each such value:
+ *
+ * 1. `decodeDataUri` strips the `data:...;base64,` (or `data:...,`) prefix
+ *    and returns the raw payload bytes.
+ * 2. `computeContentHash` hashes the payload bytes (32-byte SHA-256).
+ * 3. The payload is zstd-compressed (`codec='zstd'`) — matching
+ *    `page_html_blobs` / `json_refs`.
+ * 4. `INSERT OR IGNORE` on `hash` deduplicates: two `<img>` elements with
+ *    the same underlying base64 payload share one `blob_refs` row.
+ *
+ * Malformed data URIs that `decodeDataUri` cannot decode are logged and
+ * skipped — the raw URI string still exists in the source `images.src`
+ * row, and the migration script's operator can hunt it down from the
+ * warning log. The alternative — routing malformed large URIs back to
+ * `url_refs` — would break the "data URIs > threshold live in
+ * blob_refs" contract that Phase 6-D lookups depend on.
+ *
+ * On the reference archive only ~429 images use data URIs, so the total
+ * dictionary is tiny — this step is I/O-cheap even without full
+ * chunking, but the same batching shape is used as elsewhere for
+ * consistency.
+ * @param trx - Knex instance or transaction connected to the archive DB.
+ * @example
+ * await knex.transaction(async (trx) => {
+ *   await populateBlobRefs(trx);
+ * });
+ */
+export async function populateBlobRefs(trx: Knex): Promise<void> {
+	const hasImages = await trx.schema.hasTable('images');
+	if (!hasImages) {
+		return;
+	}
+	const hasSrc = await trx.schema.hasColumn('images', 'src');
+	const hasCurrentSrc = await trx.schema.hasColumn('images', 'currentSrc');
+	const columns = [
+		'id',
+		...(hasSrc ? ['src'] : []),
+		...(hasCurrentSrc ? ['currentSrc'] : []),
+	];
+	if (columns.length === 1) {
+		// Only `id` — neither URL column present, nothing to scan.
+		return;
+	}
+
+	const seen = new Set<string>();
+	const pending: {
+		hash: Buffer;
+		body: Buffer;
+		codec: 'zstd';
+		size_raw: number;
+		size_stored: number;
+	}[] = [];
+
+	let cursor = 0;
+	while (true) {
+		const rows: Record<string, unknown>[] = await trx('images')
+			.select(...columns)
+			.where('id', '>', cursor)
+			.orderBy('id', 'asc')
+			.limit(READ_CHUNK_SIZE);
+		if (rows.length === 0) {
+			break;
+		}
+		cursor = rows.at(-1)!.id as number;
+		for (const row of rows) {
+			const values: (string | null)[] = [];
+			if (hasSrc) {
+				values.push(row.src as string | null);
+			}
+			if (hasCurrentSrc) {
+				values.push(row.currentSrc as string | null);
+			}
+			for (const value of values) {
+				if (value == null || value.length <= DATA_URI_URL_REFS_LIMIT) {
+					continue;
+				}
+				if (!value.startsWith('data:')) {
+					continue;
+				}
+				const decoded = decodeDataUri(value);
+				if (decoded === null) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						`populateBlobRefs: skipping malformed data URI (length=${value.length}) — raw string still exists in images row`,
+					);
+					continue;
+				}
+				const hash = computeContentHash(decoded.bytes);
+				const hex = hash.toString('hex');
+				if (seen.has(hex)) {
+					continue;
+				}
+				seen.add(hex);
+				const compressed = zstdCompressSync(decoded.bytes);
+				pending.push({
+					hash,
+					body: compressed,
+					codec: 'zstd',
+					size_raw: decoded.bytes.byteLength,
+					size_stored: compressed.byteLength,
+				});
+				if (pending.length >= INSERT_CHUNK_SIZE) {
+					await trx('blob_refs').insert(pending).onConflict('hash').ignore();
+					pending.length = 0;
+				}
+			}
+		}
+	}
+
+	if (pending.length > 0) {
+		await trx('blob_refs').insert(pending).onConflict('hash').ignore();
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-content-type-refs.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-content-type-refs.spec.ts
@@ -1,0 +1,118 @@
+import knex from 'knex';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createPhase6ARefTables } from '../create-phase6a-ref-tables.js';
+import { LibsqlDialect } from '../libsql-dialect.js';
+
+import { populateContentTypeRefs } from './populate-content-type-refs.js';
+import { countRows } from './test-utils/count-rows.js';
+
+/**
+ * Sets up a minimal in-memory archive: the two source tables Phase 6-B-0
+ * scans, plus every Phase 6-A ref table (so `content_type_refs` exists as
+ * the INSERT target). Full crawler schema is not needed — the populate
+ * function only touches `pages.contentType`, `resources.contentType`, and
+ * `content_type_refs`.
+ * @returns The connected Knex instance; the caller destroys it.
+ */
+async function setup(): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.string('contentType').nullable();
+	});
+	await db.schema.createTable('resources', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.string('contentType').nullable();
+	});
+	await createPhase6ARefTables(db);
+	return db;
+}
+
+describe('populateContentTypeRefs', () => {
+	let db: ReturnType<typeof knex>;
+
+	beforeEach(async () => {
+		db = await setup();
+	});
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it('populates from pages.contentType', async () => {
+		await db('pages').insert([
+			{ url: '/a', contentType: 'text/html; charset=utf-8' },
+			{ url: '/b', contentType: 'image/png' },
+			{ url: '/c', contentType: null },
+		]);
+		await populateContentTypeRefs(db);
+		const rows = await db('content_type_refs').select('raw', 'normalized', 'category');
+		expect(rows).toEqual(
+			expect.arrayContaining([
+				{ raw: 'text/html; charset=utf-8', normalized: 'text/html', category: 'html' },
+				{ raw: 'image/png', normalized: 'image/png', category: 'image' },
+			]),
+		);
+		expect(rows).toHaveLength(2);
+	});
+
+	it('unions pages + resources content-types', async () => {
+		await db('pages').insert([{ url: '/a', contentType: 'text/html' }]);
+		await db('resources').insert([
+			{ url: '/r1', contentType: 'application/javascript' },
+			{ url: '/r2', contentType: 'text/html' },
+		]);
+		await populateContentTypeRefs(db);
+		const rows = await db('content_type_refs').select('raw');
+		expect(rows.map((r) => r.raw).toSorted()).toEqual([
+			'application/javascript',
+			'text/html',
+		]);
+	});
+
+	it('is idempotent (re-run does not duplicate rows)', async () => {
+		await db('pages').insert([{ url: '/a', contentType: 'text/html' }]);
+		await populateContentTypeRefs(db);
+		await populateContentTypeRefs(db);
+		expect(await countRows(db, 'content_type_refs')).toBe(1);
+	});
+
+	it('skips null and empty content-types', async () => {
+		await db('pages').insert([
+			{ url: '/a', contentType: null },
+			{ url: '/b', contentType: '' },
+			{ url: '/c', contentType: 'text/html' },
+		]);
+		await populateContentTypeRefs(db);
+		const rows = await db('content_type_refs').select('raw');
+		expect(rows.map((r) => r.raw)).toEqual(['text/html']);
+	});
+
+	it('is a no-op when both source tables are empty', async () => {
+		await populateContentTypeRefs(db);
+		expect(await countRows(db, 'content_type_refs')).toBe(0);
+	});
+
+	it('strips C0 control characters from the normalized column', async () => {
+		// jsdom occasionally lets a stray CR / TAB / NUL slip into a
+		// Content-Type header. The `raw` column should retain the byte-for-
+		// byte original; `normalized` must strip them so two rows for
+		// the "same" logical MIME share a normalized value.
+		const rawWithCr = 'text/html\r';
+		const rawWithTab = '\ttext/html';
+		await db('pages').insert([{ url: '/a', contentType: rawWithCr }]);
+		await db('resources').insert([{ url: '/r', contentType: rawWithTab }]);
+		await populateContentTypeRefs(db);
+		const rows = await db('content_type_refs').select('raw', 'normalized').orderBy('raw');
+		expect(rows).toHaveLength(2);
+		for (const row of rows) {
+			expect(row.normalized).toBe('text/html');
+		}
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-content-type-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-content-type-refs.ts
@@ -27,7 +27,7 @@ function stripControlChars(text: string): string {
 	let output = '';
 	for (const ch of text) {
 		const code = ch.codePointAt(0)!;
-		if (code < 0x20 || code === 0x7f) {
+		if (code < 32 /* 0x20 = SPACE */ || code === 127 /* 0x7F = DEL */) {
 			continue;
 		}
 		output += ch;

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-content-type-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-content-type-refs.ts
@@ -1,0 +1,115 @@
+import type { Knex } from 'knex';
+
+import { classifyContentType } from './classify-content-type.js';
+
+/**
+ * Distinct-`contentType` rows are collected from `pages` + `resources` in
+ * chunks of this size before being written into `content_type_refs`. The
+ * DISTINCT list is expected to be tiny (< 1000 rows even on the largest
+ * archives — the wire content-type space is small) so the chunk size only
+ * bounds worst-case parameter counts on `INSERT ... VALUES ...`.
+ */
+const INSERT_CHUNK_SIZE = 500;
+
+/**
+ * Drops every C0 control character (`0x00`..`0x1F`) and DEL (`0x7F`)
+ * from `text`. `jsdom` / lax parsers occasionally emit these inside a
+ * raw Content-Type header (e.g. `text/html\r`); leaving them in
+ * `content_type_refs.normalized` would fork two rows for the "same"
+ * content-type into different normalized values.
+ *
+ * Implemented character-by-character rather than as a regex literal so
+ * the source file carries no non-printing bytes and stays tool-friendly.
+ * @param text - Input string.
+ * @returns `text` with C0 controls and DEL stripped.
+ */
+function stripControlChars(text: string): string {
+	let output = '';
+	for (const ch of text) {
+		const code = ch.codePointAt(0)!;
+		if (code < 0x20 || code === 0x7f) {
+			continue;
+		}
+		output += ch;
+	}
+	return output;
+}
+
+/**
+ * Normalises a raw Content-Type header value to a canonical MIME
+ * (control-char stripped, trimmed, lower-cased, parameters removed).
+ * Duplicated once here instead of shared with {@link classifyContentType}
+ * — that function must accept the raw value verbatim so it can also
+ * handle `null` / `''` cases, whereas the migration insert wants the
+ * pre-normalised form to write into `content_type_refs.normalized`.
+ * @param raw - Raw Content-Type header, guaranteed non-null non-empty.
+ * @returns Lower-cased MIME with parameters and control chars stripped.
+ */
+function normalizeMime(raw: string): string {
+	const semi = raw.indexOf(';');
+	const head = semi === -1 ? raw : raw.slice(0, semi);
+	return stripControlChars(head).trim().toLowerCase();
+}
+
+/**
+ * Populates `content_type_refs` from every distinct `contentType` value
+ * currently stored in `pages` and `resources` (issue #191 step 6-B-0).
+ *
+ * Two independent DISTINCT SELECTs (one per table) are merged in JS
+ * rather than via SQL `UNION` — the cardinality is small in practice and
+ * doing it in JS avoids the knex-`union().select()` column-aliasing
+ * quirk (bare `.select()` on a union wraps in `SELECT *` and can lose
+ * the column name depending on driver version). Two per-table SELECTs
+ * are also fast because `contentType` is indexed on both tables via
+ * `idx_pages_listfilter` / natural column index (see `init-schema.ts`).
+ *
+ * `normalized` and `category` are derived in JS via {@link classifyContentType}
+ * so the rule table stays in one place; SQLite has no equivalent
+ * expression.
+ *
+ * `INSERT OR IGNORE` on the natural key `raw` makes this idempotent —
+ * re-running the populate step after a partial failure never duplicates
+ * rows, only appends the new ones.
+ * @param trx - Knex instance or transaction connected to the archive DB.
+ * @example
+ * await knex.transaction(async (trx) => {
+ *   await populateContentTypeRefs(trx);
+ * });
+ */
+export async function populateContentTypeRefs(trx: Knex): Promise<void> {
+	const distinctRaw = new Set<string>();
+	if (await trx.schema.hasTable('pages')) {
+		const pagesRows: { contentType: string | null }[] = await trx('pages')
+			.distinct('contentType')
+			.whereNotNull('contentType');
+		for (const { contentType } of pagesRows) {
+			if (contentType != null && contentType !== '') {
+				distinctRaw.add(contentType);
+			}
+		}
+	}
+	if (await trx.schema.hasTable('resources')) {
+		const resourcesRows: { contentType: string | null }[] = await trx('resources')
+			.distinct('contentType')
+			.whereNotNull('contentType');
+		for (const { contentType } of resourcesRows) {
+			if (contentType != null && contentType !== '') {
+				distinctRaw.add(contentType);
+			}
+		}
+	}
+	if (distinctRaw.size === 0) {
+		return;
+	}
+
+	const inserts = [...distinctRaw].map((raw) => ({
+		raw,
+		normalized: normalizeMime(raw),
+		category: classifyContentType(raw),
+	}));
+
+	for (let index = 0; index < inserts.length; index += INSERT_CHUNK_SIZE) {
+		const chunk = inserts.slice(index, index + INSERT_CHUNK_SIZE);
+		await trx('content_type_refs').insert(chunk).onConflict('raw').ignore();
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-header-tables.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-header-tables.spec.ts
@@ -1,0 +1,159 @@
+import knex from 'knex';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createPhase6ARefTables } from '../create-phase6a-ref-tables.js';
+import { LibsqlDialect } from '../libsql-dialect.js';
+
+import { populateHeaderTables } from './populate-header-tables.js';
+import { countRows } from './test-utils/count-rows.js';
+
+/**
+ * Minimal archive with the two source tables that Phase 6-B-5 scans, plus
+ * the Phase 6-A ref tables (including the five header tables).
+ * @returns The connected Knex instance; the caller destroys it.
+ */
+async function setup(): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.json('responseHeaders').nullable();
+	});
+	await db.schema.createTable('resources', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.json('responseHeaders').nullable();
+	});
+	await createPhase6ARefTables(db);
+	return db;
+}
+
+describe('populateHeaderTables', () => {
+	let db: ReturnType<typeof knex>;
+
+	beforeEach(async () => {
+		db = await setup();
+	});
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it('creates one header_sets row per distinct responseHeaders JSON string', async () => {
+		const rawA = JSON.stringify({ 'content-type': 'text/html', date: 'D1' });
+		const rawB = JSON.stringify({ 'content-type': 'text/html', date: 'D2' });
+		await db('pages').insert([
+			{ url: '/1', responseHeaders: rawA },
+			{ url: '/2', responseHeaders: rawA }, // duplicate
+			{ url: '/3', responseHeaders: rawB }, // different volatile
+		]);
+		await populateHeaderTables(db);
+		expect(await countRows(db, 'header_sets')).toBe(2);
+	});
+
+	it('shares header_sets id between pages and resources for identical raw JSON', async () => {
+		const raw = JSON.stringify({ 'content-type': 'text/html' });
+		await db('pages').insert([{ url: '/a', responseHeaders: raw }]);
+		await db('resources').insert([{ url: '/r', responseHeaders: raw }]);
+		await populateHeaderTables(db);
+		expect(await countRows(db, 'header_sets')).toBe(1);
+	});
+
+	it('inserts header_name_refs / header_value_refs / header_set_entries in lock-step', async () => {
+		await db('pages').insert([
+			{
+				url: '/a',
+				responseHeaders: JSON.stringify({
+					'content-type': 'text/html',
+					'cache-control': 'no-store',
+				}),
+			},
+		]);
+		await populateHeaderTables(db);
+		const nameRows = await db('header_name_refs').select('name');
+		expect(nameRows.map((r) => r.name).toSorted()).toEqual([
+			'cache-control',
+			'content-type',
+		]);
+		const valueRows = await db('header_value_refs').select('value');
+		expect(valueRows.map((r) => r.value).toSorted()).toEqual(['no-store', 'text/html']);
+		const entries = await db('header_set_entries').select();
+		expect(entries).toHaveLength(2);
+	});
+
+	it('preserves multiple same-name headers via occurrence ordinals', async () => {
+		await db('pages').insert([
+			{
+				url: '/a',
+				responseHeaders: JSON.stringify({
+					'set-cookie': ['session=abc', 'csrf=xyz'],
+				}),
+			},
+		]);
+		await populateHeaderTables(db);
+		const entries = await db('header_set_entries')
+			.join('header_name_refs', 'header_set_entries.name_id', 'header_name_refs.id')
+			.select('name', 'occurrence')
+			.orderBy('occurrence');
+		expect(entries).toEqual([
+			{ name: 'set-cookie', occurrence: 1 },
+			{ name: 'set-cookie', occurrence: 2 },
+		]);
+	});
+
+	it('populates header_flags with the correct bitmask + cache_policy', async () => {
+		await db('pages').insert([
+			{
+				url: '/a',
+				responseHeaders: JSON.stringify({
+					'content-security-policy': "default-src 'self'",
+					'strict-transport-security': 'max-age=31536000',
+					'cache-control': 'no-store',
+				}),
+			},
+		]);
+		await populateHeaderTables(db);
+		const row = await db('header_flags').first();
+		expect(row.has_csp).toBe(1);
+		expect(row.has_hsts).toBe(1);
+		expect(row.has_x_frame_options).toBe(0);
+		expect(row.cache_policy).toBe('no-store');
+	});
+
+	it('is idempotent across repeat runs', async () => {
+		const raw = JSON.stringify({ 'content-type': 'text/html' });
+		await db('pages').insert([{ url: '/a', responseHeaders: raw }]);
+		await populateHeaderTables(db);
+		await populateHeaderTables(db);
+		expect(await countRows(db, 'header_sets')).toBe(1);
+		expect(await countRows(db, 'header_set_entries', 'header_set_id')).toBe(1);
+		expect(await countRows(db, 'header_flags', 'header_set_id')).toBe(1);
+	});
+
+	it('reuses one header_sets row when two rows differ only in JSON key ordering (same raw_hash)', async () => {
+		// Same headers, different key insertion order — Phase 6-A's UNIQUE
+		// constraint on raw_hash would otherwise abort the second INSERT.
+		const jsonA = '{"content-type":"text/html","cache-control":"no-store"}';
+		const jsonB = '{"cache-control":"no-store","content-type":"text/html"}';
+		await db('pages').insert([
+			{ url: '/a', responseHeaders: jsonA },
+			{ url: '/b', responseHeaders: jsonB },
+		]);
+		await populateHeaderTables(db);
+		expect(await countRows(db, 'header_sets')).toBe(1);
+	});
+
+	it('skips null / empty / {} responseHeaders values', async () => {
+		await db('pages').insert([
+			{ url: '/a', responseHeaders: null },
+			{ url: '/b', responseHeaders: '{}' },
+			{ url: '/c', responseHeaders: '' },
+			{ url: '/d', responseHeaders: JSON.stringify({ 'content-type': 'text/html' }) },
+		]);
+		await populateHeaderTables(db);
+		expect(await countRows(db, 'header_sets')).toBe(1);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-header-tables.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-header-tables.ts
@@ -1,0 +1,410 @@
+import type { DecomposedHeaderSet } from './types.js';
+import type { Knex } from 'knex';
+
+import { computeContentHash } from './compute-content-hash.js';
+import { computeHeaderFlags } from './compute-header-flags.js';
+import { decomposeHeaderSet } from './decompose-header-set.js';
+
+/**
+ * Rows scanned per SELECT chunk against `pages.responseHeaders` /
+ * `resources.responseHeaders`. Keyset-paginated on `id` to avoid loading
+ * a 470k-row `responseHeaders` column into a single query result.
+ */
+const READ_CHUNK_SIZE = 500;
+
+/**
+ * Rows inserted per INSERT statement into `header_set_entries`. Each row
+ * binds 5 params so 500 rows = 2500 params — safely under SQLite's
+ * default variable limit.
+ */
+const ENTRY_INSERT_CHUNK_SIZE = 500;
+
+/**
+ * In-process caches shared across every source row processed by one call
+ * to {@link populateHeaderTables}. The three id-maps let us resolve
+ * `header_name_refs.id` / `header_value_refs.id` / `header_sets.id`
+ * without hitting the DB once a value has been seen (or preloaded).
+ *
+ * `setIdsProcessedThisRun` tracks the subset of `setIdByRawJsonHash` /
+ * `setIdByRawHash` that this run has already written entries + flags
+ * for. A preloaded id from a prior partial run is present in the id
+ * caches but NOT in this set — so we still re-run the entries + flags
+ * inserts (which are safe under `INSERT OR IGNORE`) to repair the
+ * missing rows. Once this run has written entries+flags for a given
+ * setId, the shortcut fires and skips redundant no-op inserts.
+ */
+interface HeaderTableCaches {
+	/** `lower-cased name → header_name_refs.id`. */
+	readonly nameIdCache: Map<string, number>;
+	/** `hexHash|value → header_value_refs.id`. */
+	readonly valueIdCache: Map<string, number>;
+	/** `hex(raw_json_hash) → header_sets.id`. */
+	readonly setIdByRawJsonHash: Map<string, number>;
+	/** `hex(raw_hash) → header_sets.id`. */
+	readonly setIdByRawHash: Map<string, number>;
+	/** `header_sets.id` values already fully processed this run. */
+	readonly setIdsProcessedThisRun: Set<number>;
+}
+
+/**
+ * Populates the five header decomposition tables (`header_name_refs`,
+ * `header_value_refs`, `header_sets`, `header_set_entries`,
+ * `header_flags`) from every `pages.responseHeaders` and
+ * `resources.responseHeaders` JSON blob (issue #191 step 6-B-5).
+ *
+ * Strategy:
+ *
+ * 1. **Warm caches** — load existing `header_name_refs`,
+ *    `header_value_refs`, and `header_sets` rows into id maps. Idempotent
+ *    re-runs then reuse ids instead of re-issuing an upsert per entry,
+ *    and new ids are appended as they are inserted.
+ * 2. **Stream `pages.responseHeaders` + `resources.responseHeaders`** in
+ *    id-keyset chunks. Each non-null value is decomposed via
+ *    {@link decomposeHeaderSet}.
+ * 3. **Reuse setIds by identity**: two responseHeaders JSON strings with
+ *    different key ordering but identical sorted entries hash to the
+ *    same `raw_hash`; we look up by `raw_hash` first so this variant
+ *    reuses the existing `header_sets.id` without triggering the
+ *    `UNIQUE(raw_hash)` conflict. Same for `raw_json_hash`.
+ * 4. **Insert entries + flags** exactly once per setId per run — a
+ *    setId preloaded from the DB (e.g. by a prior crashed run) still
+ *    runs the entries/flags path (guarded by `INSERT OR IGNORE`) so
+ *    partial state is repaired.
+ *
+ * Every write is bulk-batched so the migration stays O(chunks × per-
+ * chunk-distinct-decomposed-sets) round-trips against the DB. Idempotency
+ * across full re-runs is guaranteed by the `INSERT OR IGNORE`s and the
+ * `setIdsProcessedThisRun` guard.
+ * @param trx - Knex instance or transaction connected to the archive DB.
+ * @example
+ * await knex.transaction(async (trx) => {
+ *   await populateHeaderTables(trx);
+ * });
+ */
+export async function populateHeaderTables(trx: Knex): Promise<void> {
+	const caches: HeaderTableCaches = {
+		nameIdCache: await loadNameIdCache(trx),
+		valueIdCache: await loadValueIdCache(trx),
+		setIdByRawJsonHash: new Map<string, number>(),
+		setIdByRawHash: new Map<string, number>(),
+		setIdsProcessedThisRun: new Set<number>(),
+	};
+	await preloadSetIdCaches(trx, caches);
+
+	for (const table of ['pages', 'resources'] as const) {
+		const hasTable = await trx.schema.hasTable(table);
+		if (!hasTable) {
+			continue;
+		}
+		const hasColumn = await trx.schema.hasColumn(table, 'responseHeaders');
+		if (!hasColumn) {
+			continue;
+		}
+		await processSourceTable(trx, table, caches);
+	}
+}
+
+/**
+ * Loads every row of `header_name_refs` into `name → id`. Called once at
+ * the start of the populate step so subsequent lookups skip the DB.
+ * @param trx - Knex instance.
+ * @returns Map keyed by lower-cased header name.
+ */
+async function loadNameIdCache(trx: Knex): Promise<Map<string, number>> {
+	const cache = new Map<string, number>();
+	const rows: { id: number; name: string }[] = await trx('header_name_refs').select();
+	for (const row of rows) {
+		cache.set(row.name, row.id);
+	}
+	return cache;
+}
+
+/**
+ * Loads every row of `header_value_refs` into `hexHash|value → id`.
+ * Values are keyed by both hash and value so an identical string with a
+ * hash collision (astronomically improbable) is still disambiguated.
+ * @param trx - Knex instance.
+ * @returns Map keyed by `hexHash|value`.
+ */
+async function loadValueIdCache(trx: Knex): Promise<Map<string, number>> {
+	const cache = new Map<string, number>();
+	const rows: { id: number; hash: Uint8Array; value: string }[] =
+		await trx('header_value_refs').select();
+	for (const row of rows) {
+		cache.set(valueKey(Buffer.from(row.hash), row.value), row.id);
+	}
+	return cache;
+}
+
+/**
+ * Loads every row of `header_sets` into `hex(raw_json_hash) → id` and
+ * `hex(raw_hash) → id`. Both are UNIQUE per the Phase 6-A DDL so each
+ * is a total function.
+ * @param trx - Knex instance.
+ * @param caches - The cache bundle to seed.
+ */
+async function preloadSetIdCaches(trx: Knex, caches: HeaderTableCaches): Promise<void> {
+	const rows: { id: number; raw_json_hash: Uint8Array; raw_hash: Uint8Array }[] =
+		await trx('header_sets').select('id', 'raw_json_hash', 'raw_hash');
+	for (const row of rows) {
+		caches.setIdByRawJsonHash.set(Buffer.from(row.raw_json_hash).toString('hex'), row.id);
+		caches.setIdByRawHash.set(Buffer.from(row.raw_hash).toString('hex'), row.id);
+	}
+}
+
+/**
+ * Streams every row of one source table (`pages` or `resources`) and
+ * populates the header tables for each decomposed non-null header set.
+ * @param trx - Knex instance.
+ * @param table - Source table.
+ * @param caches - The in-process caches, mutated in place.
+ */
+async function processSourceTable(
+	trx: Knex,
+	table: 'pages' | 'resources',
+	caches: HeaderTableCaches,
+): Promise<void> {
+	let cursor = 0;
+	while (true) {
+		const rows: { id: number; responseHeaders: string | null }[] = await trx(table)
+			.select('id', 'responseHeaders')
+			.where('id', '>', cursor)
+			.orderBy('id', 'asc')
+			.limit(READ_CHUNK_SIZE);
+		if (rows.length === 0) {
+			break;
+		}
+		cursor = rows.at(-1)!.id;
+		for (const row of rows) {
+			const decomposed = decomposeHeaderSet(row.responseHeaders);
+			if (decomposed === null) {
+				continue;
+			}
+			await upsertOneHeaderSet(trx, decomposed, caches);
+		}
+	}
+}
+
+/**
+ * Upserts one decomposed header set and its entries + flags.
+ *
+ * Set-id resolution order:
+ *
+ * 1. `raw_json_hash` cache — same JSON key ordering as a previous row.
+ * 2. `raw_hash` cache — same sorted-entries identity, different JSON key
+ *    ordering. This branch links the new `raw_json_hash` to the existing
+ *    setId in the in-process map so subsequent same-JSON hits fast-path.
+ * 3. Otherwise INSERT a new `header_sets` row.
+ *
+ * Entries + flags are inserted once per `setId` per run (guarded by
+ * `setIdsProcessedThisRun`); already-inserted rows short-circuit
+ * cheaply, and preloaded-but-unprocessed setIds (partial prior run) get
+ * their entries/flags repaired via `INSERT OR IGNORE`.
+ * @param trx - Knex instance.
+ * @param decomposed - Result of `decomposeHeaderSet`.
+ * @param caches - The in-process caches, mutated in place.
+ */
+async function upsertOneHeaderSet(
+	trx: Knex,
+	decomposed: DecomposedHeaderSet,
+	caches: HeaderTableCaches,
+): Promise<void> {
+	const rawJsonHashHex = decomposed.rawJsonHash.toString('hex');
+	const rawHashHex = decomposed.rawHash.toString('hex');
+
+	let setId = caches.setIdByRawJsonHash.get(rawJsonHashHex);
+	if (setId === undefined) {
+		setId = caches.setIdByRawHash.get(rawHashHex);
+		if (setId === undefined) {
+			setId = await insertHeaderSet(trx, decomposed);
+			caches.setIdByRawJsonHash.set(rawJsonHashHex, setId);
+			caches.setIdByRawHash.set(rawHashHex, setId);
+		} else {
+			// Same sorted-entries identity as an existing row, different JSON
+			// key ordering. Reuse the existing setId; the raw_json_hash of
+			// this variant has no persistent home in the Phase 6-A schema
+			// (raw_json_hash is UNIQUE per row) — a future Phase 6-A
+			// follow-up may add a raw_json_hash → setId mapping table so
+			// Phase 6-D can find both variants.
+			caches.setIdByRawJsonHash.set(rawJsonHashHex, setId);
+		}
+	}
+
+	if (caches.setIdsProcessedThisRun.has(setId)) {
+		return;
+	}
+
+	const nameIds = await resolveNameIds(trx, decomposed.entries, caches.nameIdCache);
+	const valueIds = await resolveValueIds(trx, decomposed.entries, caches.valueIdCache);
+
+	const entryRows = decomposed.entries.map((entry, index) => ({
+		header_set_id: setId,
+		name_id: nameIds[index]!,
+		occurrence: entry.occurrence,
+		value_id: valueIds[index]!,
+		is_volatile: entry.isVolatile ? 1 : 0,
+	}));
+	for (let index = 0; index < entryRows.length; index += ENTRY_INSERT_CHUNK_SIZE) {
+		const chunk = entryRows.slice(index, index + ENTRY_INSERT_CHUNK_SIZE);
+		await trx('header_set_entries')
+			.insert(chunk)
+			.onConflict(['header_set_id', 'name_id', 'occurrence'])
+			.ignore();
+	}
+
+	const flags = computeHeaderFlags(decomposed.entries);
+	await trx('header_flags')
+		.insert({ header_set_id: setId, ...flags })
+		.onConflict('header_set_id')
+		.ignore();
+
+	caches.setIdsProcessedThisRun.add(setId);
+}
+
+/**
+ * Inserts a new `header_sets` row and returns its id. Neither
+ * `raw_json_hash` nor `raw_hash` collided with an existing row when
+ * this is called — the caller has already checked both caches.
+ * @param trx - Knex instance.
+ * @param decomposed - Result of `decomposeHeaderSet`.
+ * @returns The newly-inserted `header_sets.id`.
+ */
+async function insertHeaderSet(
+	trx: Knex,
+	decomposed: DecomposedHeaderSet,
+): Promise<number> {
+	const rows: { id: number }[] = await trx('header_sets')
+		.insert({
+			raw_json_hash: decomposed.rawJsonHash,
+			raw_hash: decomposed.rawHash,
+			stable_hash: decomposed.stableHash,
+			volatile_hash: decomposed.volatileHash,
+			entry_count: decomposed.entryCount,
+			stable_entry_count: decomposed.stableEntryCount,
+		})
+		.returning('id');
+	const first = rows[0];
+	if (first === undefined) {
+		throw new Error(
+			'populateHeaderTables: header_sets INSERT returned no rows despite absent conflict',
+		);
+	}
+	return first.id;
+}
+
+/**
+ * Resolves the `name_id` for every entry in `entries`, inserting new
+ * names into `header_name_refs` as needed. Mutates `cache` with any new
+ * ids.
+ * @param trx - Knex instance.
+ * @param entries - Decomposed entries.
+ * @param cache - Name → id cache; mutated in place.
+ * @returns Parallel array of name ids (same order as `entries`).
+ */
+async function resolveNameIds(
+	trx: Knex,
+	entries: readonly { name: string }[],
+	cache: Map<string, number>,
+): Promise<number[]> {
+	const missing = new Set<string>();
+	for (const entry of entries) {
+		if (!cache.has(entry.name)) {
+			missing.add(entry.name);
+		}
+	}
+	if (missing.size > 0) {
+		await trx('header_name_refs')
+			.insert([...missing].map((name) => ({ name })))
+			.onConflict('name')
+			.ignore();
+		const inserted: { id: number; name: string }[] = await trx('header_name_refs')
+			.select('id', 'name')
+			.whereIn('name', [...missing]);
+		for (const row of inserted) {
+			cache.set(row.name, row.id);
+		}
+	}
+	return entries.map((entry) => {
+		const id = cache.get(entry.name);
+		if (id === undefined) {
+			throw new Error(`populateHeaderTables: name_id not resolved for ${entry.name}`);
+		}
+		return id;
+	});
+}
+
+/**
+ * Resolves the `value_id` for every entry in `entries`, inserting new
+ * values into `header_value_refs` as needed. Values are hashed once and
+ * deduped by `(hash, value)` per the Phase 6-A UNIQUE constraint.
+ *
+ * The read-back after INSERT uses `.whereIn('hash')` + `.whereIn('value')`
+ * to constrain the round-trip result set to exactly the values we just
+ * wrote (a Buffer[] hash-only IN would return the correct rows in
+ * theory but leans on a driver detail — narrowing on `value` too
+ * defends against any BLOB-parameter round-trip quirk in libsql).
+ * @param trx - Knex instance.
+ * @param entries - Decomposed entries.
+ * @param cache - `hexHash|value → id` cache; mutated in place.
+ * @returns Parallel array of value ids (same order as `entries`).
+ */
+async function resolveValueIds(
+	trx: Knex,
+	entries: readonly { value: string }[],
+	cache: Map<string, number>,
+): Promise<number[]> {
+	const hashByEntryIndex: Buffer[] = entries.map((entry) =>
+		computeContentHash(entry.value),
+	);
+	const missing: { key: string; hash: Buffer; value: string }[] = [];
+	const missingKeys = new Set<string>();
+	for (const [i, entry] of entries.entries()) {
+		const hash = hashByEntryIndex[i]!;
+		const key = valueKey(hash, entry.value);
+		if (!cache.has(key) && !missingKeys.has(key)) {
+			missing.push({ key, hash, value: entry.value });
+			missingKeys.add(key);
+		}
+	}
+	if (missing.length > 0) {
+		await trx('header_value_refs')
+			.insert(missing.map(({ hash, value }) => ({ hash, value })))
+			.onConflict(['hash', 'value'])
+			.ignore();
+		const inserted: { id: number; hash: Uint8Array; value: string }[] = await trx(
+			'header_value_refs',
+		)
+			.select('id', 'hash', 'value')
+			.whereIn(
+				'value',
+				missing.map((m) => m.value),
+			);
+		for (const row of inserted) {
+			cache.set(valueKey(Buffer.from(row.hash), row.value), row.id);
+		}
+	}
+	return entries.map((entry, i) => {
+		const key = valueKey(hashByEntryIndex[i]!, entry.value);
+		const id = cache.get(key);
+		if (id === undefined) {
+			throw new Error(
+				`populateHeaderTables: value_id not resolved for ${entry.value.slice(0, 40)}…`,
+			);
+		}
+		return id;
+	});
+}
+
+/**
+ * Composite cache key for `header_value_refs`: hex-encoded hash + a
+ * separator + raw value. Two values with the same hash but different
+ * strings (astronomically improbable, but a `BLOB` hash column is not
+ * a total function per SQL semantics) still resolve to distinct cache
+ * entries.
+ * @param hash - 32-byte content hash.
+ * @param value - Header value verbatim.
+ * @returns Cache key string.
+ */
+function valueKey(hash: Buffer, value: string): string {
+	return `${hash.toString('hex')}|${value}`;
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-json-refs.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-json-refs.spec.ts
@@ -1,0 +1,107 @@
+import { zstdDecompressSync } from 'node:zlib';
+
+import knex from 'knex';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createPhase6ARefTables } from '../create-phase6a-ref-tables.js';
+import { LibsqlDialect } from '../libsql-dialect.js';
+
+import { computeContentHash } from './compute-content-hash.js';
+import { populateJsonRefs } from './populate-json-refs.js';
+
+/**
+ * Minimal archive with just the `pages.meta_extras` source column and the
+ * Phase 6-A ref tables.
+ * @returns The connected Knex instance; the caller destroys it.
+ */
+async function setup(): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.text('meta_extras').nullable();
+	});
+	await createPhase6ARefTables(db);
+	return db;
+}
+
+describe('populateJsonRefs (json-refs-dedup)', () => {
+	let db: ReturnType<typeof knex>;
+
+	beforeEach(async () => {
+		db = await setup();
+	});
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it('inserts one row per meta_extras value', async () => {
+		await db('pages').insert([
+			{ url: '/a', meta_extras: JSON.stringify({ a: 1 }) },
+			{ url: '/b', meta_extras: JSON.stringify({ b: 2 }) },
+		]);
+		await populateJsonRefs(db);
+		const rows = await db('json_refs').select();
+		expect(rows).toHaveLength(2);
+	});
+
+	it('dedupes identical meta_extras strings by hash', async () => {
+		const same = JSON.stringify({ shared: true });
+		await db('pages').insert([
+			{ url: '/a', meta_extras: same },
+			{ url: '/b', meta_extras: same },
+			{ url: '/c', meta_extras: same },
+		]);
+		await populateJsonRefs(db);
+		const rows = await db('json_refs').select();
+		expect(rows).toHaveLength(1);
+	});
+
+	it('acceptance: same meta_extras inserted twice → same json_refs.id', async () => {
+		const same = JSON.stringify({ hello: 'world' });
+		await db('pages').insert([{ url: '/a', meta_extras: same }]);
+		await populateJsonRefs(db);
+		await db('pages').insert([{ url: '/b', meta_extras: same }]);
+		await populateJsonRefs(db);
+		const rows = await db('json_refs').select('id', 'hash');
+		expect(rows).toHaveLength(1);
+		const expectedHash = computeContentHash(same);
+		expect(Buffer.from(rows[0]!.hash).equals(expectedHash)).toBe(true);
+	});
+
+	it('stores zstd-compressed body with size_raw / size_stored', async () => {
+		const json = JSON.stringify({ padded: 'x'.repeat(2000) });
+		await db('pages').insert([{ url: '/a', meta_extras: json }]);
+		await populateJsonRefs(db);
+		const row = await db('json_refs').first();
+		expect(row.codec).toBe('zstd');
+		expect(row.size_raw).toBe(Buffer.byteLength(json, 'utf8'));
+		expect(row.size_stored).toBeGreaterThan(0);
+		expect(row.size_stored).toBeLessThan(row.size_raw);
+		const decoded = zstdDecompressSync(Buffer.from(row.json_text)).toString('utf8');
+		expect(decoded).toBe(json);
+	});
+
+	it('skips null / empty meta_extras', async () => {
+		await db('pages').insert([
+			{ url: '/a', meta_extras: null },
+			{ url: '/b', meta_extras: '' },
+			{ url: '/c', meta_extras: '{}' },
+		]);
+		await populateJsonRefs(db);
+		const rows = await db('json_refs').select();
+		expect(rows).toHaveLength(1);
+	});
+
+	it('is idempotent (rerun does not duplicate)', async () => {
+		await db('pages').insert([{ url: '/a', meta_extras: '{"k":1}' }]);
+		await populateJsonRefs(db);
+		await populateJsonRefs(db);
+		const count = await db('json_refs').count<{ n: number }[]>('id as n');
+		expect(Number(count[0]!.n)).toBe(1);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-json-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-json-refs.ts
@@ -1,0 +1,107 @@
+import type { Knex } from 'knex';
+
+import { zstdCompressSync } from 'node:zlib';
+
+import { computeContentHash } from './compute-content-hash.js';
+
+/**
+ * Number of `json_refs` rows sent per INSERT. Each row binds 5 params
+ * (hash + json_text + codec + size_raw + size_stored). 200 rows = 1000
+ * params — comfortable margin under SQLite's default variable limit and
+ * bounds any one INSERT's compressed-blob payload total to a size that
+ * fits in one WAL frame.
+ */
+const INSERT_CHUNK_SIZE = 200;
+
+/**
+ * Rows scanned per source query. Same rationale as the other populators:
+ * streaming with keyset pagination on `id` avoids loading a 470k-row
+ * `meta_extras` column into a single result set.
+ */
+const READ_CHUNK_SIZE = 1000;
+
+/**
+ * Populates `json_refs` from every non-null `pages.meta_extras` value
+ * (issue #191 step 6-B-3).
+ *
+ * Each value is:
+ *
+ * 1. Hashed with {@link computeContentHash} (32-byte SHA-256; see that
+ *    function's docs for the plan-vs-implementation rationale).
+ * 2. Compressed with `zstdCompressSync` (`codec='zstd'`) — same encoder
+ *    used by `page_html_blobs`.
+ * 3. Deduplicated by hash — identical raw JSON strings produce one row.
+ *
+ * `sizeRaw` records the uncompressed byte length (UTF-8) and `sizeStored`
+ * records the compressed byte length; consumers can estimate compression
+ * savings without decompressing.
+ *
+ * `INSERT OR IGNORE` on `hash` makes the step idempotent across partial-
+ * failure restarts.
+ * @param trx - Knex instance or transaction connected to the archive DB.
+ * @example
+ * await knex.transaction(async (trx) => {
+ *   await populateJsonRefs(trx);
+ * });
+ */
+export async function populateJsonRefs(trx: Knex): Promise<void> {
+	const hasPages = await trx.schema.hasTable('pages');
+	if (!hasPages) {
+		return;
+	}
+	const hasMetaExtras = await trx.schema.hasColumn('pages', 'meta_extras');
+	if (!hasMetaExtras) {
+		return;
+	}
+
+	const seen = new Set<string>();
+	const pending: {
+		hash: Buffer;
+		json_text: Buffer;
+		codec: 'zstd';
+		size_raw: number;
+		size_stored: number;
+	}[] = [];
+
+	let cursor = 0;
+	while (true) {
+		const rows: { id: number; value: string | null }[] = await trx('pages')
+			.select('id', 'meta_extras as value')
+			.where('id', '>', cursor)
+			.orderBy('id', 'asc')
+			.limit(READ_CHUNK_SIZE);
+		if (rows.length === 0) {
+			break;
+		}
+		cursor = rows.at(-1)!.id;
+		for (const row of rows) {
+			const raw = row.value;
+			if (raw == null || raw === '') {
+				continue;
+			}
+			const rawBytes = Buffer.from(raw, 'utf8');
+			const hash = computeContentHash(rawBytes);
+			const hex = hash.toString('hex');
+			if (seen.has(hex)) {
+				continue;
+			}
+			seen.add(hex);
+			const compressed = zstdCompressSync(rawBytes);
+			pending.push({
+				hash,
+				json_text: compressed,
+				codec: 'zstd',
+				size_raw: rawBytes.byteLength,
+				size_stored: compressed.byteLength,
+			});
+			if (pending.length >= INSERT_CHUNK_SIZE) {
+				await trx('json_refs').insert(pending).onConflict('hash').ignore();
+				pending.length = 0;
+			}
+		}
+	}
+
+	if (pending.length > 0) {
+		await trx('json_refs').insert(pending).onConflict('hash').ignore();
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-phase6b-refs.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-phase6b-refs.spec.ts
@@ -1,0 +1,156 @@
+import knex from 'knex';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createPhase6ARefTables } from '../create-phase6a-ref-tables.js';
+import { LibsqlDialect } from '../libsql-dialect.js';
+
+import { populatePhase6BRefs } from './populate-phase6b-refs.js';
+import { countRows } from './test-utils/count-rows.js';
+
+/**
+ * Sets up an in-memory archive with the write-model tables that Phase
+ * 6-B reads (`pages`, `resources`, `anchors`, `images`) plus every
+ * Phase 6-A ref/header table. Rows are inserted by the test bodies.
+ * @returns The connected Knex instance; the caller destroys it.
+ */
+async function setup(): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.string('contentType').nullable();
+		t.json('responseHeaders').nullable();
+		t.string('title').nullable();
+		t.text('description').nullable();
+		t.text('keywords').nullable();
+		t.text('robots_raw').nullable();
+		t.string('og_title').nullable();
+		t.text('og_description').nullable();
+		t.string('twitter_title').nullable();
+		t.text('twitter_description').nullable();
+		t.string('canonical').nullable();
+		t.string('og_url').nullable();
+		t.string('og_image').nullable();
+		t.string('icon_href').nullable();
+		t.string('appleTouchIcon_href').nullable();
+		t.string('amphtml').nullable();
+		t.string('manifest').nullable();
+		t.string('twitter_image').nullable();
+		t.text('meta_extras').nullable();
+	});
+	await db.schema.createTable('resources', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.string('contentType').nullable();
+		t.json('responseHeaders').nullable();
+	});
+	await db.schema.createTable('anchors', (t) => {
+		t.increments('id');
+		t.integer('pageId').notNullable();
+		t.integer('hrefId').notNullable();
+		t.string('textContent').nullable();
+	});
+	await db.schema.createTable('images', (t) => {
+		t.increments('id');
+		t.integer('pageId').notNullable();
+		t.text('src').nullable();
+		t.text('currentSrc').nullable();
+		t.string('alt').nullable();
+	});
+	await createPhase6ARefTables(db);
+	return db;
+}
+
+describe('populatePhase6BRefs (orchestrator)', () => {
+	let db: ReturnType<typeof knex>;
+
+	beforeEach(async () => {
+		db = await setup();
+	});
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it('is a no-op on an empty archive', async () => {
+		await populatePhase6BRefs(db);
+		const tablesToCheck: readonly { table: string; countColumn: string }[] = [
+			{ table: 'url_refs', countColumn: 'id' },
+			{ table: 'content_type_refs', countColumn: 'id' },
+			{ table: 'text_refs', countColumn: 'id' },
+			{ table: 'json_refs', countColumn: 'id' },
+			{ table: 'blob_refs', countColumn: 'id' },
+			{ table: 'header_name_refs', countColumn: 'id' },
+			{ table: 'header_value_refs', countColumn: 'id' },
+			{ table: 'header_sets', countColumn: 'id' },
+			{ table: 'header_set_entries', countColumn: 'header_set_id' },
+			{ table: 'header_flags', countColumn: 'header_set_id' },
+		];
+		for (const { table, countColumn } of tablesToCheck) {
+			expect(await countRows(db, table, countColumn), `${table} should be empty`).toBe(0);
+		}
+	});
+
+	it('fully populates every ref table for a small realistic archive', async () => {
+		await db('pages').insert([
+			{
+				url: 'https://example.com/a',
+				contentType: 'text/html; charset=utf-8',
+				title: 'Home',
+				canonical: 'https://example.com/a',
+				meta_extras: JSON.stringify({ some: 'extra' }),
+				responseHeaders: JSON.stringify({
+					'content-type': 'text/html',
+					'cache-control': 'no-store',
+					date: 'D1',
+				}),
+			},
+		]);
+		await db('resources').insert([
+			{
+				url: 'https://cdn.example.com/one.js',
+				contentType: 'application/javascript',
+				responseHeaders: JSON.stringify({
+					'content-type': 'application/javascript',
+				}),
+			},
+		]);
+		await db('anchors').insert([
+			{ pageId: 1, hrefId: 1, textContent: 'Home' },
+			{ pageId: 1, hrefId: 1, textContent: 'About' },
+		]);
+		await db('images').insert([
+			{ pageId: 1, src: 'https://example.com/logo.png', alt: 'Logo' },
+		]);
+
+		await populatePhase6BRefs(db);
+
+		expect(await countRows(db, 'content_type_refs')).toBe(2);
+		// URLs: pages.url + pages.canonical (dedup as same value) + resources.url + images.src = 3 distinct.
+		expect(await countRows(db, 'url_refs')).toBe(3);
+		expect(await countRows(db, 'text_refs')).toBe(3);
+		expect(await countRows(db, 'json_refs')).toBe(1);
+		expect(await countRows(db, 'header_sets')).toBe(2);
+		expect(await countRows(db, 'header_flags', 'header_set_id')).toBe(2);
+	});
+
+	it('is idempotent across repeated runs', async () => {
+		await db('pages').insert([
+			{
+				url: 'https://example.com/a',
+				contentType: 'text/html',
+				title: 'Home',
+				responseHeaders: JSON.stringify({ 'content-type': 'text/html' }),
+			},
+		]);
+		await populatePhase6BRefs(db);
+		await populatePhase6BRefs(db);
+		expect(await countRows(db, 'content_type_refs')).toBe(1);
+		expect(await countRows(db, 'url_refs')).toBe(1);
+		expect(await countRows(db, 'text_refs')).toBe(1);
+		expect(await countRows(db, 'header_sets')).toBe(1);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-phase6b-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-phase6b-refs.ts
@@ -1,0 +1,53 @@
+import type { Knex } from 'knex';
+
+import { populateBlobRefs } from './populate-blob-refs.js';
+import { populateContentTypeRefs } from './populate-content-type-refs.js';
+import { populateHeaderTables } from './populate-header-tables.js';
+import { populateJsonRefs } from './populate-json-refs.js';
+import { populateTextRefs } from './populate-text-refs.js';
+import { populateUrlRefs } from './populate-url-refs.js';
+
+/**
+ * Runs the six Phase 6-B sub-steps (issue #191) in the plan-specified
+ * order against an already-connected archive:
+ *
+ * 1. `content_type_refs` — 6-B-0 (must precede 6-D-1 / 6-D-3 JOINs).
+ * 2. `url_refs` — 6-B-1.
+ * 3. `text_refs` — 6-B-2.
+ * 4. `json_refs` — 6-B-3.
+ * 5. `blob_refs` — 6-B-4.
+ * 6. Header tables — 6-B-5 (name / value / set / entries / flags).
+ *
+ * The order is not arbitrary: `content_type_refs` before Phase 6-D
+ * JOINs, and `url_refs` before Phase 6-D's `url_refs.id` lookups. Within
+ * Phase 6-B the ordering is: dictionary tables (0..4) first, header
+ * tables (5) last — the header tables' entries reference name / value
+ * refs but those live inside step 5, so no cross-step barrier is
+ * required.
+ *
+ * Every sub-step is independently idempotent via `INSERT OR IGNORE` on
+ * its natural key. Running this orchestrator twice on the same archive
+ * produces the same rows — no phase marker table is used. On the plan's
+ * spec, the whole invocation is expected to run inside one writer
+ * transaction with `.bak` protection at the caller level; this function
+ * does not open its own transaction so the caller controls the boundary.
+ * @param trx - Knex instance or transaction connected to the archive DB.
+ * @example
+ * // Typical migration-script use: connect via Archive, wrap in a
+ * // transaction, run every sub-step, then rely on the caller's `.bak`
+ * // safety net if any step throws.
+ * const archive = await Archive.open(archivePath);
+ * const knex = archive.getKnex();
+ * await knex.transaction(async (trx) => {
+ *   await populatePhase6BRefs(trx);
+ * });
+ * await archive.write();
+ */
+export async function populatePhase6BRefs(trx: Knex): Promise<void> {
+	await populateContentTypeRefs(trx);
+	await populateUrlRefs(trx);
+	await populateTextRefs(trx);
+	await populateJsonRefs(trx);
+	await populateBlobRefs(trx);
+	await populateHeaderTables(trx);
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-text-refs.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-text-refs.spec.ts
@@ -1,0 +1,144 @@
+import knex from 'knex';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createPhase6ARefTables } from '../create-phase6a-ref-tables.js';
+import { LibsqlDialect } from '../libsql-dialect.js';
+
+import { computeContentHash } from './compute-content-hash.js';
+import { populateTextRefs } from './populate-text-refs.js';
+import { countRows } from './test-utils/count-rows.js';
+
+/**
+ * Sets up the source tables (anchors / images / pages) with the specific
+ * text-shaped columns Phase 6-B-2 harvests, plus every Phase 6-A ref
+ * table. Column set is a strict subset of the real schema.
+ * @returns The connected Knex instance; the caller destroys it.
+ */
+async function setup(): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	await db.schema.createTable('anchors', (t) => {
+		t.increments('id');
+		t.integer('pageId').notNullable();
+		t.integer('hrefId').notNullable();
+		t.string('textContent').nullable();
+	});
+	await db.schema.createTable('images', (t) => {
+		t.increments('id');
+		t.integer('pageId').notNullable();
+		t.string('alt').nullable();
+	});
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.string('title').nullable();
+		t.text('description').nullable();
+		t.text('keywords').nullable();
+		t.text('robots_raw').nullable();
+		t.string('og_title').nullable();
+		t.text('og_description').nullable();
+		t.string('twitter_title').nullable();
+		t.text('twitter_description').nullable();
+	});
+	await createPhase6ARefTables(db);
+	return db;
+}
+
+describe('populateTextRefs (text-refs-dedup)', () => {
+	let db: ReturnType<typeof knex>;
+
+	beforeEach(async () => {
+		db = await setup();
+	});
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it('inserts one row per distinct text across all source columns', async () => {
+		await db('anchors').insert([
+			{ pageId: 1, hrefId: 2, textContent: 'Home' },
+			{ pageId: 1, hrefId: 3, textContent: 'About' },
+			{ pageId: 2, hrefId: 3, textContent: 'About' }, // dup
+		]);
+		await db('pages').insert([
+			{ url: '/a', title: 'Home', description: 'Home page' },
+			{ url: '/b', title: 'About' }, // reuses same text as anchor
+		]);
+		await populateTextRefs(db);
+		const rows = await db('text_refs').select('text').orderBy('text');
+		expect(rows.map((r) => r.text)).toEqual(['About', 'Home', 'Home page']);
+	});
+
+	it('stores the content hash on each row', async () => {
+		await db('pages').insert([{ url: '/', title: 'Hello' }]);
+		await populateTextRefs(db);
+		const row = await db('text_refs').first();
+		const expected = computeContentHash('Hello');
+		expect(Buffer.from(row.hash).equals(expected)).toBe(true);
+	});
+
+	it('skips null and empty values', async () => {
+		await db('anchors').insert([
+			{ pageId: 1, hrefId: 2, textContent: null },
+			{ pageId: 1, hrefId: 3, textContent: '' },
+			{ pageId: 1, hrefId: 4, textContent: 'Kept' },
+		]);
+		await populateTextRefs(db);
+		const rows = await db('text_refs').select('text');
+		expect(rows.map((r) => r.text)).toEqual(['Kept']);
+	});
+
+	it('is idempotent (rerun does not duplicate)', async () => {
+		await db('anchors').insert([{ pageId: 1, hrefId: 2, textContent: 'Home' }]);
+		await populateTextRefs(db);
+		await populateTextRefs(db);
+		expect(await countRows(db, 'text_refs')).toBe(1);
+	});
+
+	it('harvests images.alt', async () => {
+		await db('images').insert([
+			{ pageId: 1, alt: 'Logo' },
+			{ pageId: 1, alt: 'Photograph of a cat' },
+		]);
+		await populateTextRefs(db);
+		const rows = await db('text_refs').select('text').orderBy('text');
+		expect(rows.map((r) => r.text)).toEqual(['Logo', 'Photograph of a cat']);
+	});
+
+	it('harvests every documented pages text column', async () => {
+		await db('pages').insert([
+			{
+				url: '/',
+				title: 't1',
+				description: 'd1',
+				keywords: 'k1',
+				robots_raw: 'r1',
+				og_title: 'ot1',
+				og_description: 'od1',
+				twitter_title: 'tt1',
+				twitter_description: 'td1',
+			},
+		]);
+		await populateTextRefs(db);
+		const rows = await db('text_refs').select('text').orderBy('text');
+		expect(rows.map((r) => r.text).toSorted()).toEqual(
+			['d1', 'k1', 'od1', 'ot1', 'r1', 't1', 'td1', 'tt1'].toSorted(),
+		);
+	});
+
+	it('matches acceptance: count == distinct text across all covered columns', async () => {
+		await db('anchors').insert([
+			{ pageId: 1, hrefId: 2, textContent: 'Home' },
+			{ pageId: 1, hrefId: 3, textContent: 'About' },
+			{ pageId: 2, hrefId: 3, textContent: 'About' }, // dup
+		]);
+		await db('images').insert([{ pageId: 1, alt: 'Home' }]); // reuses "Home"
+		await db('pages').insert([{ url: '/', title: 'Contact' }]);
+		await populateTextRefs(db);
+		// distinct union of {Home, About, Home, Contact} = {Home, About, Contact} = 3
+		expect(await countRows(db, 'text_refs')).toBe(3);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-text-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-text-refs.ts
@@ -1,0 +1,137 @@
+import type { Knex } from 'knex';
+
+import { computeContentHash } from './compute-content-hash.js';
+
+/**
+ * Number of `text_refs` rows sent per `INSERT ... VALUES (...)` statement.
+ * Each row binds 2 params (hash + text), so 500 rows = 1000 params — well
+ * under SQLite's default `SQLITE_MAX_VARIABLE_NUMBER`.
+ */
+const INSERT_CHUNK_SIZE = 500;
+
+/**
+ * Rows scanned per keyset-paginated `SELECT` chunk. One SELECT reads all
+ * text columns for the source table's chunk simultaneously so the pages
+ * table is scanned exactly once per populate call, not N-times-once-per-
+ * text-column.
+ */
+const READ_CHUNK_SIZE = 5000;
+
+/**
+ * Source table + its text-shaped columns. Groups by table so each table
+ * is scanned exactly once with a single SELECT that covers every
+ * relevant column — the per-column-scan variant used to run 8 separate
+ * pages scans and multiplied migration wall-clock accordingly.
+ *
+ * `dom_path` is intentionally absent: derivation happens later in Phase
+ * 6-G/6-H (see §dom_path Derivation in the plan) and depends on the HTML
+ * blob, not the current write-model. Migrating dom_path into `text_refs`
+ * is the job of the image-items population step, not 6-B-2.
+ */
+const TEXT_SOURCES: readonly {
+	table: 'anchors' | 'images' | 'pages';
+	columns: readonly string[];
+}[] = [
+	{ table: 'anchors', columns: ['textContent'] },
+	{ table: 'images', columns: ['alt'] },
+	{
+		table: 'pages',
+		columns: [
+			'title',
+			'description',
+			'keywords',
+			'robots_raw',
+			'og_title',
+			'og_description',
+			'twitter_title',
+			'twitter_description',
+		],
+	},
+];
+
+/**
+ * Populates `text_refs` from every text-shaped column across `anchors`,
+ * `images`, and `pages` (issue #191 step 6-B-2).
+ *
+ * Rules:
+ *
+ * - **Content-hash dedup contract**: identical text produces one row. The
+ *   hash is derived by {@link computeContentHash} (currently SHA-256,
+ *   matching `page_html_blobs.hash`; see that function's docs for the
+ *   plan-vs-implementation rationale).
+ * - **Empty and null are skipped** — an empty `<a>` tag adds no text to
+ *   the dictionary. Anchors with no text still get an `anchor_edges` row
+ *   in Phase 6-D, just with `first_text_id = NULL`.
+ * - **INSERT OR IGNORE on (hash, text)** — the composite UNIQUE from the
+ *   Phase 6-A DDL — makes the step idempotent across partial-failure
+ *   restarts.
+ *
+ * Peak memory is bounded by the count of distinct texts (all texts are
+ * held in a Map before insert). On the reference archive this Map is
+ * about 5 MB of anchor textContent + a few MB of page meta text — well
+ * within the migration process budget.
+ * @param trx - Knex instance or transaction connected to the archive DB.
+ * @example
+ * await knex.transaction(async (trx) => {
+ *   await populateTextRefs(trx);
+ * });
+ */
+export async function populateTextRefs(trx: Knex): Promise<void> {
+	const seen = new Map<string, string>();
+
+	for (const source of TEXT_SOURCES) {
+		const hasTable = await trx.schema.hasTable(source.table);
+		if (!hasTable) {
+			continue;
+		}
+		const presentColumns: string[] = [];
+		for (const column of source.columns) {
+			if (await trx.schema.hasColumn(source.table, column)) {
+				presentColumns.push(column);
+			}
+		}
+		if (presentColumns.length === 0) {
+			continue;
+		}
+
+		let cursor = 0;
+		while (true) {
+			const rows: Record<string, unknown>[] = await trx(source.table)
+				.select('id', ...presentColumns)
+				.where('id', '>', cursor)
+				.orderBy('id', 'asc')
+				.limit(READ_CHUNK_SIZE);
+			if (rows.length === 0) {
+				break;
+			}
+			cursor = rows.at(-1)!.id as number;
+			for (const row of rows) {
+				for (const column of presentColumns) {
+					const value = row[column];
+					if (typeof value !== 'string' || value === '') {
+						continue;
+					}
+					const hash = computeContentHash(value);
+					const key = hash.toString('hex');
+					if (!seen.has(key)) {
+						seen.set(key, value);
+					}
+				}
+			}
+		}
+	}
+
+	if (seen.size === 0) {
+		return;
+	}
+
+	const inserts: { hash: Buffer; text: string }[] = [];
+	for (const [hex, text] of seen) {
+		inserts.push({ hash: Buffer.from(hex, 'hex'), text });
+	}
+
+	for (let index = 0; index < inserts.length; index += INSERT_CHUNK_SIZE) {
+		const chunk = inserts.slice(index, index + INSERT_CHUNK_SIZE);
+		await trx('text_refs').insert(chunk).onConflict(['hash', 'text']).ignore();
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-url-refs.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-url-refs.spec.ts
@@ -1,0 +1,178 @@
+import knex from 'knex';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { createPhase6ARefTables } from '../create-phase6a-ref-tables.js';
+import { LibsqlDialect } from '../libsql-dialect.js';
+
+import { populateUrlRefs } from './populate-url-refs.js';
+import { countRows } from './test-utils/count-rows.js';
+
+/**
+ * Sets up a minimal in-memory archive with the source tables (pages,
+ * resources, images) that Phase 6-B-1 scans, plus the Phase 6-A ref
+ * tables. Column set is a strict subset of the real schema — only the
+ * columns `populateUrlRefs` looks at.
+ * @returns The connected Knex instance; the caller destroys it.
+ */
+async function setup(): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+		t.string('canonical').nullable();
+		t.string('og_url').nullable();
+		t.string('og_image').nullable();
+		t.string('icon_href').nullable();
+		t.string('appleTouchIcon_href').nullable();
+		t.string('amphtml').nullable();
+		t.string('manifest').nullable();
+		t.string('twitter_image').nullable();
+	});
+	await db.schema.createTable('resources', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+	});
+	await db.schema.createTable('images', (t) => {
+		t.increments('id');
+		t.string('src').nullable();
+		t.string('currentSrc').nullable();
+	});
+	await createPhase6ARefTables(db);
+	return db;
+}
+
+describe('populateUrlRefs (url-refs-upsert)', () => {
+	let db: ReturnType<typeof knex>;
+
+	beforeEach(async () => {
+		db = await setup();
+	});
+	afterEach(async () => {
+		await db.destroy();
+	});
+
+	it('inserts one url_refs row per distinct URL across pages + resources', async () => {
+		await db('pages').insert([
+			{ url: 'https://example.com/a' },
+			{ url: 'https://example.com/b' },
+			{ url: 'https://example.com/a' }, // wouldn't happen in real schema (unique), but tests dedup
+		]);
+		await db('resources').insert([
+			{ url: 'https://cdn.example.com/one.js' },
+			{ url: 'https://example.com/a' }, // overlaps with pages
+		]);
+		await populateUrlRefs(db);
+		const rows = await db('url_refs').select('url').orderBy('url');
+		expect(rows.map((r) => r.url)).toEqual([
+			'https://cdn.example.com/one.js',
+			'https://example.com/a',
+			'https://example.com/b',
+		]);
+	});
+
+	it('decomposes scheme/host/port/path/query_hash/fragment on insert', async () => {
+		await db('pages').insert([{ url: 'https://example.com:8443/foo?q=1#top' }]);
+		await populateUrlRefs(db);
+		const row = await db('url_refs')
+			.where('url', 'https://example.com:8443/foo?q=1#top')
+			.first();
+		expect(row.scheme).toBe('https');
+		expect(row.host).toBe('example.com');
+		expect(row.port).toBe(8443);
+		expect(row.path).toBe('/foo');
+		expect(row.fragment).toBe('top');
+		expect(row.query_hash).not.toBeNull();
+		expect(Buffer.from(row.query_hash).byteLength).toBe(32);
+	});
+
+	it('harvests URL-shaped meta columns from pages', async () => {
+		await db('pages').insert([
+			{
+				url: 'https://example.com/a',
+				canonical: 'https://example.com/canonical',
+				og_url: 'https://example.com/og',
+				og_image: 'https://cdn.example.com/og-image.png',
+				icon_href: 'https://example.com/favicon.ico',
+				appleTouchIcon_href: 'https://example.com/apple.png',
+				amphtml: 'https://example.com/amp',
+				manifest: 'https://example.com/manifest.json',
+				twitter_image: 'https://example.com/tw.png',
+			},
+		]);
+		await populateUrlRefs(db);
+		const rows = await db('url_refs').select('url').orderBy('url');
+		expect(rows.map((r) => r.url)).toEqual([
+			'https://cdn.example.com/og-image.png',
+			'https://example.com/a',
+			'https://example.com/amp',
+			'https://example.com/apple.png',
+			'https://example.com/canonical',
+			'https://example.com/favicon.ico',
+			'https://example.com/manifest.json',
+			'https://example.com/og',
+			'https://example.com/tw.png',
+		]);
+	});
+
+	it('accepts short data: URIs into url_refs and skips large ones', async () => {
+		const shortDataUri = 'data:image/svg+xml;base64,PHN2Zy8+'; // ~30 chars
+		const longDataUri = 'data:image/png;base64,' + 'A'.repeat(600); // > 512
+		await db('images').insert([
+			{ src: shortDataUri, currentSrc: null },
+			{ src: longDataUri, currentSrc: null },
+			{ src: 'https://example.com/img.png', currentSrc: 'https://example.com/img.png' },
+		]);
+		await populateUrlRefs(db);
+		const urlRows = await db('url_refs').select('url');
+		const urls = new Set(urlRows.map((r) => r.url));
+		expect(urls.has(shortDataUri)).toBe(true);
+		expect(urls.has(longDataUri)).toBe(false);
+		expect(urls.has('https://example.com/img.png')).toBe(true);
+	});
+
+	it('is idempotent (upsert / no dup)', async () => {
+		await db('pages').insert([{ url: 'https://example.com/a' }]);
+		await populateUrlRefs(db);
+		await populateUrlRefs(db);
+		expect(await countRows(db, 'url_refs')).toBe(1);
+	});
+
+	it('leaves decomposed columns null for unparseable URLs but still stores raw', async () => {
+		// Leading colon guarantees WHATWG URL parse failure — no valid scheme.
+		const bad = ':::not-a-url';
+		await db('pages').insert([{ url: bad }]);
+		await populateUrlRefs(db);
+		const row = await db('url_refs').where('url', bad).first();
+		expect(row).toBeDefined();
+		expect(row.scheme).toBeNull();
+		expect(row.host).toBeNull();
+		expect(row.port).toBeNull();
+		expect(row.path).toBeNull();
+		expect(row.query_hash).toBeNull();
+		expect(row.fragment).toBeNull();
+	});
+
+	it('satisfies the acceptance count invariant (>= distinct pages.url + resources.url)', async () => {
+		await db('pages').insert([
+			{ url: 'https://example.com/a' },
+			{ url: 'https://example.com/b' },
+		]);
+		await db('resources').insert([
+			{ url: 'https://cdn.example.com/x.js' },
+			{ url: 'https://cdn.example.com/y.css' },
+		]);
+		await populateUrlRefs(db);
+		const totalRefs = await countRows(db, 'url_refs');
+		const pagesDistinct = await db('pages').countDistinct<{ n: number }[]>({ n: 'url' });
+		const resourcesDistinct = await db('resources').countDistinct<{ n: number }[]>({
+			n: 'url',
+		});
+		expect(totalRefs).toBeGreaterThanOrEqual(
+			Number(pagesDistinct[0]!.n) + Number(resourcesDistinct[0]!.n),
+		);
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/phase6b/populate-url-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/populate-url-refs.ts
@@ -1,0 +1,161 @@
+import type { Knex } from 'knex';
+
+import { DATA_URI_URL_REFS_LIMIT } from './data-uri-url-refs-limit.js';
+import { decomposeUrl } from './decompose-url.js';
+
+/**
+ * Rows inserted per `INSERT INTO url_refs ... VALUES (...)` statement. Kept
+ * well under SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (default 32766 on
+ * modern builds) — each row binds 7 parameters (url + scheme + host +
+ * port + path + query_hash + fragment), so 500 rows = 3500 params.
+ */
+const INSERT_CHUNK_SIZE = 500;
+
+/**
+ * Rows scanned per keyset-paginated `SELECT` chunk. One SELECT reads all
+ * URL columns for the source table's chunk simultaneously so the pages
+ * table is scanned exactly once per populate call, not N-times-once-
+ * per-URL-column — the previous per-column-scan implementation multiplied
+ * migration wall-clock by the count of URL-shaped columns.
+ */
+const READ_CHUNK_SIZE = 5000;
+
+/**
+ * Source table + its URL-shaped columns. Each column is scanned in
+ * lock-step per row, then filtered through
+ * {@link routeDataUriAwayFromUrlRefs} so large data URIs skip `url_refs`
+ * and route to `blob_refs` in step 6-B-4 instead.
+ *
+ * The filter is applied to EVERY URL column (not just image columns):
+ * `og:image`, `icon_href`, `apple-touch-icon`, `twitter:image`, and even
+ * `og:url` / `canonical` can legally hold data URIs in the wild, and a
+ * >512-byte data URI in any of those must land in `blob_refs`, not
+ * pollute the URL dictionary.
+ */
+const URL_SOURCES: readonly {
+	table: 'pages' | 'resources' | 'images';
+	columns: readonly string[];
+}[] = [
+	{
+		table: 'pages',
+		columns: [
+			'url',
+			'canonical',
+			'og_url',
+			'og_image',
+			'icon_href',
+			'appleTouchIcon_href',
+			'amphtml',
+			'manifest',
+			'twitter_image',
+		],
+	},
+	{ table: 'resources', columns: ['url'] },
+	{ table: 'images', columns: ['src', 'currentSrc'] },
+];
+
+/**
+ * Predicate applied to every URL column value: keep the value in the
+ * `url_refs` stream unless it is a data URI larger than
+ * {@link DATA_URI_URL_REFS_LIMIT}. Large data URIs route to `blob_refs`
+ * in step 6-B-4 (via {@link ./populate-blob-refs.ts}).
+ * @param value - Raw column value (non-null, non-empty by contract).
+ * @returns `true` if the value belongs in `url_refs`.
+ */
+function routeDataUriAwayFromUrlRefs(value: string): boolean {
+	if (!value.startsWith('data:')) {
+		return true;
+	}
+	return value.length <= DATA_URI_URL_REFS_LIMIT;
+}
+
+/**
+ * Populates `url_refs` from every URL-shaped column across `pages`,
+ * `resources`, and `images` (issue #191 step 6-B-1).
+ *
+ * Runs two passes per source table:
+ *
+ * 1. **Collect distinct URLs** into an in-process `Set<string>`, streaming
+ *    rows from each source table by keyset pagination on `id`. All the
+ *    table's URL columns are read in a single SELECT so the pages scan
+ *    is O(rows), not O(rows × columns). Peak memory is bounded by the
+ *    count of distinct URLs, not the row count.
+ * 2. **Bulk-insert** into `url_refs` in chunks of {@link INSERT_CHUNK_SIZE},
+ *    with the decomposed columns (`scheme` / `host` / `port` / `path` /
+ *    `query_hash` / `fragment`) derived in JS by {@link decomposeUrl}.
+ *
+ * `INSERT OR IGNORE` on `url_refs.url` makes the step idempotent —
+ * repeated invocations after partial failure only add new URLs.
+ * @param trx - Knex instance or transaction connected to the archive DB.
+ * @example
+ * await knex.transaction(async (trx) => {
+ *   await populateUrlRefs(trx);
+ * });
+ */
+export async function populateUrlRefs(trx: Knex): Promise<void> {
+	const seen = new Set<string>();
+
+	for (const source of URL_SOURCES) {
+		const hasTable = await trx.schema.hasTable(source.table);
+		if (!hasTable) {
+			continue;
+		}
+		const presentColumns: string[] = [];
+		for (const column of source.columns) {
+			if (await trx.schema.hasColumn(source.table, column)) {
+				presentColumns.push(column);
+			}
+		}
+		if (presentColumns.length === 0) {
+			continue;
+		}
+
+		let cursor = 0;
+		while (true) {
+			const rows: Record<string, unknown>[] = await trx(source.table)
+				.select('id', ...presentColumns)
+				.where('id', '>', cursor)
+				.orderBy('id', 'asc')
+				.limit(READ_CHUNK_SIZE);
+			if (rows.length === 0) {
+				break;
+			}
+			cursor = rows.at(-1)!.id as number;
+			for (const row of rows) {
+				for (const column of presentColumns) {
+					const value = row[column];
+					if (typeof value !== 'string' || value === '') {
+						continue;
+					}
+					if (!routeDataUriAwayFromUrlRefs(value)) {
+						continue;
+					}
+					seen.add(value);
+				}
+			}
+		}
+	}
+
+	if (seen.size === 0) {
+		return;
+	}
+
+	const inserts: {
+		url: string;
+		scheme: string | null;
+		host: string | null;
+		port: number | null;
+		path: string | null;
+		query_hash: Buffer | null;
+		fragment: string | null;
+	}[] = [];
+	for (const url of seen) {
+		const decomposed = decomposeUrl(url);
+		inserts.push({ url, ...decomposed });
+	}
+
+	for (let index = 0; index < inserts.length; index += INSERT_CHUNK_SIZE) {
+		const chunk = inserts.slice(index, index + INSERT_CHUNK_SIZE);
+		await trx('url_refs').insert(chunk).onConflict('url').ignore();
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/test-utils/count-rows.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/test-utils/count-rows.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex';
+
+/**
+ * Runs `SELECT count(?) FROM <table>` and returns the count as a plain
+ * JS number. Exists purely to keep spec files inside phase6b/ compliant
+ * with `unicorn/no-await-expression-member` — inlining
+ * `Number((await db(t).count(...))[0]!.n)` reads fine but violates the
+ * rule at every callsite.
+ * @param db - Knex instance (typically a spec-local in-memory DB).
+ * @param table - Table name.
+ * @param countColumn - Column to count; defaults to `'id'` because every
+ *   phase6b table except `header_set_entries` / `header_flags` uses
+ *   that PK name. Pass `'header_set_id'` for the two exceptions.
+ * @returns Row count.
+ */
+export async function countRows(
+	db: Knex,
+	table: string,
+	countColumn = 'id',
+): Promise<number> {
+	const rows = await db(table).count<{ n: number }[]>({ n: countColumn });
+	return Number(rows[0]!.n);
+}

--- a/packages/@nitpicker/crawler/src/archive/phase6b/types.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/types.ts
@@ -1,0 +1,195 @@
+/**
+ * Domain types for the Phase 6-B population step (issue #191). Every
+ * shared interface / type alias lives here per the repo-wide
+ * `型は types.ts に集約` rule; implementation modules export functions
+ * only.
+ */
+
+/**
+ * Decomposed URL components that populate `url_refs.{scheme,host,port,path,
+ * query_hash,fragment}`. All slots are populated in a single pass over the
+ * `url` string so callers do not have to re-parse per column.
+ */
+export interface DecomposedUrl {
+	/**
+	 * URL scheme without the trailing colon (`https`, `http`, `mailto`, ...).
+	 * `null` for URLs that fail `new URL(...)` parsing.
+	 */
+	scheme: string | null;
+	/**
+	 * Host lower-cased (`www.example.com`). `null` when the URL has no
+	 * `authority` component (e.g. `mailto:`, `data:`, `javascript:`), and
+	 * `null` on parse failure.
+	 */
+	host: string | null;
+	/**
+	 * TCP port when explicit in the URL; `null` when the URL uses the
+	 * scheme default (WHATWG URL normalises default ports away — we do NOT
+	 * synthesise a default here because two rows differing only by explicit
+	 * vs implicit `:443` should hash to the same URL, and `url_refs.url` is
+	 * the natural key, not this column).
+	 */
+	port: number | null;
+	/**
+	 * Path portion (`/foo/bar`). `null` when the URL has no path or the
+	 * URL uses an opaque scheme whose "pathname" is really an in-band
+	 * payload (`data:`, `blob:`, `javascript:`) — see
+	 * {@link ../decompose-url.ts} for the opaque-scheme handling.
+	 */
+	path: string | null;
+	/**
+	 * 32-byte content hash of the raw query string exactly as it appears in
+	 * the URL (`?a=1&b=2` — the leading `?` is stripped before hashing).
+	 * `null` when the URL has no query string, when the query string is
+	 * empty, or on parse failure.
+	 *
+	 * Storing the raw query would defeat dedup on tracker URLs whose
+	 * per-request query keys blow up dictionary size; the hash retains the
+	 * same-URL-⇒-same-row property without the payload.
+	 */
+	query_hash: Buffer | null;
+	/**
+	 * Fragment (`#section-2`) with the leading `#` stripped. `null` when
+	 * the URL has no fragment or on parse failure.
+	 */
+	fragment: string | null;
+}
+
+/**
+ * Successful decode of a `data:` URI: the raw payload bytes.
+ */
+export interface DecodedDataUri {
+	/** Payload bytes after base64 or percent-decoding. */
+	bytes: Buffer;
+}
+
+/**
+ * One header entry after decomposition — flattened out of the parsed JSON
+ * `Record<name, string | string[]>` so that:
+ *
+ * - Multiple values for the same name (e.g. two `Set-Cookie` lines) each
+ *   get their own entry with a distinct `occurrence` ordinal starting at 1.
+ * - `isVolatile` is pre-computed once per entry (rather than re-looked-up
+ *   at hash time) so both `stableHash` and the `header_set_entries`
+ *   inserts see identical classification.
+ */
+export interface HeaderEntry {
+	/** Lower-cased header name; comparison and dedup keys always use this form. */
+	name: string;
+	/** Raw header value (each element of `string[]` inputs becomes one entry). */
+	value: string;
+	/**
+	 * 1-based ordinal among entries sharing the same `name` within one
+	 * response. Always `1` for single-value headers; ≥ 2 when a name
+	 * repeats (e.g. multiple `Set-Cookie` lines).
+	 */
+	occurrence: number;
+	/** Pre-computed volatility. */
+	isVolatile: boolean;
+}
+
+/**
+ * Result of decomposing one raw `responseHeaders` JSON string into the
+ * shape required for `header_sets`, `header_set_entries`, and
+ * `header_flags` inserts. `null` results from the decompose helper
+ * indicate "no header set to insert" (null / `{}` / parse failure);
+ * callers write `header_set_id = null` to the referring row.
+ */
+export interface DecomposedHeaderSet {
+	/**
+	 * 32-byte hash of the raw JSON string exactly as stored on the source
+	 * row. Populates `header_sets.raw_json_hash` — a temporary column used
+	 * by the Phase 6-D lookup to map an old `pages.responseHeaders` /
+	 * `resources.responseHeaders` value back to its `header_sets.id`
+	 * without any SQL function call.
+	 */
+	rawJsonHash: Buffer;
+	/**
+	 * 32-byte hash of the sorted `name=value` pairs of **all** entries
+	 * (stable + volatile). Populates `header_sets.raw_hash` — a UNIQUE
+	 * column so a JS-side upsert can dedup on identical decoded sets.
+	 */
+	rawHash: Buffer;
+	/**
+	 * 32-byte hash of the sorted `name=value` pairs of stable entries
+	 * only. Populates `header_sets.stable_hash` — indexed so Phase 6-F
+	 * readers can answer "how many responses share this stable header
+	 * profile" without scanning every entry.
+	 */
+	stableHash: Buffer;
+	/**
+	 * 32-byte hash of the sorted `name=value` pairs of volatile entries
+	 * only, or `null` when the set has no volatile entries. Populates
+	 * `header_sets.volatile_hash`.
+	 */
+	volatileHash: Buffer | null;
+	/** Every decomposed entry, ordered by (name, occurrence). */
+	entries: readonly HeaderEntry[];
+	/** Total entry count — matches `header_sets.entry_count`. */
+	entryCount: number;
+	/**
+	 * Number of stable entries — matches `header_sets.stable_entry_count`.
+	 * `volatile_entry_count` is derived as `entry_count - stable_entry_count`
+	 * and not stored separately.
+	 */
+	stableEntryCount: number;
+}
+
+/**
+ * Shape written into `header_flags` for one `header_set_id`. `has_*`
+ * columns are `INTEGER NOT NULL` (0/1) per the Phase 6-A DDL;
+ * `cache_policy` is nullable and holds a compact summary of the
+ * `Cache-Control` value (or `null` when absent).
+ */
+export interface HeaderFlagsRow {
+	/** `1` when at least one entry's name equals `content-security-policy`. */
+	has_csp: 0 | 1;
+	/** `1` when at least one entry's name equals `x-frame-options`. */
+	has_x_frame_options: 0 | 1;
+	/** `1` when at least one entry's name equals `x-content-type-options`. */
+	has_x_content_type_options: 0 | 1;
+	/** `1` when at least one entry's name equals `strict-transport-security`. */
+	has_hsts: 0 | 1;
+	/** `1` when at least one entry's name equals `referrer-policy`. */
+	has_referrer_policy: 0 | 1;
+	/** `1` when at least one entry's name equals `permissions-policy`. */
+	has_permissions_policy: 0 | 1;
+	/** `1` when at least one entry's name equals `set-cookie`. */
+	has_set_cookie: 0 | 1;
+	/**
+	 * The `cache-control` value, verbatim, when present; `null` when
+	 * absent. Multi-value `Cache-Control` headers are joined with `, ` so
+	 * the summary captures every directive without losing per-occurrence
+	 * context.
+	 */
+	cache_policy: string | null;
+}
+
+/**
+ * Category label attached to each content-type rule. Mirrors the union
+ * `ContentTypeCategory` in `@nitpicker/query/src/types.ts` — kept as a
+ * plain string literal here so `@nitpicker/crawler`'s Phase 6-B step
+ * does not need to depend on `@nitpicker/query` (which itself depends
+ * on this package). If the two copies drift, `classify-content-type.spec.ts`
+ * here and `content-type-rules.spec.ts` on the query side will disagree
+ * on the same fixture.
+ */
+export type Phase6BContentTypeCategory =
+	| 'html'
+	| 'pdf'
+	| 'csv'
+	| 'word'
+	| 'excel'
+	| 'powerpoint'
+	| 'image'
+	| 'audio'
+	| 'video'
+	| 'font'
+	| 'css'
+	| 'javascript'
+	| 'json'
+	| 'xml'
+	| 'archive'
+	| 'text'
+	| 'other'
+	| 'unknown';

--- a/packages/@nitpicker/crawler/src/archive/phase6b/volatile-header-names.ts
+++ b/packages/@nitpicker/crawler/src/archive/phase6b/volatile-header-names.ts
@@ -1,0 +1,32 @@
+/**
+ * Header names — always lower-cased — that are EXCLUDED from `stable_hash`.
+ * These change on every response (timestamps / request IDs / cache
+ * telemetry) and would defeat the dedup goal if hashed alongside the
+ * stable set.
+ *
+ * `set-cookie` sits here because per-session cookies rotate constantly on
+ * authenticated sites — the plan's §Stable / Volatile Classification
+ * table treats it as volatile even though it is technically a stable
+ * security signal.
+ *
+ * Kept in lock-step with the plan (`docs/write-model-refactor-plan.md`
+ * §Stable / Volatile Classification). Any header not in this set is
+ * treated as **stable** by {@link ./header-stability.ts:isVolatileHeader}
+ * — the safer default because miscounting a genuinely volatile header as
+ * stable only loses dedup; miscounting a stable one as volatile could
+ * split the same logical header set into multiple `header_sets` rows.
+ */
+export const VOLATILE_HEADER_NAMES: ReadonlySet<string> = new Set([
+	'date',
+	'expires',
+	'last-modified',
+	'etag',
+	'age',
+	'via',
+	'x-cache',
+	'cf-ray',
+	'x-request-id',
+	'set-cookie',
+	'server-timing',
+	'x-amz-request-id',
+]);

--- a/packages/@nitpicker/crawler/src/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler.ts
@@ -46,3 +46,16 @@ export * from './types.js';
 export * from './crawler/types.js';
 export { classifyErrorKind } from './classify-error-kind.js';
 export { computeFileSha256 } from './utils/compute-file-sha256.js';
+
+// Phase 6-B ref-table population (issue #191, epic #103). Exposed as the
+// public seam that a follow-up migration script (`scripts/migrate-to-
+// phase6.mjs` per the plan) drives against an already-connected archive.
+// The individual sub-steps are also exported so the migration script can
+// resume mid-way if the caller decides to split the transaction.
+export { populatePhase6BRefs } from './archive/phase6b/populate-phase6b-refs.js';
+export { populateContentTypeRefs } from './archive/phase6b/populate-content-type-refs.js';
+export { populateUrlRefs } from './archive/phase6b/populate-url-refs.js';
+export { populateTextRefs } from './archive/phase6b/populate-text-refs.js';
+export { populateJsonRefs } from './archive/phase6b/populate-json-refs.js';
+export { populateBlobRefs } from './archive/phase6b/populate-blob-refs.js';
+export { populateHeaderTables } from './archive/phase6b/populate-header-tables.js';


### PR DESCRIPTION
Part of #103. Closes #191 (blocked by #190, already merged in #198).

## Summary

Populates the ten Phase 6-A ref / header dictionary tables from existing archive data. Additive only — no existing table is touched; both schemas coexist until Phase 6-F swaps readers.

Six populate helpers land under `packages/@nitpicker/crawler/src/archive/phase6b/`:

- `populateContentTypeRefs` (6-B-0)
- `populateUrlRefs` (6-B-1)
- `populateTextRefs` (6-B-2)
- `populateJsonRefs` (6-B-3, zstd + hash dedup)
- `populateBlobRefs` (6-B-4, data URIs > 512 B routed here)
- `populateHeaderTables` (6-B-5, decomposes `responseHeaders` JSON)

An orchestrator `populatePhase6BRefs` runs them in the plan-specified order. All exposed via `crawler.ts` so the follow-up migration script (per plan §Migration Strategy) can drive them.

## Design notes

- **Hash**: SHA-256 (32-byte `BLOB`, matches `page_html_blobs.hash`). The plan named BLAKE3 as an example, but no BLAKE3 lib is in the crawler's dependency graph; every call routes through `computeContentHash` so a later swap is a one-file edit.
- **Idempotence**: every sub-step uses `INSERT OR IGNORE` on its natural key; the whole invocation is meant to run inside one writer transaction with `.bak` protection at the caller level.
- **Header decomposition**: handles Phase 6-A's `raw_json_hash` + `raw_hash` double-UNIQUE via a raw_hash-first lookup (two JSON strings with different key ordering but identical sorted entries share one `header_sets` row). Case-insensitive duplicate header names get distinct occurrence ordinals (`Cookie` + `cookie` → occurrence 1 + 2). Partial-run recovery: preloaded set-ids still trigger entries + flags inserts so orphaned `header_sets` rows are repaired instead of skipped.
- **Data URI routing**: `> 512 B` goes to `blob_refs`, ≤ 512 B stays in `url_refs`. Filter applied to every URL-shaped column across pages / resources / images so `og:image` / `icon_href` / etc data URIs land in the right table. Base64 payloads validated (alphabet + padding shape) so malformed URIs return `null` instead of silently decoding to truncated garbage. Non-base64 percent-decoded via octet-preserving byte scan (avoids the `decodeURIComponent` → UTF-8 re-encode round-trip that corrupts arbitrary binary).
- **Opaque schemes**: `data:` / `blob:` / `javascript:` leave `url_refs.path` null so per-URL base64 tails don't pollute the indexed column.

## Acceptance (per issue #191)

- [x] `url_refs count` ≥ `distinct(pages.url) + distinct(resources.url)` (spec-verified)
- [x] `text_refs count` = distinct text across all covered columns (spec-verified)
- [x] Same `meta_extras` twice → same `json_refs.id` (spec-verified)
- [x] Unit tests: `url-refs-upsert`, `text-refs-dedup`, `json-refs-dedup`, `header-set-decomposition` (including multiple same-name headers), `header-flags-computation`
- [x] Sub-issue branch off `feature/impl-new-db`

## Test plan

- [x] `yarn vitest run --dir packages/@nitpicker/crawler/src/archive/phase6b/` — 14 files, 109 tests, all pass
- [x] `yarn build` — full monorepo builds cleanly
- [x] `yarn lint` — no new errors introduced (0 errors from phase6b files; pre-existing warnings elsewhere untouched)
- [ ] CI green on this PR

## Deferred / follow-up

Findings from code review that are out of Phase 6-B scope, worth their own issues:

- Move `CONTENT_TYPE_RULES` to `@d-zero/shared` so `@nitpicker/crawler` and `@nitpicker/query` share one source of truth (currently duplicated with a documented drift-warning contract)
- Phase 6-A schema: add a `raw_json_hash → setId` mapping table so identical-content responses with different JSON key ordering can BOTH be found via `raw_json_hash` lookup in Phase 6-D (current PR handles the second variant in-process only; on restart Phase 6-D loses the mapping)
- Async zstd or worker-thread compression for `populateJsonRefs` / `populateBlobRefs` on very large archives (current sync compression blocks the event loop)
- Benchmark harness for `populatePhase6BRefs` against a real large archive

## Blocks

Blocks #193 per the plan's Phase 6-C ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
