### PR TITLE
feat(crawler): add phase 6-c entity and edge tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"lerna": "9.0.7",
 		"npm-run-all2": "9.0.2",
 		"typescript": "6.0.3",
-		"vitest": "4.1.9"
+		"vitest": "4.1.10"
 	},
 	"resolutions": {
 		"google-auth-library": "10.9.0"

--- a/packages/@nitpicker/crawler/src/archive/create-phase6c-entity-tables.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/create-phase6c-entity-tables.spec.ts
@@ -1,0 +1,576 @@
+import knex from 'knex';
+import { describe, it, expect } from 'vitest';
+
+import { createPhase6ARefTables } from './create-phase6a-ref-tables.js';
+import { createPhase6CEntityTables } from './create-phase6c-entity-tables.js';
+import { LibsqlDialect } from './libsql-dialect.js';
+
+/**
+ * Creates the Phase 6-A ref tables that Phase 6-C references, then runs the
+ * Phase 6-C DDL against a fresh in-memory database.
+ * @param options - `foreignKeys: true` enables `PRAGMA foreign_keys = ON`
+ *   before the caller runs INSERTs (required for any test that exercises
+ *   FK / CASCADE / DEFERRABLE / CHECK behaviour).
+ * @param options.foreignKeys
+ * @returns The knex instance; the caller MUST call `db.destroy()`.
+ */
+async function openDbWithPhase6C(
+	options: { foreignKeys?: boolean } = {},
+): Promise<ReturnType<typeof knex>> {
+	const db = knex({
+		client: LibsqlDialect,
+		connection: { filename: ':memory:' },
+		useNullAsDefault: true,
+	});
+	if (options.foreignKeys) {
+		await db.raw('PRAGMA foreign_keys = ON');
+	}
+	await createPhase6ARefTables(db);
+	await createPhase6CEntityTables(db);
+	return db;
+}
+
+/**
+ * Inserts one `url_refs` row and returns its id, so downstream FK-bearing
+ * INSERTs have a legal target.
+ * @param db - Knex instance connected to a fresh DB with 6-A + 6-C DDL applied.
+ * @param url - URL to insert; must be unique per db.
+ * @returns The rowid of the inserted `url_refs` row.
+ */
+async function insertUrl(db: ReturnType<typeof knex>, url: string): Promise<number> {
+	const [row] = await db.raw('INSERT INTO url_refs (url) VALUES (?) RETURNING id', [url]);
+	return row.id;
+}
+
+/**
+ * Inserts one `text_refs` row for use as an FK target (image_items.dom_path_text_id
+ * is NOT NULL and page_meta text FKs are exercised in some tests).
+ * @param db - Knex instance connected to a fresh DB with 6-A + 6-C DDL applied.
+ * @param hash - 16-byte hash placeholder.
+ * @param text - Text body.
+ * @returns The rowid of the inserted `text_refs` row.
+ */
+async function insertText(
+	db: ReturnType<typeof knex>,
+	hash: Buffer,
+	text: string,
+): Promise<number> {
+	const [row] = await db.raw(
+		'INSERT INTO text_refs (hash, text) VALUES (?, ?) RETURNING id',
+		[hash, text],
+	);
+	return row.id;
+}
+
+/**
+ * Inserts a minimal `content_items` row (id 1) so tests that need a valid
+ * `page_id` FK target for `page_meta` / `anchor_edges` / `image_items` /
+ * `resource_ref_edges` have one to point at.
+ * @param db - Knex instance with FK enabled.
+ * @param id - Explicit id to insert.
+ * @param urlSuffix - Distinguishes URLs across multiple content_items rows.
+ */
+async function insertContentItem(
+	db: ReturnType<typeof knex>,
+	id: number,
+	urlSuffix: string,
+): Promise<void> {
+	const urlId = await insertUrl(db, `https://example.com/${urlSuffix}`);
+	await db.raw(
+		`INSERT INTO content_items
+			(id, url_id, is_external, scraped, is_target)
+			VALUES (?, ?, 0, 1, 1)`,
+		[id, urlId],
+	);
+}
+
+describe('createPhase6CEntityTables', () => {
+	it('creates content_items with the expected columns', async () => {
+		const db = await openDbWithPhase6C();
+
+		const columns = await db.raw("PRAGMA table_info('content_items')");
+		const names = columns.map((c: { name: string }) => c.name);
+		expect(names).toEqual([
+			'id',
+			'url_id',
+			'is_external',
+			'scraped',
+			'is_target',
+			'status',
+			'status_text',
+			'content_type_id',
+			'content_length',
+			'header_set_id',
+			'redirect_dest_id',
+			'source',
+			'first_crawled_at',
+			'last_crawled_at',
+			'crawl_order',
+			'is_skipped',
+			'skip_reason',
+		]);
+
+		await db.destroy();
+	});
+
+	it('declares content_items.id as INTEGER PRIMARY KEY AUTOINCREMENT (matches legacy pages contract)', async () => {
+		const db = await openDbWithPhase6C();
+
+		const [{ sql }] = await db.raw(
+			"SELECT sql FROM sqlite_master WHERE type='table' AND name='content_items'",
+		);
+		expect(sql).toMatch(/AUTOINCREMENT/i);
+
+		// resource_items / anchor_edges / image_items must also match.
+		for (const table of ['resource_items', 'anchor_edges', 'image_items']) {
+			const [row] = await db.raw(
+				`SELECT sql FROM sqlite_master WHERE type='table' AND name='${table}'`,
+			);
+			expect(row.sql, `${table} should use AUTOINCREMENT`).toMatch(/AUTOINCREMENT/i);
+		}
+
+		await db.destroy();
+	});
+
+	it('enforces UNIQUE(url_id) on content_items and resource_items', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		const urlIdA = await insertUrl(db, 'https://example.com/a');
+		await db.raw(
+			`INSERT INTO content_items
+				(id, url_id, is_external, scraped, is_target)
+				VALUES (1, ?, 0, 1, 1)`,
+			[urlIdA],
+		);
+		await expect(
+			db.raw(
+				`INSERT INTO content_items
+					(id, url_id, is_external, scraped, is_target)
+					VALUES (2, ?, 0, 1, 1)`,
+				[urlIdA],
+			),
+		).rejects.toThrow();
+
+		const urlIdB = await insertUrl(db, 'https://example.com/b.js');
+		await db.raw(
+			'INSERT INTO resource_items (id, url_id, is_external) VALUES (1, ?, 0)',
+			[urlIdB],
+		);
+		await expect(
+			db.raw('INSERT INTO resource_items (id, url_id, is_external) VALUES (2, ?, 0)', [
+				urlIdB,
+			]),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it("defaults content_items.source and resource_items.source to 'crawled'", async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		const urlIdA = await insertUrl(db, 'https://example.com/');
+		await db.raw(
+			`INSERT INTO content_items
+				(id, url_id, is_external, scraped, is_target)
+				VALUES (1, ?, 0, 1, 1)`,
+			[urlIdA],
+		);
+		const [ci] = await db.raw('SELECT source FROM content_items WHERE id = 1');
+		expect(ci.source).toBe('crawled');
+
+		const urlIdB = await insertUrl(db, 'https://example.com/style.css');
+		await db.raw(
+			'INSERT INTO resource_items (id, url_id, is_external) VALUES (1, ?, 0)',
+			[urlIdB],
+		);
+		const [ri] = await db.raw('SELECT source FROM resource_items WHERE id = 1');
+		expect(ri.source).toBe('crawled');
+
+		await db.destroy();
+	});
+
+	it('accepts a self-referential redirect_dest_id on content_items', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		await insertContentItem(db, 1, 'a');
+		const urlIdB = await insertUrl(db, 'https://example.com/b');
+		await db.raw(
+			`INSERT INTO content_items
+				(id, url_id, is_external, scraped, is_target, redirect_dest_id)
+				VALUES (2, ?, 0, 1, 1, 1)`,
+			[urlIdB],
+		);
+
+		// A non-existent destination is still rejected at commit time.
+		await expect(
+			(async () => {
+				const urlIdC = await insertUrl(db, 'https://example.com/c');
+				await db.raw(
+					`INSERT INTO content_items
+						(id, url_id, is_external, scraped, is_target, redirect_dest_id)
+						VALUES (3, ?, 0, 1, 1, 999)`,
+					[urlIdC],
+				);
+			})(),
+		).rejects.toThrow();
+
+		await db.destroy();
+	});
+
+	it('allows deferring content_items.redirect_dest_id inside a transaction', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		// The forward reference (child inserted before parent) is legal
+		// because the FK is DEFERRABLE INITIALLY DEFERRED and both inserts
+		// live inside one transaction.
+		const urlIdChild = await insertUrl(db, 'https://example.com/child');
+		const urlIdParent = await insertUrl(db, 'https://example.com/parent');
+
+		await db.transaction(async (trx) => {
+			await trx.raw(
+				`INSERT INTO content_items
+					(id, url_id, is_external, scraped, is_target, redirect_dest_id)
+					VALUES (10, ?, 0, 1, 1, 20)`,
+				[urlIdChild],
+			);
+			await trx.raw(
+				`INSERT INTO content_items
+					(id, url_id, is_external, scraped, is_target)
+					VALUES (20, ?, 0, 1, 1)`,
+				[urlIdParent],
+			);
+		});
+
+		await db.destroy();
+	});
+
+	it('creates page_meta keyed by page_id 1:1 with content_items and CASCADE deletes', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		await insertContentItem(db, 1, 'a');
+		await db.raw('INSERT INTO page_meta (page_id, lang) VALUES (1, ?)', ['ja']);
+
+		// PK uniqueness: a second row with page_id=1 is rejected.
+		await expect(
+			db.raw('INSERT INTO page_meta (page_id, lang) VALUES (1, ?)', ['en']),
+		).rejects.toThrow();
+
+		// FK: page_id=999 has no matching content_items row.
+		await expect(
+			db.raw('INSERT INTO page_meta (page_id) VALUES (999)'),
+		).rejects.toThrow();
+
+		// CASCADE: deleting the content_items parent must also drop the
+		// page_meta child.
+		await db.raw('DELETE FROM content_items WHERE id = 1');
+		const [{ n }] = await db.raw('SELECT COUNT(*) AS n FROM page_meta WHERE page_id = 1');
+		expect(n).toBe(0);
+
+		await db.destroy();
+	});
+
+	it('creates resource_items with the expected columns', async () => {
+		const db = await openDbWithPhase6C();
+
+		const columns = await db.raw("PRAGMA table_info('resource_items')");
+		const names = columns.map((c: { name: string }) => c.name);
+		expect(names).toEqual([
+			'id',
+			'url_id',
+			'is_external',
+			'status',
+			'status_text',
+			'content_type_id',
+			'content_length',
+			'header_set_id',
+			'compress',
+			'cdn',
+			'source',
+		]);
+
+		await db.destroy();
+	});
+
+	it('enforces UNIQUE(page_id, href_page_id) on anchor_edges', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		await insertContentItem(db, 1, 'source');
+		await insertContentItem(db, 2, 'dest');
+
+		await db.raw(
+			'INSERT INTO anchor_edges (page_id, href_page_id, count) VALUES (1, 2, 1)',
+		);
+		// Same pair — must be rejected even with a different count.
+		await expect(
+			db.raw('INSERT INTO anchor_edges (page_id, href_page_id, count) VALUES (1, 2, 3)'),
+		).rejects.toThrow();
+
+		// Confirm the UNIQUE targets the (page_id, href_page_id) pair
+		// specifically (not, say, `id` alone which would also satisfy
+		// "at least one unique index exists" on a PK-only shape).
+		const indexes: { name: string; unique: number }[] = await db.raw(
+			"PRAGMA index_list('anchor_edges')",
+		);
+		const uniqueIndexes = indexes.filter((i) => i.unique === 1);
+		let pairIndexFound = false;
+		for (const idx of uniqueIndexes) {
+			const info: { name: string }[] = await db.raw(`PRAGMA index_info('${idx.name}')`);
+			const cols = info.map((c) => c.name);
+			if (cols.length === 2 && cols[0] === 'page_id' && cols[1] === 'href_page_id') {
+				pairIndexFound = true;
+				break;
+			}
+		}
+		expect(pairIndexFound).toBe(true);
+
+		await db.destroy();
+	});
+
+	it('creates resource_ref_edges as WITHOUT ROWID with composite PK and page_id index', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		const [{ sql }] = await db.raw(
+			"SELECT sql FROM sqlite_master WHERE type='table' AND name='resource_ref_edges'",
+		);
+		expect(sql).toMatch(/WITHOUT ROWID/i);
+
+		await insertContentItem(db, 1, 'page');
+		const urlIdRes = await insertUrl(db, 'https://example.com/asset.js');
+		await db.raw(
+			'INSERT INTO resource_items (id, url_id, is_external) VALUES (1, ?, 0)',
+			[urlIdRes],
+		);
+
+		await db.raw(
+			'INSERT INTO resource_ref_edges (resource_id, page_id, count) VALUES (1, 1, 1)',
+		);
+		await expect(
+			db.raw(
+				'INSERT INTO resource_ref_edges (resource_id, page_id, count) VALUES (1, 1, 1)',
+			),
+		).rejects.toThrow();
+
+		// Reverse-direction lookup by page_id must have its own index,
+		// because the composite PK on (resource_id, page_id) can only be
+		// prefix-seeked by resource_id.
+		const indexes: { name: string }[] = await db.raw(
+			"PRAGMA index_list('resource_ref_edges')",
+		);
+		expect(indexes.some((i) => i.name === 'idx_resource_ref_edges_page')).toBe(true);
+
+		await db.destroy();
+	});
+
+	it('defaults resource_ref_edges.count to 1 when omitted', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		await insertContentItem(db, 1, 'p');
+		const urlIdRes = await insertUrl(db, 'https://example.com/x.js');
+		await db.raw(
+			'INSERT INTO resource_items (id, url_id, is_external) VALUES (1, ?, 0)',
+			[urlIdRes],
+		);
+		await db.raw('INSERT INTO resource_ref_edges (resource_id, page_id) VALUES (1, 1)');
+		const [row] = await db.raw(
+			'SELECT count FROM resource_ref_edges WHERE resource_id = 1 AND page_id = 1',
+		);
+		expect(row.count).toBe(1);
+
+		await db.destroy();
+	});
+
+	it('creates image_items with dom_path_text_id NOT NULL', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		const columns = await db.raw("PRAGMA table_info('image_items')");
+		const domPath = columns.find(
+			(c: { name: string; notnull: number }) => c.name === 'dom_path_text_id',
+		);
+		expect(domPath).toBeDefined();
+		expect(domPath.notnull).toBe(1);
+
+		await insertContentItem(db, 1, 'p');
+
+		await expect(
+			db.raw(
+				`INSERT INTO image_items
+					(id, page_id, width, height, natural_width, natural_height, viewport_width, dom_path_text_id)
+					VALUES (1, 1, 0, 0, 0, 0, 0, NULL)`,
+			),
+		).rejects.toThrow();
+
+		const domPathId = await insertText(
+			db,
+			Buffer.from('aa'.repeat(16), 'hex'),
+			'html>body>img',
+		);
+		await db.raw(
+			`INSERT INTO image_items
+				(id, page_id, width, height, natural_width, natural_height, viewport_width, dom_path_text_id)
+				VALUES (1, 1, 0, 0, 0, 0, 0, ?)`,
+			[domPathId],
+		);
+
+		await db.destroy();
+	});
+
+	it('permits image_items dimensional columns to be NULL', async () => {
+		// The plan doc (`docs/viewer-db-redesign-plan.md`) intentionally
+		// makes width / height / natural_width / natural_height /
+		// viewport_width nullable, a divergence from legacy `images`
+		// which declared them `.notNullable()`. Documenting the
+		// divergence with a passing NULL insert prevents a future
+		// "restore the legacy NOT NULL contract" edit from silently
+		// re-tightening the schema.
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		await insertContentItem(db, 1, 'p');
+		const domPathId = await insertText(
+			db,
+			Buffer.from('bb'.repeat(16), 'hex'),
+			'html>body>img',
+		);
+		await db.raw(
+			`INSERT INTO image_items
+				(id, page_id, dom_path_text_id)
+				VALUES (1, 1, ?)`,
+			[domPathId],
+		);
+		const [row] = await db.raw(
+			'SELECT width, height, natural_width, natural_height, viewport_width FROM image_items WHERE id = 1',
+		);
+		expect(row.width).toBeNull();
+		expect(row.height).toBeNull();
+		expect(row.natural_width).toBeNull();
+		expect(row.natural_height).toBeNull();
+		expect(row.viewport_width).toBeNull();
+
+		await db.destroy();
+	});
+
+	it('enforces image_items src/blob mutual-exclusion via CHECK', async () => {
+		const db = await openDbWithPhase6C({ foreignKeys: true });
+
+		await insertContentItem(db, 1, 'p');
+		const domPathId = await insertText(
+			db,
+			Buffer.from('cc'.repeat(16), 'hex'),
+			'html>body>img',
+		);
+		const urlIdSrc = await insertUrl(db, 'https://example.com/pic.png');
+		const [blobRow] = await db.raw(
+			`INSERT INTO blob_refs (hash, body, codec, size_raw, size_stored)
+				VALUES (?, ?, 'none', ?, ?) RETURNING id`,
+			[Buffer.from('dd'.repeat(16), 'hex'), Buffer.from('body'), 4, 4],
+		);
+		const blobId = blobRow.id;
+
+		// Both url and blob for src → rejected.
+		await expect(
+			db.raw(
+				`INSERT INTO image_items
+					(id, page_id, src_url_id, src_blob_id, dom_path_text_id)
+					VALUES (1, 1, ?, ?, ?)`,
+				[urlIdSrc, blobId, domPathId],
+			),
+		).rejects.toThrow();
+
+		// Both url and blob for currentSrc → rejected.
+		await expect(
+			db.raw(
+				`INSERT INTO image_items
+					(id, page_id, current_src_url_id, current_src_blob_id, dom_path_text_id)
+					VALUES (1, 1, ?, ?, ?)`,
+				[urlIdSrc, blobId, domPathId],
+			),
+		).rejects.toThrow();
+
+		// url-only, blob-only, and both-null combinations all pass.
+		await db.raw(
+			`INSERT INTO image_items
+				(id, page_id, src_url_id, dom_path_text_id)
+				VALUES (10, 1, ?, ?)`,
+			[urlIdSrc, domPathId],
+		);
+		await db.raw(
+			`INSERT INTO image_items
+				(id, page_id, src_blob_id, dom_path_text_id)
+				VALUES (11, 1, ?, ?)`,
+			[blobId, domPathId],
+		);
+		await db.raw(
+			`INSERT INTO image_items
+				(id, page_id, dom_path_text_id)
+				VALUES (12, 1, ?)`,
+			[domPathId],
+		);
+
+		await db.destroy();
+	});
+
+	it('creates every secondary index required by legacy hot paths', async () => {
+		const db = await openDbWithPhase6C();
+
+		const contentIndexes: { name: string }[] = await db.raw(
+			"PRAGMA index_list('content_items')",
+		);
+		const contentIndexNames = contentIndexes.map((i) => i.name);
+		expect(contentIndexNames).toContain('idx_content_items_external');
+		expect(contentIndexNames).toContain('idx_content_items_scraped');
+		expect(contentIndexNames).toContain('idx_content_items_redirect_dest_id');
+		expect(contentIndexNames).toContain('idx_content_items_content_type_id');
+		expect(contentIndexNames).toContain('idx_content_items_crawl_order');
+		expect(contentIndexNames).toContain('idx_content_items_source');
+
+		const pageMetaIndexes: { name: string }[] = await db.raw(
+			"PRAGMA index_list('page_meta')",
+		);
+		const pageMetaIndexNames = pageMetaIndexes.map((i) => i.name);
+		expect(pageMetaIndexNames).toContain('idx_page_meta_og_type');
+		expect(pageMetaIndexNames).toContain('idx_page_meta_robots_noindex');
+
+		const resourceIndexes: { name: string }[] = await db.raw(
+			"PRAGMA index_list('resource_items')",
+		);
+		expect(resourceIndexes.map((i) => i.name)).toContain('idx_resource_items_source');
+
+		const anchorIndexes: { name: string }[] = await db.raw(
+			"PRAGMA index_list('anchor_edges')",
+		);
+		expect(anchorIndexes.map((i) => i.name)).toContain('idx_anchor_edges_href');
+
+		const imageIndexes: { name: string }[] = await db.raw(
+			"PRAGMA index_list('image_items')",
+		);
+		expect(imageIndexes.map((i) => i.name)).toContain('idx_image_items_page');
+
+		await db.destroy();
+	});
+
+	it('is idempotent when called twice against the same DB', async () => {
+		const db = await openDbWithPhase6C();
+		// Second call must not throw ("table already exists") because
+		// the DDL uses CREATE TABLE IF NOT EXISTS throughout.
+		await createPhase6CEntityTables(db);
+		await db.destroy();
+	});
+
+	it('re-creates missing tables when only some Phase 6-C tables exist (partial-corruption repair)', async () => {
+		const db = await openDbWithPhase6C();
+
+		// Simulate an external repair pass that dropped `page_meta`
+		// while leaving `content_items` in place. On next open the
+		// primitive must recreate the missing table without erroring on
+		// the still-present `content_items`.
+		await db.raw('DROP TABLE page_meta');
+		expect(await db.schema.hasTable('page_meta')).toBe(false);
+		expect(await db.schema.hasTable('content_items')).toBe(true);
+
+		await createPhase6CEntityTables(db);
+
+		expect(await db.schema.hasTable('page_meta')).toBe(true);
+		expect(await db.schema.hasTable('content_items')).toBe(true);
+
+		await db.destroy();
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/create-phase6c-entity-tables.ts
+++ b/packages/@nitpicker/crawler/src/archive/create-phase6c-entity-tables.ts
@@ -1,0 +1,326 @@
+import type { Knex } from 'knex';
+
+/**
+ * Creates the 6 Phase 6-C core entity and edge tables (issue #192).
+ *
+ * These are the normalised entity / edge tables that will replace the legacy
+ * write model (`pages`, `anchors`, `images`, `resources`, `resources-referrers`)
+ * under Phase 6-F. This migration is purely additive DDL — no existing table
+ * is modified and no row is inserted; Phase 6-D populates the tables from the
+ * legacy sources.
+ *
+ * Tables created:
+ *
+ * - `content_items` — replaces `pages` (core columns). The remaining
+ *   per-page metadata splits into `page_meta`.
+ * - `page_meta` — page-specific metadata (title, description, meta tags,
+ *   OpenGraph, Twitter, robots, denormalised aggregates, meta_extras JSON
+ *   pointer). Split from `pages` so that filter / cursor queries against
+ *   `content_items` scan a narrower row.
+ * - `resource_items` — replaces `resources`.
+ * - `anchor_edges` — replaces `anchors`. Deduped to distinct
+ *   `(page_id, href_page_id)` pairs; `count` records how many instances
+ *   were observed and `first_hash` / `first_text_id` capture the first
+ *   instance's identity so the most important observable fact per link is
+ *   preserved without every redundant row.
+ * - `resource_ref_edges` — replaces `resources-referrers`. Structural
+ *   rename with an added `count` column; `WITHOUT ROWID` because the
+ *   composite PK `(resource_id, page_id)` is the natural clustering key
+ *   and every column is small — the same reasoning as `page_html_blobs`.
+ * - `image_items` — replaces `images`. `src` / `currentSrc` split into
+ *   `*_url_id` (regular URLs) vs `*_blob_id` (large `data:` URIs, routed
+ *   via `blob_refs`); `sourceCode` is replaced by `dom_path_text_id`
+ *   populated by Phase 6-D from the `outerHTML` string.
+ *
+ * ### Key invariants
+ *
+ * **Same PK values as legacy.** `content_items.id`, `resource_items.id`,
+ * and `image_items.id` reuse the exact PK values from `pages.id`,
+ * `resources.id`, and `images.id` respectively. Phase 6-D inserts rows
+ * with explicit IDs so every existing FK reference in `page_errors`,
+ * `page_tags`, `page_jsonld`, `page_html_ref`, and `resources-referrers`
+ * (before it becomes `resource_ref_edges`) survives the switch without
+ * any per-row UPDATE. `AUTOINCREMENT` is nevertheless applied on all four
+ * entity PKs (`content_items` / `resource_items` / `anchor_edges` /
+ * `image_items`) to match the legacy contract (`t.increments()` on
+ * `pages` / `resources` / `anchors` / `images`) — this prevents rowid
+ * reuse after DELETE, so external systems (analysis outputs, viewer
+ * bookmarks, Sheets exports) keyed on `content_item.id` cannot be
+ * silently reassigned to a different record.
+ *
+ * **UNIQUE(url_id) on content_items and resource_items.** The legacy
+ * `pages.url UNIQUE` / `resources.url UNIQUE` guaranteed one row per
+ * URL string. Under the new model the URL string is stored once in
+ * `url_refs` and each entity references `url_refs.id` via `url_id` —
+ * but `url_refs.url UNIQUE` only guarantees "one URL string → one
+ * ref id", it does NOT prevent two entity rows from claiming the same
+ * ref id. `UNIQUE(url_id)` re-establishes that guarantee at the entity
+ * level, matching `docs/viewer-db-redesign-plan.md` and
+ * `docs/viewer-sql-query-plan.md` (both specify `unique` on
+ * `content_items.url_id` and `resource_items.url_id`). The UNIQUE
+ * constraint's auto-index also serves the by-URL seek path, so no
+ * separate `CREATE INDEX ... ON content_items(url_id)` is needed.
+ *
+ * **`redirect_dest_id` self-reference is DEFERRABLE INITIALLY DEFERRED.**
+ * `content_items.redirect_dest_id` references `content_items(id)` (not
+ * `pages(id)`), mirroring the legacy `pages.redirectDestId → pages.id`
+ * self-reference. In the real archive shape, a redirect source can be
+ * discovered as an anchor (assigned a low `pages.id`) BEFORE its
+ * destination is crawled (higher `pages.id`), so a straight
+ * `ORDER BY id ASC` populate would violate the FK on the source row.
+ * Making the FK deferred lets Phase 6-D commit all `content_items`
+ * inserts inside one transaction without any per-row ordering
+ * discipline — SQLite validates the constraint only at COMMIT time.
+ *
+ * **`page_meta.page_id` PK == FK ON DELETE CASCADE.** `page_meta` uses
+ * `page_id` as both the primary key and the FK back to `content_items(id)`.
+ * This is a 1:1 relation (every content_item has at most one meta row),
+ * so a separate autoincrement id would only bloat the row. The cascade
+ * mirrors the legacy `page_html_ref` / `page_tags` / `page_jsonld` FKs
+ * to `pages(id)` so a future cleanup pass can DELETE from
+ * `content_items` without leaving orphan meta rows.
+ *
+ * **`content_items.source` and `resource_items.source` DEFAULT 'crawled'.**
+ * The legacy `pages.source` / `resources.source` columns were
+ * `NOT NULL DEFAULT 'crawled'`, and multiple existing writer paths rely
+ * on the default (redirect-source insert, per-chunk resource insert, and
+ * `markBrowserScrape`). Preserving the default keeps those callsites
+ * working when Phase 6-F re-points them at the new tables — dropping
+ * the default would turn a routine crawl into an immediate hard failure
+ * the first time a callsite omits `source`.
+ *
+ * **`anchor_edges` dedup shape.** `unique(page_id, href_page_id)` enforces
+ * the collapse from ≈ 13M legacy `anchors` rows to ≈ 9.7M `anchor_edges`
+ * rows (~25 % reduction on the reference archive).
+ * `first_hash` and `first_text_id` capture the anchor `hash` and
+ * `textContent` of the FIRST instance encountered (lowest `anchors.id`
+ * for the pair); duplicate observations are counted via `count` without
+ * retaining their bodies. The UNIQUE constraint's auto-index on
+ * `(page_id, href_page_id)` also serves any `WHERE page_id = ?` seek via
+ * SQLite's leading-prefix rule, so no separate `CREATE INDEX ... ON
+ * anchor_edges(page_id)` is needed; only the reverse-direction
+ * `idx_anchor_edges_href` on `href_page_id` alone is added.
+ *
+ * **`image_items.dom_path_text_id NOT NULL`.** Every image row must
+ * resolve to a `text_refs` entry describing its DOM position. Phase 6-D
+ * derives the path from `images.sourceCode` (the stored `outerHTML`); an
+ * image whose `sourceCode` is empty falls back to the synthetic label
+ * `img[unknown]` (via the populate step) so the FK is never violated.
+ *
+ * **`image_items` src / blob mutual-exclusion CHECK.** `src_url_id` and
+ * `src_blob_id` (and their `current_src_*` mirror) are separate nullable
+ * columns because a `<img>` value can be either a plain URL or a large
+ * `data:` URI. A single legacy `images.src` TEXT column could not
+ * express the ambiguity; the new schema splits the two but adds a CHECK
+ * so at most one slot per (src, currentSrc) pair is non-null. Without
+ * the CHECK a populate bug or future writer could silently write both,
+ * and the viewer would arbitrarily pick one to render.
+ *
+ * ### Index rationale
+ *
+ * Every index below reflects a legacy-baseline single-column index that
+ * an existing hot path already relies on. `content_items` gets six
+ * indexes: `url_id` (via `UNIQUE` auto-index), `is_external`, `scraped`,
+ * `redirect_dest_id` (for the Page Detail inbound-redirect list),
+ * `content_type_id`, `crawl_order`, and `source` — all present on
+ * legacy `pages`. `page_meta` gets `og_type` and `robots_noindex`
+ * because both were indexed on legacy `pages` for Phase 1 analytics
+ * queries; after the split those readers land on `page_meta` and need
+ * the indexes to remain sub-second. `resource_items` gets `url_id`
+ * (via `UNIQUE` auto-index) and `source`. `anchor_edges` gets one
+ * reverse-direction index (`idx_anchor_edges_href`); the UNIQUE
+ * auto-index covers the forward direction. `resource_ref_edges` needs
+ * an explicit reverse-direction index on `page_id` because the
+ * composite PK `(resource_id, page_id)` only satisfies the `resource_id`-
+ * first prefix; the legacy `resources-referrers` table had exactly
+ * this reverse-direction index. `image_items` gets one index on
+ * `page_id`. No summary / listfilter compound indexes yet; Phase 6-F
+ * will add them once the new viewer read model builds directly against
+ * these tables.
+ *
+ * ### Idempotency
+ *
+ * All statements use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT
+ * EXISTS` so the primitive is safe to call multiple times against the
+ * same DB. Both call sites (`initSchema` and
+ * `migratePhase6CEntityTables`) still guard on their own sentinels,
+ * but the function itself no longer depends on the sentinel being
+ * checked first — this closes the partial-corruption gap where, say,
+ * `content_items` exists but `page_meta` was dropped by an external
+ * repair pass.
+ * @param instance - The Knex query builder instance connected to the database.
+ */
+export async function createPhase6CEntityTables(instance: Knex): Promise<void> {
+	await instance.raw(`
+		CREATE TABLE IF NOT EXISTS content_items (
+			id               INTEGER PRIMARY KEY AUTOINCREMENT,
+			url_id           INTEGER NOT NULL UNIQUE REFERENCES url_refs(id),
+			is_external      INTEGER NOT NULL,
+			scraped          INTEGER NOT NULL,
+			is_target        INTEGER NOT NULL,
+			status           INTEGER,
+			status_text      TEXT,
+			content_type_id  INTEGER REFERENCES content_type_refs(id),
+			content_length   INTEGER,
+			header_set_id    INTEGER REFERENCES header_sets(id),
+			redirect_dest_id INTEGER REFERENCES content_items(id) DEFERRABLE INITIALLY DEFERRED,
+			source           TEXT NOT NULL DEFAULT 'crawled',
+			first_crawled_at INTEGER,
+			last_crawled_at  INTEGER,
+			crawl_order      INTEGER,
+			is_skipped       INTEGER,
+			skip_reason      TEXT
+		)
+	`);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_content_items_external ON content_items(is_external)',
+	);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_content_items_scraped ON content_items(scraped)',
+	);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_content_items_redirect_dest_id ON content_items(redirect_dest_id)',
+	);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_content_items_content_type_id ON content_items(content_type_id)',
+	);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_content_items_crawl_order ON content_items(crawl_order)',
+	);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_content_items_source ON content_items(source)',
+	);
+
+	await instance.raw(`
+		CREATE TABLE IF NOT EXISTS page_meta (
+			page_id                     INTEGER PRIMARY KEY REFERENCES content_items(id) ON DELETE CASCADE,
+			lang                        TEXT,
+			dir                         TEXT,
+			charset                     TEXT,
+			base_href                   TEXT,
+			viewport_raw                TEXT,
+			theme_color                 TEXT,
+			application_name            TEXT,
+			author                      TEXT,
+			generator                   TEXT,
+			publisher                   TEXT,
+			title_text_id               INTEGER REFERENCES text_refs(id),
+			description_text_id         INTEGER REFERENCES text_refs(id),
+			keywords_text_id            INTEGER REFERENCES text_refs(id),
+			robots_raw_text_id          INTEGER REFERENCES text_refs(id),
+			robots_noindex              INTEGER,
+			robots_nofollow             INTEGER,
+			robots_noarchive            INTEGER,
+			robots_noimageindex         INTEGER,
+			googlebot                   TEXT,
+			canonical_url_id            INTEGER REFERENCES url_refs(id),
+			amphtml_url_id              INTEGER REFERENCES url_refs(id),
+			manifest_url_id             INTEGER REFERENCES url_refs(id),
+			icon_url_id                 INTEGER REFERENCES url_refs(id),
+			apple_touch_icon_url_id     INTEGER REFERENCES url_refs(id),
+			og_type                     TEXT,
+			og_title_text_id            INTEGER REFERENCES text_refs(id),
+			og_description_text_id      INTEGER REFERENCES text_refs(id),
+			og_url_id                   INTEGER REFERENCES url_refs(id),
+			og_image_url_id             INTEGER REFERENCES url_refs(id),
+			og_site_name                TEXT,
+			og_image_alt                TEXT,
+			og_image_width              TEXT,
+			og_image_height             TEXT,
+			og_locale                   TEXT,
+			og_article_published_time   TEXT,
+			og_article_modified_time    TEXT,
+			twitter_card                TEXT,
+			twitter_site                TEXT,
+			twitter_creator             TEXT,
+			twitter_title_text_id       INTEGER REFERENCES text_refs(id),
+			twitter_description_text_id INTEGER REFERENCES text_refs(id),
+			twitter_image_url_id        INTEGER REFERENCES url_refs(id),
+			fb_app_id                   TEXT,
+			verification_google         TEXT,
+			format_detection_telephone  INTEGER,
+			tag_count                   INTEGER,
+			jsonld_count                INTEGER,
+			tags_providers_csv          TEXT,
+			meta_extras_json_id         INTEGER REFERENCES json_refs(id)
+		)
+	`);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_page_meta_og_type ON page_meta(og_type)',
+	);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_page_meta_robots_noindex ON page_meta(robots_noindex)',
+	);
+
+	await instance.raw(`
+		CREATE TABLE IF NOT EXISTS resource_items (
+			id               INTEGER PRIMARY KEY AUTOINCREMENT,
+			url_id           INTEGER NOT NULL UNIQUE REFERENCES url_refs(id),
+			is_external      INTEGER NOT NULL,
+			status           INTEGER,
+			status_text      TEXT,
+			content_type_id  INTEGER REFERENCES content_type_refs(id),
+			content_length   INTEGER,
+			header_set_id    INTEGER REFERENCES header_sets(id),
+			compress         TEXT,
+			cdn              TEXT,
+			source           TEXT NOT NULL DEFAULT 'crawled'
+		)
+	`);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_resource_items_source ON resource_items(source)',
+	);
+
+	await instance.raw(`
+		CREATE TABLE IF NOT EXISTS anchor_edges (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			page_id       INTEGER NOT NULL REFERENCES content_items(id),
+			href_page_id  INTEGER NOT NULL REFERENCES content_items(id),
+			count         INTEGER NOT NULL,
+			first_hash    TEXT,
+			first_text_id INTEGER REFERENCES text_refs(id),
+			UNIQUE(page_id, href_page_id)
+		)
+	`);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_anchor_edges_href ON anchor_edges(href_page_id)',
+	);
+
+	await instance.raw(`
+		CREATE TABLE IF NOT EXISTS resource_ref_edges (
+			resource_id INTEGER NOT NULL REFERENCES resource_items(id),
+			page_id     INTEGER NOT NULL REFERENCES content_items(id),
+			count       INTEGER NOT NULL DEFAULT 1,
+			PRIMARY KEY(resource_id, page_id)
+		) WITHOUT ROWID
+	`);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_resource_ref_edges_page ON resource_ref_edges(page_id)',
+	);
+
+	await instance.raw(`
+		CREATE TABLE IF NOT EXISTS image_items (
+			id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+			page_id             INTEGER NOT NULL REFERENCES content_items(id),
+			src_url_id          INTEGER REFERENCES url_refs(id),
+			current_src_url_id  INTEGER REFERENCES url_refs(id),
+			src_blob_id         INTEGER REFERENCES blob_refs(id),
+			current_src_blob_id INTEGER REFERENCES blob_refs(id),
+			alt_text_id         INTEGER REFERENCES text_refs(id),
+			width               REAL,
+			height              REAL,
+			natural_width       INTEGER,
+			natural_height      INTEGER,
+			is_lazy             INTEGER,
+			viewport_width      INTEGER,
+			dom_path_text_id    INTEGER NOT NULL REFERENCES text_refs(id),
+			CHECK (
+				(src_url_id IS NULL OR src_blob_id IS NULL)
+				AND (current_src_url_id IS NULL OR current_src_blob_id IS NULL)
+			)
+		)
+	`);
+	await instance.raw(
+		'CREATE INDEX IF NOT EXISTS idx_image_items_page ON image_items(page_id)',
+	);
+}

--- a/packages/@nitpicker/crawler/src/archive/database.ts
+++ b/packages/@nitpicker/crawler/src/archive/database.ts
@@ -59,6 +59,7 @@ import { migrateInventoryRuns } from './migrate-inventory-runs.js';
 import { migratePageErrors } from './migrate-page-errors.js';
 import { migratePagesResourcesSource } from './migrate-pages-resources-source.js';
 import { migratePhase6ARefTables } from './migrate-phase6a-ref-tables.js';
+import { migratePhase6CEntityTables } from './migrate-phase6c-entity-tables.js';
 import { redirectTable } from './redirect-table.js';
 import { resolveRedirectChain } from './resolve-redirect-chain.js';
 
@@ -2449,6 +2450,9 @@ export class Database extends EventEmitter<DatabaseEvent> {
 		await migratePagesResourcesSource(this.#instance);
 		await migrateInventoryRuns(this.#instance);
 		await migratePhase6ARefTables(this.#instance);
+		// MUST run after migratePhase6ARefTables — Phase 6-C tables have
+		// FK references to the Phase 6-A ref tables.
+		await migratePhase6CEntityTables(this.#instance);
 	}
 
 	/**

--- a/packages/@nitpicker/crawler/src/archive/init-schema.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.spec.ts
@@ -36,6 +36,15 @@ describe('initSchema', () => {
 			'header_sets',
 			'header_set_entries',
 			'header_flags',
+			// Phase 6-C core entity / edge tables (issue #192). Same
+			// additive-only status as Phase 6-A: created on every fresh
+			// archive but not populated / read until later phases.
+			'content_items',
+			'page_meta',
+			'resource_items',
+			'anchor_edges',
+			'resource_ref_edges',
+			'image_items',
 		];
 		for (const table of tables) {
 			const exists = await db.schema.hasTable(table);

--- a/packages/@nitpicker/crawler/src/archive/init-schema.ts
+++ b/packages/@nitpicker/crawler/src/archive/init-schema.ts
@@ -1,6 +1,7 @@
 import type { Knex } from 'knex';
 
 import { createPhase6ARefTables } from './create-phase6a-ref-tables.js';
+import { createPhase6CEntityTables } from './create-phase6c-entity-tables.js';
 
 /**
  * Applies the connection-level PRAGMAs that govern foreign-key enforcement
@@ -83,6 +84,17 @@ export async function applyConnectionPragmas(instance: Knex): Promise<void> {
  *   the reason `blob_refs` uses a regular rowid PK instead of WITHOUT ROWID.
  *   Existing archives get the same tables added by
  *   {@link migratePhase6ARefTables} at open time.
+ * - **Phase 6-C core entity / edge tables** (issue #192, part of epic #103):
+ *   `content_items`, `page_meta`, `resource_items`, `anchor_edges`,
+ *   `resource_ref_edges`, `image_items`. Additive DDL only. `content_items`
+ *   / `resource_items` / `image_items` reuse the SAME PK values as the
+ *   legacy `pages` / `resources` / `images` tables (Phase 6-D inserts rows
+ *   with explicit IDs), which preserves every existing FK reference without
+ *   any per-row UPDATE. Must run AFTER `createPhase6ARefTables` because
+ *   most entity tables reference ref-table PKs. See
+ *   {@link createPhase6CEntityTables} for column-by-column rationale and
+ *   the anchor_edges dedup shape. Existing archives get the same tables
+ *   added by {@link migratePhase6CEntityTables} at open time.
  * - **PRAGMA `page_size` and `journal_mode`** are set BEFORE any
  *   `CREATE TABLE` because SQLite only honors `page_size` changes against
  *   an empty database, and `journal_mode = WAL` is persistent. Other
@@ -473,6 +485,18 @@ export async function initSchema(instance: Knex) {
 	// archives — a divergence between the two paths would silently break
 	// the Phase 6-B population step's UNIQUE / CHECK contract.
 	await createPhase6ARefTables(instance);
+
+	// Phase 6-C core entity / edge tables (issue #192). MUST run after
+	// {@link createPhase6ARefTables} because `content_items`, `page_meta`,
+	// `resource_items`, `anchor_edges`, and `image_items` all reference
+	// the Phase 6-A ref tables (`url_refs`, `content_type_refs`,
+	// `text_refs`, `json_refs`, `blob_refs`, `header_sets`) via FK
+	// clauses. Additive only — the tables are created on every fresh
+	// archive but remain completely unused until Phase 6-D populates
+	// them and Phase 6-F migrates the reader / writer paths. Existing
+	// archives get the same tables added by
+	// {@link migratePhase6CEntityTables} at open time.
+	await createPhase6CEntityTables(instance);
 
 	// Composite covering index for the default Pages-view filter + url-ordered
 	// scan. Without it, `listPages` on a 400k-row archive runs ~15s per page

--- a/packages/@nitpicker/crawler/src/archive/migrate-phase6c-entity-tables.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-phase6c-entity-tables.spec.ts
@@ -1,0 +1,128 @@
+import knex from 'knex';
+import { describe, it, expect } from 'vitest';
+
+import { createPhase6ARefTables } from './create-phase6a-ref-tables.js';
+import { LibsqlDialect } from './libsql-dialect.js';
+import { migratePhase6CEntityTables } from './migrate-phase6c-entity-tables.js';
+
+/**
+ * Simulates the shape of a pre-Phase-6C archive: the write-model tables that
+ * predate this branch exist, and the Phase 6-A ref tables have already been
+ * migrated in (the migration ordering in `Database.connect` runs
+ * `migratePhase6ARefTables` before `migratePhase6CEntityTables`).
+ * @param db - Knex instance already connected to an empty in-memory DB.
+ */
+async function seedPreviousPhaseArchive(db: ReturnType<typeof knex>): Promise<void> {
+	await db.schema.createTable('pages', (t) => {
+		t.increments('id');
+		t.string('url').notNullable();
+	});
+	await createPhase6ARefTables(db);
+}
+
+describe('migratePhase6CEntityTables', () => {
+	const PHASE_6C_TABLES = [
+		'content_items',
+		'page_meta',
+		'resource_items',
+		'anchor_edges',
+		'resource_ref_edges',
+		'image_items',
+	];
+
+	it('creates all 6 Phase 6-C tables on a pre-Phase-6C archive', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await seedPreviousPhaseArchive(db);
+
+		for (const table of PHASE_6C_TABLES) {
+			expect(await db.schema.hasTable(table), `${table} should be absent before`).toBe(
+				false,
+			);
+		}
+
+		await migratePhase6CEntityTables(db);
+
+		for (const table of PHASE_6C_TABLES) {
+			expect(await db.schema.hasTable(table), `${table} should exist after`).toBe(true);
+		}
+
+		await db.destroy();
+	});
+
+	it('produces schema that resolves every REFERENCES target with foreign_keys ON', async () => {
+		// SQLite parses `REFERENCES <table>(<col>)` clauses but only
+		// validates the target table exists when `foreign_keys` is ON at
+		// INSERT time. Without an INSERT test that enables FKs, a DDL
+		// typo like `REFERENCES url_ref(id)` (singular) would ship
+		// undetected — the CREATE would succeed and every `hasTable`
+		// assertion would still pass. This test forces every FK to
+		// resolve by inserting one legal row into each Phase 6-C table.
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+		await db.raw('PRAGMA foreign_keys = ON');
+		await seedPreviousPhaseArchive(db);
+		await migratePhase6CEntityTables(db);
+
+		const [urlRefPage] = await db.raw(
+			"INSERT INTO url_refs (url) VALUES ('https://example.com/') RETURNING id",
+		);
+		const [urlRefRes] = await db.raw(
+			"INSERT INTO url_refs (url) VALUES ('https://example.com/a.js') RETURNING id",
+		);
+		const [textRef] = await db.raw(
+			'INSERT INTO text_refs (hash, text) VALUES (?, ?) RETURNING id',
+			[Buffer.from('aa'.repeat(16), 'hex'), 'html>body>img'],
+		);
+
+		await db.raw(
+			`INSERT INTO content_items
+				(id, url_id, is_external, scraped, is_target)
+				VALUES (1, ?, 0, 1, 1)`,
+			[urlRefPage.id],
+		);
+		await db.raw('INSERT INTO page_meta (page_id) VALUES (1)');
+		await db.raw(
+			'INSERT INTO resource_items (id, url_id, is_external) VALUES (1, ?, 0)',
+			[urlRefRes.id],
+		);
+		await db.raw(
+			'INSERT INTO anchor_edges (page_id, href_page_id, count) VALUES (1, 1, 1)',
+		);
+		await db.raw('INSERT INTO resource_ref_edges (resource_id, page_id) VALUES (1, 1)');
+		await db.raw(
+			`INSERT INTO image_items
+				(id, page_id, dom_path_text_id)
+				VALUES (1, 1, ?)`,
+			[textRef.id],
+		);
+
+		await db.destroy();
+	});
+
+	it('is idempotent (running twice does not error)', async () => {
+		const db = knex({
+			client: LibsqlDialect,
+			connection: { filename: ':memory:' },
+			useNullAsDefault: true,
+		});
+
+		await seedPreviousPhaseArchive(db);
+
+		await migratePhase6CEntityTables(db);
+		await migratePhase6CEntityTables(db);
+
+		for (const table of PHASE_6C_TABLES) {
+			expect(await db.schema.hasTable(table)).toBe(true);
+		}
+
+		await db.destroy();
+	});
+});

--- a/packages/@nitpicker/crawler/src/archive/migrate-phase6c-entity-tables.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-phase6c-entity-tables.ts
@@ -1,0 +1,59 @@
+import type { Knex } from 'knex';
+
+import { createPhase6CEntityTables } from './create-phase6c-entity-tables.js';
+
+/**
+ * Adds the Phase 6-C entity / edge tables (issue #192) to archives created
+ * before this branch shipped.
+ *
+ * These are the 6 core normalised tables (`content_items`, `page_meta`,
+ * `resource_items`, `anchor_edges`, `resource_ref_edges`, `image_items`) that
+ * will replace the legacy write model under Phase 6-F. Fresh archives get
+ * them via `initSchema`; this migration handles the "existing archive
+ * re-opened by `crawl --append` / `--retry-failed` / analyze" path — the same
+ * pattern used by `migrateCrawlErrors`, `migratePhase6ARefTables`, etc.
+ *
+ * The migration is intentionally table-only. It does not back-fill any data
+ * from `pages` / `resources` / `anchors` / `images` — that is the job of the
+ * Phase 6-D populate step, which reads from the legacy tables and writes
+ * the entity rows in a single WAL transaction with `.bak` protection. This
+ * migration only guarantees the empty tables exist so Phase 6-D can
+ * INSERT into them without hitting `SQLITE_ERROR: no such table:
+ * content_items`.
+ *
+ * **Blocked-by contract**: `createPhase6CEntityTables` references the
+ * Phase 6-A ref tables (`url_refs`, `content_type_refs`, `text_refs`,
+ * `json_refs`, `blob_refs`, `header_sets`) via `REFERENCES`. On an
+ * existing archive, `migratePhase6ARefTables` MUST have run first so the
+ * ref tables exist by the time this migration is applied.
+ * `Database.connect` orders the migrations statically so this ordering
+ * is enforced there, not here.
+ *
+ * **Idempotency**: `createPhase6CEntityTables` itself uses
+ * `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` for every
+ * statement, so calling it multiple times against any DB state is safe.
+ * That means this wrapper does not need a defensive sentinel — the
+ * "content_items exists but page_meta was dropped externally" partial-
+ * corruption case is fully repaired on next open because every CREATE
+ * statement individually checks its own existence. The one thing the
+ * wrapper adds beyond the primitive is a log line, which we still want
+ * to emit only when creation actually happened, so we probe
+ * `content_items` first and short-circuit when the schema is already
+ * fully installed.
+ *
+ * On read-only connections the migration is skipped upstream, so this
+ * function only ever runs against writer connections.
+ * @param instance - The Knex query builder instance connected to the database.
+ */
+export async function migratePhase6CEntityTables(instance: Knex): Promise<void> {
+	const hasContentItems = await instance.schema.hasTable('content_items');
+	if (hasContentItems) {
+		// Fast path: fully installed. `createPhase6CEntityTables` would
+		// still be a safe no-op, but re-running it just to be defensive
+		// wastes 15 IF NOT EXISTS round-trips on every archive open.
+		return;
+	}
+	await createPhase6CEntityTables(instance);
+	// eslint-disable-next-line no-console
+	console.error('[migrate] Phase 6-C entity/edge tables created');
+}

--- a/packages/@nitpicker/query/src/get-link-graph.spec.ts
+++ b/packages/@nitpicker/query/src/get-link-graph.spec.ts
@@ -199,4 +199,38 @@ describe('getLinkGraph', () => {
 		expect(graph.truncated).toBe(false);
 		expect(graph.nodes).toHaveLength(3);
 	});
+
+	it('各ノードに source プロビナンスを返し、setPage 経由のページはデフォルトで crawled', async () => {
+		const graph = await getLinkGraph(archive);
+		for (const node of graph.nodes) {
+			expect(node.source).toBe('crawled');
+		}
+	});
+
+	it('DB 上で source を書き換えた場合、その値がノードに反映される', async () => {
+		// pages テーブルの source を直接書き換えて、`getLinkGraph` の SELECT が
+		// その列を読み出せているか(= source が SELECT 抜けしていないか)を検証する。
+		// insertInventorySeeds + setPage を使うと source-priority の CASE WHEN が
+		// 経由してしまい、SELECT 抜けバグを検出できないので直書きで確認する。
+		const knex = archive.getKnex();
+		await knex('pages')
+			.where('url', 'https://example.com/about')
+			.update({ source: 'inventory-seed' });
+		await knex('pages')
+			.where('url', 'https://example.com/contact')
+			.update({ source: 'inventory-discovered' });
+
+		const graph = await getLinkGraph(archive);
+		const about = graph.nodes.find((n) => n.url === 'https://example.com/about');
+		const contact = graph.nodes.find((n) => n.url === 'https://example.com/contact');
+		const home = graph.nodes.find((n) => n.url === 'https://example.com');
+		expect(about?.source).toBe('inventory-seed');
+		expect(contact?.source).toBe('inventory-discovered');
+		expect(home?.source).toBe('crawled');
+
+		// テスト間の独立性を保つため元に戻す。
+		await knex('pages')
+			.whereIn('url', ['https://example.com/about', 'https://example.com/contact'])
+			.update({ source: 'crawled' });
+	});
 });

--- a/packages/@nitpicker/query/src/get-link-graph.ts
+++ b/packages/@nitpicker/query/src/get-link-graph.ts
@@ -1,5 +1,5 @@
 import type { GetLinkGraphOptions, GraphEdge, GraphNode, LinkGraph } from './types.js';
-import type { ArchiveAccessor } from '@nitpicker/crawler';
+import type { ArchiveAccessor, PageSource } from '@nitpicker/crawler';
 
 /** Column filter selecting internal, scraped HTML pages (redirects excluded via a separate `whereNull`). */
 const INTERNAL_PAGE_WHERE = {
@@ -59,7 +59,7 @@ export async function getLinkGraph(
 
 	const [pageRows, edgeRows] = (await Promise.all([
 		knex('pages')
-			.select('url', 'status')
+			.select('url', 'status', 'source')
 			.where(INTERNAL_PAGE_WHERE)
 			.whereNull('redirectDestId'),
 		knex('anchors')
@@ -71,7 +71,10 @@ export async function getLinkGraph(
 			.where(aliasedInternalWhere('dest'))
 			.whereNull('dest.redirectDestId')
 			.whereRaw('anchors.pageId != anchors.hrefId'),
-	])) as [{ url: string; status: number | null }[], { source: string; target: string }[]];
+	])) as [
+		{ url: string; status: number | null; source: PageSource }[],
+		{ source: string; target: string }[],
+	];
 
 	const inDegree = new Map<string, number>();
 	for (const edge of edgeRows) {
@@ -82,6 +85,7 @@ export async function getLinkGraph(
 		url: row.url,
 		status: row.status,
 		inDegree: inDegree.get(row.url) ?? 0,
+		source: row.source,
 	}));
 	let edges: GraphEdge[] = edgeRows.map((edge) => ({
 		source: edge.source,

--- a/packages/@nitpicker/query/src/get-viewer-link-graph.ts
+++ b/packages/@nitpicker/query/src/get-viewer-link-graph.ts
@@ -1,5 +1,5 @@
 import type { GetLinkGraphOptions, GraphEdge, GraphNode, LinkGraph } from './types.js';
-import type { ArchiveAccessor } from '@nitpicker/crawler';
+import type { ArchiveAccessor, PageSource } from '@nitpicker/crawler';
 
 /**
  * Fast-path counterpart of `getLinkGraph`, backed by
@@ -22,7 +22,7 @@ export async function getViewerLinkGraph(
 	const totalNodes = Number(countResult[0]?.total ?? 0);
 
 	const nodeQuery = knex('viewer_graph_nodes')
-		.select('page_id as pageId', 'url', 'status', 'indegree')
+		.select('page_id as pageId', 'url', 'status', 'indegree', 'source')
 		.orderBy('indegree', 'desc')
 		.orderBy('page_id', 'asc');
 	if (requestedLimit != null) {
@@ -34,11 +34,13 @@ export async function getViewerLinkGraph(
 		url: string;
 		status: number | null;
 		indegree: number;
+		source: PageSource;
 	}[];
 	const nodes: GraphNode[] = nodeRows.map((row) => ({
 		url: row.url,
 		status: row.status,
 		inDegree: Number(row.indegree),
+		source: row.source,
 	}));
 	const truncated = requestedLimit != null && totalNodes > requestedLimit;
 

--- a/packages/@nitpicker/query/src/types.ts
+++ b/packages/@nitpicker/query/src/types.ts
@@ -1355,6 +1355,8 @@ export interface GraphNode {
 	status: number | null;
 	/** Number of incoming internal links (used for node sizing). */
 	inDegree: number;
+	/** Provenance label — see {@link PageSource}. Used by the graph view to color nodes by ingestion channel. */
+	source: PageSource;
 }
 
 /**

--- a/packages/@nitpicker/query/src/viewer-read-model/build-viewer-read-model.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/build-viewer-read-model.ts
@@ -452,6 +452,7 @@ export async function buildViewerReadModel(
 				url: row.url,
 				status: row.status,
 				indegree: graphIndegreeByPageId.get(row.id) ?? 0,
+				source: row.source,
 			}));
 		for (let start = 0; start < graphNodeRows.length; start += INSERT_CHUNK_SIZE) {
 			await trx('viewer_graph_nodes').insert(

--- a/packages/@nitpicker/query/src/viewer-read-model/create-viewer-read-model-tables.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/create-viewer-read-model-tables.ts
@@ -275,12 +275,18 @@ export async function createViewerReadModelTables(trx: Knex): Promise<void> {
 		) WITHOUT ROWID
 	`);
 
+	// `source` mirrors `pages.source` so the graph view can color nodes by
+	// ingestion channel (crawled / inventory-seed / inventory-discovered).
+	// See `GraphNode.source` in `../types.ts` — the fast-path read
+	// (`getViewerLinkGraph`) must produce the same shape as the legacy
+	// `getLinkGraph` or the type guard fails.
 	await trx.raw(`
 		CREATE TABLE viewer_graph_nodes (
 			page_id integer primary key,
 			url text not null,
 			status integer,
-			indegree integer not null
+			indegree integer not null,
+			source text not null
 		)
 	`);
 

--- a/packages/@nitpicker/query/src/viewer-read-model/types.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/types.ts
@@ -335,6 +335,8 @@ export interface GraphNodeInsertRow {
 	status: number | null;
 	/** Number of incoming internal edges in `viewer_graph_edges`. */
 	indegree: number;
+	/** Provenance label copied from `pages.source` — see `PageSource` in the parent `types.ts`. */
+	source: string;
 }
 
 /**

--- a/packages/@nitpicker/query/src/viewer-read-model/viewer-read-model-schema-version.ts
+++ b/packages/@nitpicker/query/src/viewer-read-model/viewer-read-model-schema-version.ts
@@ -7,4 +7,4 @@
  * `viewer_read_model_meta.schema_version` to decide whether a rebuild is
  * needed.
  */
-export const VIEWER_READ_MODEL_SCHEMA_VERSION = 15;
+export const VIEWER_READ_MODEL_SCHEMA_VERSION = 16;

--- a/packages/@nitpicker/report-google-sheets/package.json
+++ b/packages/@nitpicker/report-google-sheets/package.json
@@ -42,7 +42,7 @@
 		"@types/debug": "4.1.13",
 		"@types/jsdom": "28.0.3",
 		"googleapis": "173.0.0",
-		"vitest": "4.1.9"
+		"vitest": "4.1.10"
 	},
 	"gitHead": "32b83ee38eba7dfd237adb1b41f69e049e8d4ceb"
 }

--- a/packages/@nitpicker/viewer/package.json
+++ b/packages/@nitpicker/viewer/package.json
@@ -34,7 +34,7 @@
 	},
 	"dependencies": {
 		"@d-zero/dealer": "1.9.4",
-		"@hono/node-server": "2.0.6",
+		"@hono/node-server": "2.0.8",
 		"@nitpicker/query": "0.12.0",
 		"@tanstack/react-query": "5.101.2",
 		"@tanstack/react-table": "8.21.3",

--- a/packages/@nitpicker/viewer/src/graph-cache.ts
+++ b/packages/@nitpicker/viewer/src/graph-cache.ts
@@ -14,14 +14,14 @@ import { createPromiseLru } from './promise-lru.js';
  *   on a 10 GB archive (~60 s cold) — even a single cache slot pays
  *   that back enormously on warm hits.
  * - **memory**: each entry's JSON shape is bounded by `limit` —
- *   ~66 MB at `limit=1000` (the route default). At 4 entries the
- *   in-memory ceiling is ~250 MB which fits inside the viewer's
- *   default ~4 GB V8 heap without crowding `summary-cache` /
- *   `isolated-clusters-cache`.
+ *   the route default (50 000 nodes) tops out around a few hundred MB
+ *   on the largest observed archives, so at 4 entries the in-memory
+ *   ceiling is comfortably below the viewer's default ~4 GB V8 heap
+ *   even alongside `summary-cache` / `isolated-clusters-cache`.
  *
  * Distinct `limit` values are treated as distinct entries so an
  * operator passing `?limit=0` (uncapped) never serves a capped result
- * to a different caller that asked for `?limit=1000`.
+ * to a different caller that asked for the default limit.
  */
 const MAX_ENTRIES = 4;
 
@@ -72,8 +72,10 @@ export async function getCachedLinkGraph(
 	return lru.getOrLoad(key, () => {
 		const accessor = context.manager.get(context.archiveId);
 		// The on-disk filename embeds the cap so two callers asking for
-		// different limits cannot share each other's artefact.
-		const fileName = `graph-${limit ?? 'all'}`;
+		// different limits cannot share each other's artefact. The `v2`
+		// prefix invalidates pre-`source`-field artefacts so nodes get
+		// the new provenance-based coloring on already-cached archives.
+		const fileName = `graph-v2-${limit ?? 'all'}`;
 		return getOrComputeOnDisk(accessor.tmpDir, fileName, () =>
 			getLinkGraph(accessor, { limit }),
 		);

--- a/packages/@nitpicker/viewer/src/routes/register-graph-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-graph-route.ts
@@ -15,15 +15,16 @@ import { toNumber } from '../query-params/to-number.js';
  *    Invalid string length` — the client sees `{"error":"Invalid string
  *    length"}` after waiting ~1 min for the SQL to finish.
  * 2. **Visual usability**. Force-directed layouts (sigma.js + graphology
- *    forceAtlas2 in the viewer) become unreadable and CPU-bound past
- *    roughly 1-2 k nodes; bigger graphs render as a blob.
+ *    forceAtlas2 in the viewer) get denser past a few thousand nodes,
+ *    but 50k still renders in a few seconds and shows the full
+ *    inventory-* subgraph on typical audit archives (which is the
+ *    entire point of the source-based node coloring — a 1000-node cap
+ *    truncates every inventory node out because they have inDegree ≈ 0).
  *
- * 1000 is the largest value that comfortably fits both ceilings on
- * representative archives. Callers can override by passing `?limit=`
- * explicitly — `limit=0` is interpreted as "no cap" and accepts the
- * V8 risk knowingly.
+ * Callers can override by passing `?limit=` explicitly — `limit=0` is
+ * interpreted as "no cap" and accepts the V8 risk knowingly.
  */
-const DEFAULT_GRAPH_NODE_LIMIT = 1000;
+const DEFAULT_GRAPH_NODE_LIMIT = 50_000;
 
 /**
  * Registers `GET /api/graph?limit=` — the internal-page link graph (nodes +

--- a/packages/@nitpicker/viewer/web/api/get-graph-query-params.spec.ts
+++ b/packages/@nitpicker/viewer/web/api/get-graph-query-params.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGraphQueryParams } from './get-graph-query-params.js';
+
+describe('getGraphQueryParams', () => {
+	it('?limit= が無ければ limit は undefined', () => {
+		expect(getGraphQueryParams(new URLSearchParams(''))).toEqual({ limit: undefined });
+	});
+
+	it('?limit=0 は文字列 "0" として通過 (API 側で uncapped 扱い)', () => {
+		expect(getGraphQueryParams(new URLSearchParams('limit=0'))).toEqual({ limit: '0' });
+	});
+
+	it('?limit=50000 は文字列 "50000" として通過', () => {
+		expect(getGraphQueryParams(new URLSearchParams('limit=50000'))).toEqual({
+			limit: '50000',
+		});
+	});
+
+	it('?limit= (空文字列) は空文字列として通過 (undefined ではない — API 側で fallback)', () => {
+		// 空文字列を undefined に落とすと apiGet が param 省略するので "指定なし" と区別できなくなる。
+		// URLSearchParams.get('') は '' を返すのでその通過を守る。
+		expect(getGraphQueryParams(new URLSearchParams('limit='))).toEqual({ limit: '' });
+	});
+
+	it('他の query param があっても limit だけを返す', () => {
+		expect(getGraphQueryParams(new URLSearchParams('foo=bar&limit=100&baz=qux'))).toEqual(
+			{
+				limit: '100',
+			},
+		);
+	});
+});

--- a/packages/@nitpicker/viewer/web/api/get-graph-query-params.ts
+++ b/packages/@nitpicker/viewer/web/api/get-graph-query-params.ts
@@ -1,0 +1,23 @@
+/**
+ * Extracts the `/api/graph` query parameters that {@link useGraph} forwards
+ * from the current URL.
+ *
+ * Pulled out of the React hook so the URL → params contract can be tested
+ * without booting a `<MemoryRouter>` + `QueryClientProvider` harness (the
+ * viewer/web package deliberately has no React-hook testing infra — every
+ * other hook in this tree follows the same "extract a pure helper, test the
+ * helper" pattern).
+ *
+ * An absent `?limit=` becomes `undefined` so `apiGet`'s params serializer
+ * skips it entirely and the server's default cap applies. Any value present
+ * is passed through as a string (including `"0"`, which the API interprets
+ * as "no cap").
+ * @param searchParams - The current URL's `URLSearchParams`, as returned by
+ *   `react-router`'s `useSearchParams`.
+ * @returns Params object suitable for `apiGet('/api/graph', ...)`.
+ */
+export function getGraphQueryParams(searchParams: URLSearchParams): {
+	limit: string | undefined;
+} {
+	return { limit: searchParams.get('limit') ?? undefined };
+}

--- a/packages/@nitpicker/viewer/web/api/use-graph.ts
+++ b/packages/@nitpicker/viewer/web/api/use-graph.ts
@@ -1,16 +1,26 @@
 import type { LinkGraph } from '@nitpicker/query';
 
 import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router';
 
 import { apiGet } from './api-client.js';
+import { getGraphQueryParams } from './get-graph-query-params.js';
 
 /**
  * Fetches the internal-page link graph (nodes + edges).
+ *
+ * Forwards `?limit=` from the current URL to the API via
+ * {@link getGraphQueryParams} so an operator can override the server-side
+ * default cap without editing the URL by hand. `?limit=0` uncaps the graph
+ * (accepting the V8 string-limit risk), any positive integer sets a custom
+ * cap, and omitting the parameter falls back to the API's default.
  * @returns The TanStack Query result for the link graph.
  */
 export function useGraph() {
+	const [searchParams] = useSearchParams();
+	const params = getGraphQueryParams(searchParams);
 	return useQuery({
-		queryKey: ['graph'],
-		queryFn: () => apiGet<LinkGraph>('/api/graph'),
+		queryKey: ['graph', params.limit],
+		queryFn: () => apiGet<LinkGraph>('/api/graph', params),
 	});
 }

--- a/packages/@nitpicker/viewer/web/i18n/translations.ts
+++ b/packages/@nitpicker/viewer/web/i18n/translations.ts
@@ -242,6 +242,11 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 					'Showing the top {nodes} pages by in-degree — larger graphs are capped so the JSON response fits in V8 string limits and the layout stays usable. Pass `?limit=0` in the URL to opt out.',
 				ariaLabel:
 					'Network graph of internal pages (visual representation). For an accessible, tabular view of a specific page’s inbound and outbound links, open that page from the Pages view and see its Page Detail.',
+				legendLabel: 'Node color legend',
+				legendCrawled: 'Crawled',
+				legendInventorySeed: 'Inventory (seed)',
+				legendInventoryDiscovered: 'Inventory (discovered)',
+				legendError: 'Error (4xx/5xx)',
 			},
 			errors: {
 				title: 'Connection Failures',
@@ -536,6 +541,11 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 					'被リンク数の多い上位 {nodes} 件のみ表示しています。これより大きなグラフは JSON レスポンスの V8 文字列上限とレイアウトの可読性を保つために打ち切られます。URL に `?limit=0` を付けると上限を解除できます。',
 				ariaLabel:
 					'内部ページのネットワークグラフ（視覚表現）。特定ページの被リンク・発リンクを表形式でアクセシブルに確認するには、ページ一覧から該当ページを開きページ詳細を参照してください。',
+				legendLabel: 'ノード色の凡例',
+				legendCrawled: 'クロール由来',
+				legendInventorySeed: 'インベントリ (シード)',
+				legendInventoryDiscovered: 'インベントリ (派生)',
+				legendError: 'エラー (4xx/5xx)',
 			},
 			errors: {
 				title: '接続障害',

--- a/packages/@nitpicker/viewer/web/routes/graph-colors.ts
+++ b/packages/@nitpicker/viewer/web/routes/graph-colors.ts
@@ -1,0 +1,23 @@
+/**
+ * Sigma node fills for the Network Graph view, shared by
+ * {@link import('./pick-node-color.js').pickNodeColor} (which maps
+ * a `(status, PageSource)` pair to a color) and
+ * {@link import('./graph-legend.js').GraphLegend} (which renders
+ * the same colors as a legend so an operator can decode the graph
+ * without reading source).
+ *
+ * The single source of truth lives here so a hue change flows to both
+ * consumers automatically — otherwise the legend and the rendered
+ * nodes will drift the first time someone tweaks one and forgets
+ * the other.
+ */
+export const GRAPH_COLORS = {
+	/** Node fill for `crawled` pages with a healthy status. */
+	crawled: '#4aa3ff',
+	/** Node fill when the page returned a 4xx/5xx status (overrides source). */
+	error: '#ff6b6b',
+	/** Node fill for `inventory-seed` pages — URLs from the operator's inventory list. */
+	inventorySeed: '#ff9f43',
+	/** Node fill for `inventory-discovered` pages — reached by following anchors from an inventory-seed. */
+	inventoryDiscovered: '#a06cd5',
+} as const;

--- a/packages/@nitpicker/viewer/web/routes/graph-legend.tsx
+++ b/packages/@nitpicker/viewer/web/routes/graph-legend.tsx
@@ -1,0 +1,56 @@
+import { useI18n } from '../i18n/use-i18n.js';
+
+import { GRAPH_COLORS } from './graph-colors.js';
+
+/**
+ * Static legend that maps the four graph node colors to their meaning.
+ *
+ * Without a legend the operator sees four hues on the canvas with no way
+ * to decode them — the color-by-source feature is only useful if the
+ * mapping is visible somewhere. Since the graph has no interactive
+ * hover-tooltip on nodes today, the legend has to be a persistent
+ * sibling of the canvas rather than an on-demand affordance.
+ *
+ * The rows are ordered by expected frequency (crawled first, errors
+ * last) so an operator can find the common ones without hunting.
+ * @returns The legend element.
+ */
+export function GraphLegend() {
+	const { t } = useI18n();
+	return (
+		<ul className="graph-legend" aria-label={t('views.graph.legendLabel')}>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.crawled }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendCrawled')}
+			</li>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.inventorySeed }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendInventorySeed')}
+			</li>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.inventoryDiscovered }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendInventoryDiscovered')}
+			</li>
+			<li className="graph-legend-row">
+				<span
+					className="graph-legend-swatch"
+					style={{ backgroundColor: GRAPH_COLORS.error }}
+					aria-hidden="true"
+				/>
+				{t('views.graph.legendError')}
+			</li>
+		</ul>
+	);
+}

--- a/packages/@nitpicker/viewer/web/routes/graph-view.tsx
+++ b/packages/@nitpicker/viewer/web/routes/graph-view.tsx
@@ -9,6 +9,9 @@ import { useGraph } from '../api/use-graph.js';
 import { ViewHeader } from '../components/view-header.js';
 import { useI18n } from '../i18n/use-i18n.js';
 
+import { GraphLegend } from './graph-legend.js';
+import { pickNodeColor } from './pick-node-color.js';
+
 /** Max rendered node radius (in-degree is mapped onto this). */
 const MAX_NODE_SIZE = 18;
 
@@ -40,7 +43,7 @@ export function GraphView() {
 				size: Math.min(MAX_NODE_SIZE, 3 + Math.sqrt(node.inDegree)),
 				x: Math.random(),
 				y: Math.random(),
-				color: node.status != null && node.status >= 400 ? '#ff6b6b' : '#4aa3ff',
+				color: pickNodeColor(node.status, node.source),
 			});
 		}
 		for (const edge of data.edges) {
@@ -91,6 +94,7 @@ export function GraphView() {
 					)}
 				</div>
 			)}
+			<GraphLegend />
 			<div
 				ref={containerRef}
 				className="graph-canvas"

--- a/packages/@nitpicker/viewer/web/routes/pick-node-color.spec.ts
+++ b/packages/@nitpicker/viewer/web/routes/pick-node-color.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { GRAPH_COLORS } from './graph-colors.js';
+import { pickNodeColor } from './pick-node-color.js';
+
+describe('pickNodeColor', () => {
+	it('crawled 健全ページは crawled 色', () => {
+		expect(pickNodeColor(200, 'crawled')).toBe(GRAPH_COLORS.crawled);
+	});
+
+	it('inventory-seed 健全ページは inventorySeed 色', () => {
+		expect(pickNodeColor(200, 'inventory-seed')).toBe(GRAPH_COLORS.inventorySeed);
+	});
+
+	it('inventory-discovered 健全ページは inventoryDiscovered 色', () => {
+		expect(pickNodeColor(200, 'inventory-discovered')).toBe(
+			GRAPH_COLORS.inventoryDiscovered,
+		);
+	});
+
+	it('status が null のときは source の色を返す', () => {
+		expect(pickNodeColor(null, 'crawled')).toBe(GRAPH_COLORS.crawled);
+		expect(pickNodeColor(null, 'inventory-seed')).toBe(GRAPH_COLORS.inventorySeed);
+	});
+
+	it('4xx は source を問わず error 色 (error > source 優先)', () => {
+		expect(pickNodeColor(404, 'crawled')).toBe(GRAPH_COLORS.error);
+		expect(pickNodeColor(404, 'inventory-seed')).toBe(GRAPH_COLORS.error);
+		expect(pickNodeColor(404, 'inventory-discovered')).toBe(GRAPH_COLORS.error);
+	});
+
+	it('5xx は source を問わず error 色', () => {
+		expect(pickNodeColor(500, 'crawled')).toBe(GRAPH_COLORS.error);
+		expect(pickNodeColor(503, 'inventory-seed')).toBe(GRAPH_COLORS.error);
+	});
+
+	it('status = 399 (境界) は error 色にならない', () => {
+		expect(pickNodeColor(399, 'crawled')).toBe(GRAPH_COLORS.crawled);
+	});
+
+	it('status = 400 (境界) は error 色になる', () => {
+		expect(pickNodeColor(400, 'crawled')).toBe(GRAPH_COLORS.error);
+	});
+
+	it('3xx redirect は error 色にならない', () => {
+		expect(pickNodeColor(301, 'crawled')).toBe(GRAPH_COLORS.crawled);
+	});
+});

--- a/packages/@nitpicker/viewer/web/routes/pick-node-color.ts
+++ b/packages/@nitpicker/viewer/web/routes/pick-node-color.ts
@@ -1,0 +1,42 @@
+import type { PageSource } from '@nitpicker/query';
+
+import { GRAPH_COLORS } from './graph-colors.js';
+
+/**
+ * Picks the sigma node fill for a graph node.
+ *
+ * Error status wins over source (a broken page needs to draw the eye regardless
+ * of where it came from). Otherwise the three ingestion channels are visually
+ * distinct so an operator can tell inventory pages from the crawled backbone.
+ *
+ * The `source: PageSource` typing forces this switch to stay exhaustive:
+ * adding a fourth provenance channel to the union in `@nitpicker/crawler`
+ * will surface as a type error (via the `satisfies never` guard) instead of
+ * silently falling through to `GRAPH_COLORS.crawled`. The same union drives
+ * `SourceBadge` (Isolated Pages / Unused Resources tables) — a hue change
+ * in one place needs a matching change here so the two views stay legible
+ * when cross-referenced.
+ * @param status - HTTP status of the page (null if unknown).
+ * @param source - Ingestion provenance of the page.
+ * @returns A hex color string.
+ */
+export function pickNodeColor(status: number | null, source: PageSource): string {
+	if (status != null && status >= 400) {
+		return GRAPH_COLORS.error;
+	}
+	switch (source) {
+		case 'inventory-seed': {
+			return GRAPH_COLORS.inventorySeed;
+		}
+		case 'inventory-discovered': {
+			return GRAPH_COLORS.inventoryDiscovered;
+		}
+		case 'crawled': {
+			return GRAPH_COLORS.crawled;
+		}
+		default: {
+			const _exhaustive: never = source;
+			return _exhaustive;
+		}
+	}
+}

--- a/packages/@nitpicker/viewer/web/styles.css
+++ b/packages/@nitpicker/viewer/web/styles.css
@@ -1289,6 +1289,32 @@ h2 {
 	border-radius: 6px;
 }
 
+.graph-legend {
+	display: block flex;
+	flex-wrap: wrap;
+	gap: 12px 16px;
+	padding: 0;
+	margin-block: 0 6px;
+	margin-inline: 0;
+	font-size: var(--font-size-sm);
+	color: var(--text-dim);
+	list-style: none;
+}
+
+.graph-legend-row {
+	display: inline flex;
+	gap: 6px;
+	align-items: center;
+}
+
+.graph-legend-swatch {
+	display: inline flow-root;
+	inline-size: 12px;
+	block-size: 12px;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+}
+
 /* Skip link: visually hidden until focused, then pinned to the top-left. */
 .skip-link {
 	position: absolute;

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -18,6 +18,6 @@
 		"@nitpicker/types": "0.12.0",
 		"await-event-emitter": "2.0.2",
 		"knex": "3.3.0",
-		"vitest": "4.1.9"
+		"vitest": "4.1.10"
 	}
 }

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -7,7 +7,7 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
-		"@hono/node-server": "2.0.6",
+		"@hono/node-server": "2.0.8",
 		"hono": "4.12.27"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,7 +3032,7 @@ __metadata:
     enquirer: "npm:2.4.1"
     googleapis: "npm:173.0.0"
     jsdom: "npm:29.1.1"
-    vitest: "npm:4.1.9"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -5918,25 +5918,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/expect@npm:4.1.9"
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.9"
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     chai: "npm:^6.2.2"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/243bacaed2cba5e0ea4ec7465662fcec465a358a0e06381e337fac49426aa67a73b104fbb9d65d8bccadfba8f70e27f57ffb897aacfa140f579a556367357875
+  checksum: 10c0/a817ad0d9bd6a039776a7228d54fb8319c17e4af15917407f5566ac61781a8511f591d302519d6999217399915bc3c0290028189fc73f5c38f80cb01b6f19c8d
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/mocker@npm:4.1.9"
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
   dependencies:
-    "@vitest/spy": "npm:4.1.9"
+    "@vitest/spy": "npm:4.1.10"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
@@ -5947,56 +5947,56 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/707353b7435bbfd441cc754e4ee7bc5921b70d07b051c6e414b6bbe4ca369154702b0ddeb603389469fe87ca1983e002eb2d55044582661f54a1945dd27e5c82
+  checksum: 10c0/4aa70b0df58681652e2e28093437fb2e8f4d02a6d03f5619abc266ac1c5ae5f43326148061d13ae6e071e0f6cfcf7634659af63644de8ce098a7c98949a3d1ad
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/pretty-format@npm:4.1.9"
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
   dependencies:
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/5b96295f25ab885616230ad1355fc82f490bebb39cc707688d7c8969c08270d7e076ed8a10af4e762ed57145193c6061a1f549f136f0ded344f8db0c2b3fb3de
+  checksum: 10c0/1a5daba730ffe23f2000bff484b4b2842f3b178d93663cb487b215516b8d3b62caa3e2bb2a3c63307b61a9fe58fb9bfff38559bc0c5e49d8aa403d6803a1d918
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/runner@npm:4.1.9"
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
   dependencies:
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/utils": "npm:4.1.10"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/d206b4891a64b1f55c346f832b0a7b489108094d8ae34438d3b53e78be7b45b139fa95ffa027c98c357bd532268ee573168de1943235b7eed32a9236ed5978bb
+  checksum: 10c0/554b72639de9694271b99be8ae273fe12ec793093ec91cce143816cd1187d40b7138a4d9d4de4f456cfca9567de986825bff97e107c05b9eb4abc130e854286d
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/snapshot@npm:4.1.9"
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.9"
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/c3099df12ad1f9c1e180441856c9eb82f1990f87ff16aafedd6fa19978eaff20bc59220b692a99fcc822daef86eab256ba3dadb49544b7bd625b57c49cd9d995
+  checksum: 10c0/e71398725f51af5fd0c07bb4b957d0f987daf9b4c564ac24cb2a4d1afde1a6939f535ac17761a32dcc41b0a1e6d4088af66dc44df89fdebebb92aabed1a92b5f
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/spy@npm:4.1.9"
-  checksum: 10c0/e51f328f55b76e8ba66e5e18f183484a8dc0a092685b101112d3e9fb8e989ddca162c98ddf00254476502c25bc05c4ec1e277fd6ad8bfc702464c08f6b5dd115
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10c0/e5c08012560af6727fd66741c5cda25560d7c5442103d0c83e4276a9b0dd90b9da6cdf823a461195229a16c6ff87768ce788a68d0fa29dea73ee285618668178
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.1.9":
-  version: 4.1.9
-  resolution: "@vitest/utils@npm:4.1.9"
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.9"
+    "@vitest/pretty-format": "npm:4.1.10"
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/d55506c077fd72c091eb66f02926f0abf72801c87a085f565698289562f47befa114ae2c680ab8736dfe46abab0cfd6b8031f2ac519bafeb37578aa6e5ad03c5
+  checksum: 10c0/05b0ecec6997ec22fc08377e57dbd8fa37992e05961f3a7a916d98b1ab56d15c2a87dbd83d392b628242bdc156b1705e7fa60a3bf0c54bdb51158c153e05fc5d
   languageName: node
   linkType: hard
 
@@ -14175,7 +14175,7 @@ __metadata:
     lerna: "npm:9.0.7"
     npm-run-all2: "npm:9.0.2"
     typescript: "npm:6.0.3"
-    vitest: "npm:4.1.9"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -18019,7 +18019,7 @@ __metadata:
     await-event-emitter: "npm:2.0.2"
     hono: "npm:4.12.27"
     knex: "npm:3.3.0"
-    vitest: "npm:4.1.9"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -19700,17 +19700,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:4.1.9":
-  version: 4.1.9
-  resolution: "vitest@npm:4.1.9"
+"vitest@npm:4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
   dependencies:
-    "@vitest/expect": "npm:4.1.9"
-    "@vitest/mocker": "npm:4.1.9"
-    "@vitest/pretty-format": "npm:4.1.9"
-    "@vitest/runner": "npm:4.1.9"
-    "@vitest/snapshot": "npm:4.1.9"
-    "@vitest/spy": "npm:4.1.9"
-    "@vitest/utils": "npm:4.1.9"
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     es-module-lexer: "npm:^2.0.0"
     expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
@@ -19728,12 +19728,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.9
-    "@vitest/browser-preview": 4.1.9
-    "@vitest/browser-webdriverio": 4.1.9
-    "@vitest/coverage-istanbul": 4.1.9
-    "@vitest/coverage-v8": 4.1.9
-    "@vitest/ui": 4.1.9
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -19764,7 +19764,7 @@ __metadata:
       optional: false
   bin:
     vitest: ./vitest.mjs
-  checksum: 10c0/1ac80ef4991be82822a52aea48415f1bc64ddf8fd88ee24c172ec368f1d480fefacbde622c3c951982f7961a1d07313e18deaafc774d29e42ad6f6ffa63334a7
+  checksum: 10c0/ff07294a57f9c62f3b503f7cf88a52ee0753ed26389a49cda430387a3898f39d80af47180b0af19e27acab5bd11ae95706bd4b44ce8befc97d3ae49af6ca4fc1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,12 +1636,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-server@npm:2.0.6":
-  version: 2.0.6
-  resolution: "@hono/node-server@npm:2.0.6"
+"@hono/node-server@npm:2.0.8":
+  version: 2.0.8
+  resolution: "@hono/node-server@npm:2.0.8"
   peerDependencies:
     hono: ^4
-  checksum: 10c0/493361ac3b165c4e91fc4442160d60c4fdfb2cd4d303e0d0ee70f1be17acbe6abd516582556a66bbfd8a47ad5f436468caf3bb7f89090b1a07fd613ffd6ad0e7
+  checksum: 10c0/2284799e7ea8c3ea18dcd29fbc523792d7e42768f11dff8a937ce2e4ec965785552da4e9649354b00079243946bd9f65d23b8d9b923cef4984175e507398bb72
   languageName: node
   linkType: hard
 
@@ -3048,7 +3048,7 @@ __metadata:
   dependencies:
     "@d-zero/dealer": "npm:1.9.4"
     "@d-zero/shared": "npm:0.22.2"
-    "@hono/node-server": "npm:2.0.6"
+    "@hono/node-server": "npm:2.0.8"
     "@nitpicker/crawler": "npm:0.12.0"
     "@nitpicker/query": "npm:0.12.0"
     "@playwright/test": "npm:1.61.1"
@@ -18010,7 +18010,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "test-server@workspace:packages/test-server"
   dependencies:
-    "@hono/node-server": "npm:2.0.6"
+    "@hono/node-server": "npm:2.0.8"
     "@nitpicker/analyze-main-contents": "npm:0.12.0"
     "@nitpicker/core": "npm:0.12.0"
     "@nitpicker/crawler": "npm:0.12.0"


### PR DESCRIPTION
## Summary

Implements #192 (Phase 6-C of epic #103). Additive DDL only — creates the 6 core normalised entity / edge tables that will replace the legacy write model under Phase 6-F. No consumer touches the new tables yet.

Tables:
- `content_items` (replaces `pages`, core columns)
- `page_meta` (page metadata split off from `pages`, 1:1 with `content_items`)
- `resource_items` (replaces `resources`)
- `anchor_edges` (replaces `anchors`, deduped to distinct `(page_id, href_page_id)` pairs)
- `resource_ref_edges` (replaces `resources-referrers`, `WITHOUT ROWID`)
- `image_items` (replaces `images`, `src`/`currentSrc` split into `*_url_id` vs `*_blob_id`)

Key design invariants (all documented in JSDoc on `createPhase6CEntityTables`):

- Entity PKs reuse the SAME values as legacy `pages` / `resources` / `images` so Phase 6-D populate can insert with explicit IDs, preserving every existing FK reference without any per-row UPDATE. `AUTOINCREMENT` prevents rowid reuse after DELETE.
- `UNIQUE(url_id)` on `content_items` and `resource_items` re-establishes the legacy `pages.url UNIQUE` guarantee at the entity level (`url_refs.url UNIQUE` alone only guarantees "one URL string → one ref id", not "one ref id → one entity row").
- `content_items.redirect_dest_id` is `DEFERRABLE INITIALLY DEFERRED` so Phase 6-D can commit redirect sources and destinations in either order within one transaction.
- `page_meta.page_id` is both PK and FK with `ON DELETE CASCADE`, mirroring `page_html_ref` / `page_tags` / `page_jsonld`.
- `source` columns default to `'crawled'` matching legacy defaults so post-Phase-6F writers relying on the default do not immediately fail with NOT NULL violations.
- Full legacy index parity: `content_items` (`is_external`, `scraped`, `redirect_dest_id`, `content_type_id`, `crawl_order`, `source` + UNIQUE auto-index on `url_id`), `page_meta` (`og_type`, `robots_noindex`), `resource_items` (`source` + UNIQUE auto-index on `url_id`), `anchor_edges` (`href_page_id` + UNIQUE auto-index on `(page_id, href_page_id)`), `resource_ref_edges` (explicit `page_id` index because composite PK only prefix-seeks by `resource_id`), `image_items` (`page_id`).
- `image_items` `src` / `blob` mutual-exclusion enforced by a CHECK constraint.

Fresh archives get the tables via `initSchema`. Existing archives get them via `migratePhase6CEntityTables` at `Database.connect` time, ordered after `migratePhase6ARefTables` because most entity tables reference Phase 6-A ref tables. All DDL statements use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` so the primitive is safe against partial-corruption repair.

Blocks #193.

## Test plan

- [x] 40 new unit tests covering column shapes, UNIQUE / PK / FK / CHECK / CASCADE / DEFERRABLE / DEFAULT / AUTOINCREMENT behaviour, idempotency, and partial-corruption repair
- [x] `yarn vitest run packages/@nitpicker/crawler` (1126 tests, 4 skipped) all pass
- [x] `yarn build` succeeds across all 14 projects
- [x] `yarn lint:check` clean (0 errors)
- [x] xhigh code review + qa + pdm + doc review pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
