### PR TITLE
refactor(crawler): split database.ts into per-file op modules

### DIFF
--- a/packages/@nitpicker/crawler/src/archive/db-ops/_shared/get-id-by-url.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/_shared/get-id-by-url.ts
@@ -1,0 +1,85 @@
+import type { DB_Page, PageSource } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Returns the `pages.id` for `url`, inserting a placeholder row when the
+ * URL is not yet known. Foundational identity primitive shared by every
+ * op that needs to record an edge or lookup to a URL (see the callers
+ * under `pages/write/`, `resources/insert-resource-referrers.ts`, and
+ * `errors/insert-page-error.ts`).
+ *
+ * **Source semantics.** `source` is written ONLY on the INSERT path —
+ * when the row already exists, we never reach the INSERT and the
+ * existing row's `source` stays untouched. This is what keeps a second
+ * `crawl --inventory` from "demoting" a page that was first labelled
+ * `'inventory-seed'` back to `'inventory-discovered'` on later passes.
+ *
+ * **Crawled-wins downgrade.** When a row that was previously labelled
+ * `'inventory-seed'` or `'inventory-discovered'` is re-encountered via a
+ * `'crawled'`-lineage anchor (the parent page is part of the graph
+ * reachable from the original crawl roots), downgrade the row to
+ * `'crawled'`. The inventory goal is finding orphans — anything reachable
+ * from the crawled chain is NOT an orphan and should not retain an
+ * inventory label.
+ *
+ * **Race-condition safety.** `onConflict('url').ignore()` returns 0 rows
+ * inserted when a concurrent transaction won the race. In that case we
+ * re-SELECT the row to recover its id rather than throw.
+ * @param qb - Knex instance OR a transaction, used verbatim for both
+ *   the initial SELECT and any INSERT / UPDATE the function issues. Pass
+ *   a `trx` when the caller is running inside a transaction so the read
+ *   sees uncommitted writes from that same transaction; otherwise pass
+ *   the base Knex instance. Callers must resolve `trx ?? knex` before
+ *   calling — the fallback logic that used to live inside the class-level
+ *   `#getIdByUrl` (`const qb = trx ?? this.#instance`) is now the
+ *   caller's responsibility so `getIdByUrl` stays a pure function of its
+ *   arguments.
+ * @param url - The URL to look up or insert.
+ * @param isExternal - Optional; recorded on new inserts only. `1` marks
+ *   the row as an external URL that will never be scraped as a target.
+ * @param source - Optional provenance label put on a newly-inserted row.
+ *   Omit to let the `pages.source` DEFAULT (`'crawled'`) apply.
+ * @returns The `pages.id` of the existing or newly inserted row.
+ * @throws When `onConflict.ignore()` returns 0 rows and the follow-up
+ *   SELECT also fails to locate the URL — should not happen under
+ *   normal race conditions, so it surfaces as a hard error.
+ */
+export async function getIdByUrl(
+	qb: Knex | Knex.Transaction,
+	url: string,
+	isExternal?: 0 | 1,
+	source?: PageSource,
+): Promise<number> {
+	const [record] = await qb
+		.select('id', 'source')
+		.from<DB_Page>('pages')
+		.where('url', url);
+	// Must use `?` because it may be `undefined`
+	const pageId = record?.id ?? Number.NaN;
+	if (Number.isFinite(pageId)) {
+		if (source === 'crawled' && record?.source && record.source !== 'crawled') {
+			await qb<DB_Page>('pages').where('id', pageId).update({ source: 'crawled' });
+		}
+		return pageId;
+	}
+	const insertedRows = await qb<DB_Page>('pages')
+		.insert({
+			url,
+			scraped: 0,
+			isTarget: 0,
+			...(isExternal != null && { isExternal }),
+			...(source === undefined ? {} : { source }),
+		})
+		.onConflict('url')
+		.ignore();
+	const [insertedId] = insertedRows;
+	if (!insertedId) {
+		// onConflict.ignore() returns 0 on race condition — re-select
+		const [existing] = await qb.select('id').from<DB_Page>('pages').where('url', url);
+		if (existing?.id) {
+			return existing.id;
+		}
+		throw new Error(`Failed to insert a new page: ${url}`);
+	}
+	return insertedId;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/_shared/retry-setting.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/_shared/retry-setting.ts
@@ -1,0 +1,20 @@
+import type { RetryCallOptions } from '@d-zero/shared/retry';
+
+/**
+ * Default retry options shared by every `Database.*` op that wraps its
+ * knex work in {@link ../../../utils/error/emit-error-with-retry.ts}
+ * (`emitErrorAndRetry`) or {@link ../../../utils/error/emit-error.ts}
+ * (`emitError`, no retry). Three retries at 300 ms intervals covers the
+ * transient libsql failure modes (WAL contention, brief lock waits)
+ * without letting a genuinely broken query hang the crawler for long.
+ *
+ * Two ops deliberately do NOT use these settings and instead wrap
+ * `retryCall` themselves so they can override `label` (`getResourceByUrl`)
+ * or opt out entirely (`checkpoint`, `destroy`, `getKnex`, `addOrderField`,
+ * `setUrlOrder`, the `constructor`, and `Database.connect`). See the
+ * corresponding op files for the reasoning at each site.
+ */
+export const retrySetting: RetryCallOptions = {
+	interval: 300,
+	retries: 3,
+};

--- a/packages/@nitpicker/crawler/src/archive/db-ops/_shared/safe-parse-json.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/_shared/safe-parse-json.ts
@@ -1,0 +1,17 @@
+/**
+ * Parses a JSON column value, returning `null` on parse failure rather
+ * than throwing. JSON columns in `page_jsonld` (`parsed`) and `page_tags`
+ * (`categories`, `sources`) are written by `JSON.stringify` and round-trip
+ * cleanly under normal conditions; a hand-edited archive that has
+ * malformed JSON in those columns should degrade gracefully rather than
+ * propagate a parse error up to the consumer.
+ * @param value - JSON-encoded text.
+ * @returns Parsed value, or `null` if the input could not be parsed.
+ */
+export function safeParseJson(value: string): unknown {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return null;
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/analysis/replace-analysis-violations.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/analysis/replace-analysis-violations.ts
@@ -1,0 +1,112 @@
+import type { DB_Page } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { createHash } from 'node:crypto';
+
+import { eachSplitted } from '../../../utils/array/each-splitted.js';
+
+/**
+ * Replaces the stored analysis violations with a freshly generated set.
+ *
+ * The function resolves every violation URL to a `pages.id`, deduplicates
+ * message/code text through `analysis_text_refs`, and rewrites
+ * `analysis_violations` in one transaction. This is the storage-side
+ * counterpart of the query-layer `getViolations` read path.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param violations - Flat violation list from the analyze phase.
+ */
+export async function replaceAnalysisViolations(
+	knex: Knex,
+	violations: readonly {
+		validator: string;
+		severity: string;
+		rule: string;
+		code?: string | null;
+		message: string;
+		url: string;
+	}[],
+): Promise<void> {
+	await knex.transaction(async (trx) => {
+		await trx('analysis_violations').delete();
+		await trx('analysis_text_refs').delete();
+		if (violations.length === 0) {
+			return;
+		}
+
+		const urls = [...new Set(violations.map((v) => v.url))];
+		const pageRows = await trx
+			.select('id', 'url')
+			.from<DB_Page>('pages')
+			.whereIn('url', urls);
+		const pageIdByUrl = new Map(pageRows.map((row) => [row.url, row.id]));
+		if (pageIdByUrl.size !== urls.length) {
+			const missing = urls.filter((url) => !pageIdByUrl.has(url));
+			throw new Error(
+				`replaceAnalysisViolations: could not resolve ${missing.length} page URL(s): ${missing[0]}`,
+			);
+		}
+
+		const textByValue = new Map<string, number>();
+		const resolveTextId = async (text: string): Promise<number> => {
+			const cached = textByValue.get(text);
+			if (cached != null) {
+				return cached;
+			}
+			const sha256 = createHash('sha256').update(text).digest('hex');
+			await trx('analysis_text_refs')
+				.insert({ text, sha256 })
+				.onConflict(['sha256', 'text'])
+				.ignore();
+			const [existing] = await trx
+				.select('id')
+				.from<{ id: number }>('analysis_text_refs')
+				.where('sha256', sha256)
+				.where('text', text);
+			if (!existing) {
+				throw new Error(
+					`replaceAnalysisViolations: failed to resolve text ref for ${text}`,
+				);
+			}
+			textByValue.set(text, existing.id);
+			return existing.id;
+		};
+
+		const rows: Array<{
+			page_id: number;
+			validator: string;
+			severity: string;
+			rule: string;
+			message_text_id: number;
+			code_text_id: number | null;
+			page_url_sort_key: string;
+			message_sort_key: string;
+			code_sort_key: string;
+		}> = [];
+		for (const violation of violations) {
+			const pageId = pageIdByUrl.get(violation.url);
+			if (!pageId) {
+				throw new Error(
+					`replaceAnalysisViolations: could not resolve page URL: ${violation.url}`,
+				);
+			}
+			const messageTextId = await resolveTextId(violation.message);
+			const codeValue = violation.code ?? '';
+			const codeTextId = codeValue === '' ? null : await resolveTextId(codeValue);
+			rows.push({
+				page_id: pageId,
+				validator: violation.validator,
+				severity: violation.severity,
+				rule: violation.rule,
+				message_text_id: messageTextId,
+				code_text_id: codeTextId,
+				page_url_sort_key: violation.url,
+				message_sort_key: violation.message,
+				code_sort_key: codeValue,
+			});
+		}
+
+		await eachSplitted(rows, 500, async (chunk) => {
+			await trx('analysis_violations').insert(chunk);
+		});
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/anchors/get-anchors-on-page.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/anchors/get-anchors-on-page.ts
@@ -1,0 +1,25 @@
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves all anchors (outgoing links) on a specific page.
+ * Joins the `anchors` table with the `pages` table to resolve link destinations.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param pageId - The database ID of the page whose anchors to retrieve.
+ * @returns An array of anchor records with resolved URL, title, status, and content type.
+ */
+export async function getAnchorsOnPage(knex: Knex, pageId: number) {
+	const res = await knex
+		.select(
+			'pages.url',
+			'pages.title',
+			'pages.status',
+			'pages.statusText',
+			'pages.contentType',
+			'anchors.hash',
+			'anchors.textContent',
+		)
+		.from('anchors')
+		.join('pages', 'anchors.hrefId', '=', 'pages.id')
+		.where('anchors.pageId', pageId);
+	return res;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/config/get-base-url.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/config/get-base-url.ts
@@ -1,0 +1,17 @@
+import type { Config } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves the base URL of the crawl session from the `info` table.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns The base URL string.
+ * @throws {Error} If no base URL is found in the database.
+ */
+export async function getBaseUrl(knex: Knex): Promise<string> {
+	const selected = await knex.select('baseUrl').from<Config>('info');
+	if (!selected[0]) {
+		throw new Error('No baseUrl');
+	}
+	const [{ baseUrl }] = selected;
+	return baseUrl || '';
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/config/get-config.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/config/get-config.ts
@@ -1,0 +1,31 @@
+import type { Config } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { dbLog } from '../../debug.js';
+import { getJSON } from '../../get-json.js';
+
+/**
+ * Retrieves the full crawl configuration from the `info` table.
+ * Deserializes JSON-encoded fields (`roots`, `excludes`, `excludeKeywords`, `excludeUrls`).
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns The parsed {@link Config} object.
+ * @throws {Error} If no configuration is found in the database.
+ */
+export async function getConfig(knex: Knex): Promise<Config> {
+	const [config] = await knex.select('*').from<Config>('info');
+	if (!config) {
+		throw new Error('No config');
+	}
+	const opt: Config = {
+		...config,
+		excludes: getJSON<string[]>(config.excludes, []),
+		excludeKeywords: getJSON<string[]>(config.excludeKeywords, []),
+		excludeUrls: getJSON<string[]>(config.excludeUrls, []),
+		roots: getJSON<string[]>(config.roots, []),
+		retry: config.retry ?? 3,
+	};
+	// @ts-expect-error — `id` is the primary key, not part of the public Config shape
+	delete opt.id;
+	dbLog('Table `info`: %O => %O', config, opt);
+	return opt;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/config/get-name.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/config/get-name.ts
@@ -1,0 +1,17 @@
+import type { Config } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves the crawl session name from the `info` table.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns The name string.
+ * @throws {Error} If no name is found in the database.
+ */
+export async function getName(knex: Knex): Promise<string> {
+	const selected = await knex.select('name').from<Config>('info');
+	if (!selected[0]) {
+		throw new Error('No name');
+	}
+	const [{ name }] = selected;
+	return name;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/config/info-column-allowlist.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/config/info-column-allowlist.ts
@@ -1,0 +1,28 @@
+import type { Config } from '../../types.js';
+
+/**
+ * Columns of the `info` table that `setConfig` / `updateConfig` are allowed to
+ * write. Any key outside this set is silently dropped so callers can splat a
+ * wider runtime config (with extras like `cwd`) without hitting "no such
+ * column" at the SQL layer.
+ */
+export const INFO_COLUMN_ALLOWLIST: ReadonlySet<string> = new Set<keyof Config>([
+	'version',
+	'name',
+	'baseUrl',
+	'roots',
+	'recursive',
+	'interval',
+	'image',
+	'fetchExternal',
+	'parallels',
+	'excludes',
+	'excludeKeywords',
+	'excludeUrls',
+	'maxExcludedDepth',
+	'retry',
+	'fromList',
+	'disableQueries',
+	'userAgent',
+	'ignoreRobots',
+]);

--- a/packages/@nitpicker/crawler/src/archive/db-ops/config/info-json-columns.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/config/info-json-columns.ts
@@ -1,0 +1,12 @@
+import type { Config } from '../../types.js';
+
+/**
+ * Subset of {@link ./info-column-allowlist.ts} that is stored as a JSON-encoded
+ * string and therefore needs `JSON.stringify` on write.
+ */
+export const INFO_JSON_COLUMNS: ReadonlySet<string> = new Set<keyof Config>([
+	'roots',
+	'excludes',
+	'excludeKeywords',
+	'excludeUrls',
+]);

--- a/packages/@nitpicker/crawler/src/archive/db-ops/config/set-config.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/config/set-config.ts
@@ -1,0 +1,25 @@
+import type { Config } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { INFO_COLUMN_ALLOWLIST } from './info-column-allowlist.js';
+import { INFO_JSON_COLUMNS } from './info-json-columns.js';
+
+/**
+ * Stores the crawl configuration in the `info` table.
+ * Only fields in {@link ./info-column-allowlist.ts} are forwarded — any extra
+ * runtime-only field on the input is silently dropped so callers can splat
+ * a wider config object without producing SQL errors. JSON-array fields
+ * are serialized via `JSON.stringify`.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param config - The {@link Config} object to store.
+ */
+export async function setConfig(knex: Knex, config: Config) {
+	const payload: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(config)) {
+		if (!INFO_COLUMN_ALLOWLIST.has(key)) {
+			continue;
+		}
+		payload[key] = INFO_JSON_COLUMNS.has(key) ? JSON.stringify(value) : value;
+	}
+	return knex.from<Config>('info').insert(payload);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/config/update-config.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/config/update-config.ts
@@ -1,0 +1,40 @@
+import type { Config } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { INFO_COLUMN_ALLOWLIST } from './info-column-allowlist.js';
+import { INFO_JSON_COLUMNS } from './info-json-columns.js';
+
+/**
+ * Update the single row in the `info` table with a partial config patch.
+ *
+ * Used by the append flow to extend `roots` (and any other tweakable
+ * field) without replacing the entire row. JSON-array fields are serialized on
+ * the fly; primitive fields are written verbatim. Unspecified fields stay as-is.
+ *
+ * Unknown keys (anything outside the allow-list of `info`-table columns) are
+ * silently dropped instead of being passed to SQL, so callers that splat a
+ * wider runtime config (e.g. `CrawlConfig` with `cwd` / `executablePath`)
+ * cannot accidentally trigger a "no such column" SQL error.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param patch - Partial {@link Config} fields to overwrite. `undefined` values are skipped.
+ */
+export async function updateConfig(knex: Knex, patch: Partial<Config>): Promise<void> {
+	const payload: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(patch)) {
+		if (value === undefined) {
+			continue;
+		}
+		if (!INFO_COLUMN_ALLOWLIST.has(key)) {
+			continue;
+		}
+		if (INFO_JSON_COLUMNS.has(key)) {
+			payload[key] = JSON.stringify(value);
+			continue;
+		}
+		payload[key] = value;
+	}
+	if (Object.keys(payload).length === 0) {
+		return;
+	}
+	await knex.from<Config>('info').update(payload);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/errors/insert-crawl-error.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/errors/insert-crawl-error.ts
@@ -1,0 +1,28 @@
+import type { Knex } from 'knex';
+
+/**
+ * Records a crawler-level (`error` channel) failure into `crawl_errors`.
+ *
+ * Unlike `insertPageError` this is not tied to a scraped page: `url`
+ * may be an external link that never became a page row, or `null` for a
+ * process-level error. The cause is intentionally not stored — it is derived
+ * on read so that older archives (which only have `error.log`) and freshly
+ * captured rows classify identically.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param url - The URL the error is about, or `null` for a process-level error.
+ * @param message - The error message (one line is enough for classification).
+ * @param isExternal - Whether the URL is external to the crawl scope.
+ */
+export async function insertCrawlError(
+	knex: Knex,
+	url: string | null,
+	message: string,
+	isExternal = false,
+): Promise<void> {
+	await knex('crawl_errors').insert({
+		url,
+		isExternal: isExternal ? 1 : 0,
+		message,
+		createdAt: Date.now(),
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/errors/insert-page-error.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/errors/insert-page-error.ts
@@ -1,0 +1,36 @@
+import type { Knex } from 'knex';
+
+import { getIdByUrl } from '../_shared/get-id-by-url.js';
+
+/**
+ * Records a partial scrape failure against the page identified by `url`.
+ *
+ * The page row is resolved (or inserted as a stub) via
+ * {@link getIdByUrl} so the error can be recorded even before
+ * `setPage` has run — useful when the failure fires during scraping
+ * (e.g. mid-`scrapeStart`) and the orchestrator enqueues this write
+ * before the success write for the same URL.
+ *
+ * A single page can have multiple `page_errors` rows (e.g. both
+ * `desktop-compact` and `mobile-small` viewports failing).
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param url - URL of the page being scraped.
+ * @param phase - Scrape phase name (typically `'retryExhausted'`).
+ * @param message - Human-readable failure message.
+ * @param isExternal - Whether the URL is external. Defaults to `false`.
+ */
+export async function insertPageError(
+	knex: Knex,
+	url: string,
+	phase: string,
+	message: string,
+	isExternal = false,
+): Promise<void> {
+	const pageId = await getIdByUrl(knex, url, isExternal ? 1 : 0);
+	await knex('page_errors').insert({
+		pageId,
+		phase,
+		message,
+		createdAt: Date.now(),
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/errors/list-dns-burned-host-candidates.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/errors/list-dns-burned-host-candidates.ts
@@ -1,0 +1,149 @@
+import type { Knex } from 'knex';
+
+import { classifyErrorKind } from '../../../classify-error-kind.js';
+
+/**
+ * Hostnames whose `crawl_errors` history is consistently DNS failures and
+ * for which no recent 2xx-3xx page or resource is recorded — i.e. hosts
+ * the previous crawl already proved unreachable. Returned in lower-cased
+ * form. Used by `CrawlerOrchestrator.#preloadDnsBurnedHostCache` so the
+ * next session short-circuits HEAD pre-flight on these hosts.
+ *
+ * Implementation: a coarse `LIKE` filter over `crawl_errors.message`
+ * narrows the row set, then `classifyErrorKind` confirms `'dns'` in JS
+ * (the regex is the single truth source — DB-side filters never narrow
+ * it). Exclusion bags are built from a single `pages` and a single
+ * `resources` scan: any host with a 2xx-3xx page, a 2xx-3xx resource, or
+ * a `pages.lastCrawledAt` newer than its latest DNS error is dropped
+ * (the host probably recovered between the failure and the last crawl).
+ *
+ * Returns `[]` on legacy archives that pre-date the `crawl_errors`
+ * table — the `hasTable` guard keeps the call non-destructive.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns Lower-cased hostnames safe to short-circuit.
+ */
+export async function listDnsBurnedHostCandidates(knex: Knex): Promise<string[]> {
+	const hasCrawlErrors = await knex.schema.hasTable('crawl_errors');
+	if (!hasCrawlErrors) {
+		return [];
+	}
+
+	// Coarse SQL filter: cheap LIKE OR-chain over `message`. The dns regex
+	// truth source lives in `classifyErrorKind`, so we only need to feed it
+	// rows that COULD match a DNS token. Each LIKE is anchored on a known
+	// substring of the regex so future additions to the regex (without
+	// matching new SQL terms) widen the JS-side filter only — never narrow it.
+	//
+	// `%EAI_AGAIN%` is deliberately NOT in the SQL filter: it now classifies
+	// as `dns-transient` (local resolver hiccup), not `dns`, so it must not
+	// reach this candidate set. The `%getaddrinfo%` term still pulls
+	// `getaddrinfo EAI_AGAIN ...` rows but the JS-side `classifyErrorKind`
+	// check (first-match-wins) routes them to `dns-transient` and they
+	// silently drop out — keeping the cache focused on real NXDOMAIN.
+	const dnsLikeRows = (await knex('crawl_errors')
+		.select('url', 'message', 'createdAt')
+		.whereNotNull('url')
+		.where((qb) => {
+			qb.where('message', 'like', '%ENOTFOUND%')
+				.orWhere('message', 'like', '%getaddrinfo%')
+				.orWhere('message', 'like', '%ERR_NAME_NOT_RESOLVED%')
+				.orWhere('message', 'like', '%ERR_NAME_RESOLUTION_FAILED%');
+		})) as { url: string; message: string; createdAt: number }[];
+
+	if (dnsLikeRows.length === 0) {
+		return [];
+	}
+
+	// Map<hostname, latestErrorCreatedAt> for hosts whose error message
+	// confidently classifies as DNS (LIKE matched but classifyErrorKind says
+	// e.g. `unknown` → drop).
+	const candidateLatestErrorAt = new Map<string, number>();
+	for (const row of dnsLikeRows) {
+		if (classifyErrorKind(row.message) !== 'dns') {
+			continue;
+		}
+		let host: string;
+		try {
+			host = new URL(row.url).hostname.toLowerCase();
+		} catch {
+			continue;
+		}
+		if (!host) {
+			continue;
+		}
+		const createdAt = typeof row.createdAt === 'number' ? row.createdAt : 0;
+		const previous = candidateLatestErrorAt.get(host) ?? 0;
+		if (createdAt > previous) {
+			candidateLatestErrorAt.set(host, createdAt);
+		}
+	}
+
+	if (candidateLatestErrorAt.size === 0) {
+		return [];
+	}
+
+	// Exclusion-bag #1: pages with a 2xx-3xx status anywhere on the host.
+	// Tracking the latest `lastCrawledAt` per host lets us additionally
+	// drop hosts whose last successful contact post-dates the most recent
+	// DNS error (the host probably came back after a transient outage).
+	const pageOkRows = (await knex('pages')
+		.select('url', 'lastCrawledAt')
+		.whereBetween('status', [200, 399])) as {
+		url: string;
+		lastCrawledAt: number | null;
+	}[];
+	const pageOkHosts = new Set<string>();
+	const latestPageOkAt = new Map<string, number>();
+	for (const row of pageOkRows) {
+		let host: string;
+		try {
+			host = new URL(row.url).hostname.toLowerCase();
+		} catch {
+			continue;
+		}
+		pageOkHosts.add(host);
+		if (typeof row.lastCrawledAt === 'number') {
+			const previous = latestPageOkAt.get(host) ?? 0;
+			if (row.lastCrawledAt > previous) {
+				latestPageOkAt.set(host, row.lastCrawledAt);
+			}
+		}
+	}
+
+	// Exclusion-bag #2: non-HTML resources with a 2xx-3xx status. resources
+	// have no timestamp column so this is presence-only.
+	const resourceOkRows = (await knex('resources')
+		.select('url')
+		.whereBetween('status', [200, 399])) as { url: string }[];
+	const resourceOkHosts = new Set<string>();
+	for (const row of resourceOkRows) {
+		let host: string;
+		try {
+			host = new URL(row.url).hostname.toLowerCase();
+		} catch {
+			continue;
+		}
+		resourceOkHosts.add(host);
+	}
+
+	// A candidate host is burned only if neither pages nor resources hold a
+	// 2xx-3xx for it, AND its latest 2xx page (if any) is not newer than
+	// the latest DNS error. The third check guards against re-burning a
+	// host that recovered between the last DNS failure and the most recent
+	// crawl.
+	const burned: string[] = [];
+	for (const [host, latestErrorAt] of candidateLatestErrorAt) {
+		if (pageOkHosts.has(host)) {
+			continue;
+		}
+		if (resourceOkHosts.has(host)) {
+			continue;
+		}
+		const latestOkAt = latestPageOkAt.get(host);
+		if (typeof latestOkAt === 'number' && latestOkAt > latestErrorAt) {
+			continue;
+		}
+		burned.push(host);
+	}
+	return burned;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/html/get-html-of-page-by-id.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/html/get-html-of-page-by-id.ts
@@ -1,0 +1,35 @@
+import type { Knex } from 'knex';
+
+import { decodeStoredBlob } from '../../decode-html-blob.js';
+
+/**
+ * Reads the HTML snapshot stored as a zstd-compressed BLOB for the given page.
+ *
+ * Joins `page_html_ref` → `page_html_blobs` and decompresses inline. Returns
+ * `null` when the page has no stored body (a non-HTML resource, a redirect
+ * source, a degraded render). Read works identically on read-only / stub
+ * connections — the special-cased "do we have a loose dir vs zip?" branching
+ * the previous file-backed layout required is gone.
+ *
+ * Tables `page_html_ref` and `page_html_blobs` are created by `initSchema`.
+ * Older `.nitpicker` archives that predate this migration must be passed
+ * through `scripts/migrate-to-0.10.mjs` before they can be read.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param pageId - The database ID of the page.
+ * @returns The decompressed HTML string, or `null` if no snapshot is stored.
+ */
+export async function getHtmlOfPageById(
+	knex: Knex,
+	pageId: number,
+): Promise<string | null> {
+	const row = await knex
+		.from<{ body: Uint8Array; codec: string }>('page_html_ref')
+		.join('page_html_blobs', 'page_html_ref.hash', '=', 'page_html_blobs.hash')
+		.select('page_html_blobs.body as body', 'page_html_blobs.codec as codec')
+		.where('page_html_ref.page_id', pageId)
+		.first();
+	if (!row) {
+		return null;
+	}
+	return decodeStoredBlob(row.body, row.codec);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/inventory/record-inventory-run.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/inventory/record-inventory-run.ts
@@ -1,0 +1,44 @@
+import type { InventoryRunMeta } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Appends one row to the `inventory_runs` audit log.
+ *
+ * Called by `CrawlerOrchestrator.inventory` on every successful
+ * `--inventory <list>` invocation so the archive carries a durable
+ * record of which deploy list was applied when and at what scale —
+ * the operational question "did we apply last month's list" the
+ * archive itself can answer without consulting external bookkeeping.
+ *
+ * Append-only. There is intentionally no UPDATE path and no UNIQUE
+ * constraint on `source_file_sha256`; two applies of the same list
+ * each get their own row. Duplicate detection is left to readers —
+ * the hash is recorded as the content-identity key they would use.
+ * Field-level NULL semantics live on {@link InventoryRunMeta}.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param meta - The run metadata to record. Only `ran_at` is required.
+ * @returns The autoincremented `id` of the newly-inserted row.
+ */
+export async function recordInventoryRun(
+	knex: Knex,
+	meta: InventoryRunMeta,
+): Promise<number> {
+	const inserted = await knex
+		.from('inventory_runs')
+		.insert({
+			ran_at: meta.ran_at,
+			list_label: meta.list_label ?? null,
+			source_file_sha256: meta.source_file_sha256 ?? null,
+			total_lines: meta.total_lines ?? null,
+			new_pages: meta.new_pages ?? null,
+			new_resources: meta.new_resources ?? null,
+			scope_skipped: meta.scope_skipped ?? null,
+			notes: meta.notes ?? null,
+		})
+		.returning('id');
+	const id = inserted[0]?.id;
+	if (typeof id !== 'number') {
+		throw new TypeError('recordInventoryRun: INSERT returned no row id');
+	}
+	return id;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/lifecycle/checkpoint.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/lifecycle/checkpoint.ts
@@ -1,0 +1,11 @@
+import type { Knex } from 'knex';
+
+/**
+ * Forces a WAL checkpoint, writing all pending WAL data back to the main database file.
+ * Uses TRUNCATE mode to reset the WAL file to zero bytes after checkpointing.
+ * This ensures the database is fully self-contained in `db.sqlite` before archiving.
+ * @param knex - Knex query builder connected to the archive DB.
+ */
+export async function checkpoint(knex: Knex): Promise<void> {
+	await knex.raw('PRAGMA wal_checkpoint(TRUNCATE)');
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/lifecycle/destroy.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/lifecycle/destroy.ts
@@ -1,0 +1,9 @@
+import type { Knex } from 'knex';
+
+/**
+ * Destroys the database connection, releasing all pooled resources.
+ * @param knex - Knex query builder connected to the archive DB.
+ */
+export async function destroy(knex: Knex): Promise<void> {
+	await knex.destroy();
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/lifecycle/init.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/lifecycle/init.ts
@@ -1,0 +1,54 @@
+import type { Knex } from 'knex';
+
+import { applyConnectionPragmas, initSchema } from '../../init-schema.js';
+import { assertCompatibleVersion } from '../../meta/assert-compatible-version.js';
+import { migrateAnalysisViolations } from '../../migrate-analysis-violations.js';
+import { migrateCrawlErrors } from '../../migrate-crawl-errors.js';
+import { migrateEntityTables } from '../../migrate-entity-tables.js';
+import { migrateHtmlBlobTables } from '../../migrate-html-blob-tables.js';
+import { migrateInfoRoots } from '../../migrate-info-roots.js';
+import { migrateInventoryRuns } from '../../migrate-inventory-runs.js';
+import { migratePageErrors } from '../../migrate-page-errors.js';
+import { migratePagesResourcesSource } from '../../migrate-pages-resources-source.js';
+import { migrateRefTables } from '../../migrate-ref-tables.js';
+
+/**
+ * Initializes the database schema if tables do not exist, then runs lightweight
+ * migrations that bring older archives up to the current schema.
+ *
+ * Migrations are idempotent and run on every writer-side `Database.connect`;
+ * in read-only mode they are SKIPPED so the same DB can be opened safely
+ * by a viewer attached to a live (or interrupted) crawl without rewriting
+ * the user's tmpDir.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param readOnly - When true, skip schema init + migrations.
+ */
+export async function init(knex: Knex, readOnly: boolean): Promise<void> {
+	// Connection-level PRAGMAs (foreign_keys, mmap_size, …) must be
+	// reapplied on every connect — they are not persisted across opens.
+	// They are safe in read-only mode because they don't write to the
+	// user's tmpDir, just configure the libsql connection.
+	await applyConnectionPragmas(knex);
+	// Reject pre-0.10 archives before any further work. Runs for both
+	// writer and read-only (stub viewer) connections so old
+	// `._nitpicker-*` stubs surface a clear error instead of
+	// dereferencing missing columns at query time. New archives (no
+	// `info` table yet) pass through; the schema is filled in by
+	// `initSchema` below.
+	await assertCompatibleVersion(knex);
+	if (readOnly) {
+		return;
+	}
+	await initSchema(knex);
+	await migrateInfoRoots(knex);
+	await migratePageErrors(knex);
+	await migrateCrawlErrors(knex);
+	await migrateHtmlBlobTables(knex);
+	await migrateAnalysisViolations(knex);
+	await migratePagesResourcesSource(knex);
+	await migrateInventoryRuns(knex);
+	await migrateRefTables(knex);
+	// MUST run after migrateRefTables — 0.13 tables have
+	// FK references to the 0.13 ref tables.
+	await migrateEntityTables(knex);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/meta/get-jsonld-of-page.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/meta/get-jsonld-of-page.ts
@@ -1,0 +1,40 @@
+import type { JsonLdRow } from '../../meta/types.js';
+import type { Knex } from 'knex';
+
+import { safeParseJson } from '../_shared/safe-parse-json.js';
+
+/**
+ * Retrieves all `page_jsonld` rows for the given page id, parsed back into
+ * {@link JsonLdRow} shape (with `parsed` deserialised from its JSON column).
+ *
+ * Read-side counterpart to `insertJsonLd`. Returns rows in insertion order
+ * by `id` so the order observed by `get-page-jsonld` matches the order the
+ * scraper saw them.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param pageId
+ */
+export async function getJsonLdOfPage(knex: Knex, pageId: number): Promise<JsonLdRow[]> {
+	type Row = {
+		id: number;
+		pageId: number;
+		kind: string;
+		type: string | null;
+		raw: string;
+		parsed: string | null;
+		parseError: string | null;
+	};
+	const rows = await knex
+		.select<Row[]>('id', 'pageId', 'kind', 'type', 'raw', 'parsed', 'parseError')
+		.from('page_jsonld')
+		.where('pageId', pageId)
+		.orderBy('id', 'asc');
+	return rows.map((r) => ({
+		id: r.id,
+		pageId: r.pageId,
+		kind: r.kind === 'speculationrules' ? 'speculationrules' : 'ld+json',
+		type: r.type,
+		raw: r.raw,
+		parsed: r.parsed === null ? null : safeParseJson(r.parsed),
+		parseError: r.parseError,
+	}));
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/meta/get-tags-of-page.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/meta/get-tags-of-page.ts
@@ -1,0 +1,47 @@
+import type { TagRow } from '../../meta/types.js';
+import type { Knex } from 'knex';
+
+import { safeParseJson } from '../_shared/safe-parse-json.js';
+
+/**
+ * Retrieves all `page_tags` rows for the given page id, parsed back into
+ * {@link TagRow} shape (with `categories` and `sources` JSON columns
+ * deserialised).
+ *
+ * Read-side counterpart to `insertTags`.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param pageId
+ */
+export async function getTagsOfPage(knex: Knex, pageId: number): Promise<TagRow[]> {
+	type Row = {
+		id: number;
+		pageId: number;
+		provider: string;
+		category: string | null;
+		externalId: string | null;
+		version: string | null;
+		confidence: number | null;
+		categories: string | null;
+		sources: string | null;
+	};
+	const rows = await knex
+		.select<
+			Row[]
+		>('id', 'pageId', 'provider', 'category', 'externalId', 'version', 'confidence', 'categories', 'sources')
+		.from('page_tags')
+		.where('pageId', pageId)
+		.orderBy('id', 'asc');
+	return rows.map((r) => ({
+		id: r.id,
+		pageId: r.pageId,
+		provider: r.provider,
+		category: r.category,
+		externalId: r.externalId,
+		version: r.version,
+		confidence: r.confidence,
+		categories:
+			r.categories === null ? [] : ((safeParseJson(r.categories) as string[]) ?? []),
+		sources:
+			r.sources === null ? [] : ((safeParseJson(r.sources) as TagRow['sources']) ?? []),
+	}));
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/order/add-order-field.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/order/add-order-field.ts
@@ -1,0 +1,18 @@
+import type { Knex } from 'knex';
+
+/**
+ * Adds the `order` column to the `pages` table for URL sort ordering.
+ * If the column already exists, this function does nothing.
+ * @deprecated Since v0.1.x. The column is now created during table initialization.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns The result of the schema alteration, or void if the column already exists.
+ */
+export async function addOrderField(knex: Knex) {
+	const hasColumn = await knex.schema.hasColumn('pages', 'order');
+	if (hasColumn) {
+		return;
+	}
+	return await knex.schema.table('pages', (t) => {
+		t.integer('order').unsigned().nullable().defaultTo(null);
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/order/set-url-order.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/order/set-url-order.ts
@@ -1,0 +1,39 @@
+import type { DB_Page } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { pathComparator } from '@d-zero/shared/sort/path';
+
+import { dbLog } from '../../../debug.js';
+
+/**
+ * Assigns natural URL sort order values to all internal pages.
+ * Pages are sorted using {@link pathComparator} and assigned sequential order numbers.
+ * @param knex - Knex query builder connected to the archive DB.
+ */
+export async function setUrlOrder(knex: Knex): Promise<void> {
+	dbLog('Set URL Order');
+	const res = await knex
+		.select('id', 'url')
+		.from<DB_Page>('pages')
+		.where('isExternal', '=', 0);
+	const sorted = res.toSorted((a, b) => pathComparator(a.url, b.url));
+
+	// Batch update using chunked CASE statements to avoid N+1 queries
+	const BATCH_SIZE = 500;
+	for (let i = 0; i < sorted.length; i += BATCH_SIZE) {
+		const batch = sorted.slice(i, i + BATCH_SIZE);
+		const ids = batch.map((row) => row.id);
+		const bindings: (string | number)[] = [];
+		const cases = batch
+			.map((row, j) => {
+				bindings.push(row.id, i + j + 1);
+				return 'WHEN ? THEN ?';
+			})
+			.join(' ');
+		const placeholders = ids.map(() => '?').join(',');
+		await knex.raw(
+			`UPDATE pages SET \`order\` = CASE id ${cases} END WHERE id IN (${placeholders})`,
+			[...bindings, ...ids],
+		);
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-crawling-state.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-crawling-state.ts
@@ -1,0 +1,97 @@
+import type { DB_Page } from '../../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves the current crawling state by listing scraped and pending URLs.
+ *
+ * `scraped` is straightforward: every page row whose `scraped` flag is `1`
+ * — that is, every URL the crawl reached a terminal state on, including
+ * setSkippedPage / setExternalPage / outright setPage success or failure.
+ *
+ * `pending` is intentionally STRICT — not "every `scraped = 0` row".
+ * Three filters apply:
+ *
+ * 1. `scraped = 0` — work still incomplete.
+ * 2. `isExternal = 0` — only in-scope work. External URLs go through a
+ *    HEAD-only path that always lands on `scraped = 1` (either setPage or
+ *    setExternalPage). A row with `isExternal = 1 AND scraped = 0` is
+ *    therefore a data anomaly, and resume / inventory / append have no
+ *    business retrying it on the next session.
+ * 3. `EXISTS (anchor with hrefId = pages.id) OR source != 'crawled'` —
+ *    the row was either discovered as an anchor destination during a
+ *    previous scrape OR was explicitly tagged with a non-default
+ *    source label (`'inventory-seed'`, `'inventory-discovered'`, …).
+ *    Both halves of the OR represent "deliberately enqueued, expected
+ *    to be processed", which is exactly what `resume` should pick up.
+ *
+ *    The orphan filter targets the **predicted-discard leak** in
+ *    `crawler.ts` where `shouldDiscardPredicted` returns true but no
+ *    `emit('skip')` follows. Such placeholders are inserted with the
+ *    DB DEFAULT `source = 'crawled'` (no caller explicitly labels
+ *    them) AND have no anchor referrer (predicted URLs are
+ *    synthesised from pagination patterns, never anchored from a
+ *    rendered page) — both halves of the OR are therefore false and
+ *    the leak is excluded.
+ *
+ *    The `source != 'crawled'` clause specifically saves the
+ *    `--inventory` × `--retry-failed` interaction: an inventory-seed
+ *    URL came from the operator's URL list (no anchor referrer) and
+ *    `resetFailedPages` puts it back at `scraped = 0`. Without this
+ *    clause those legitimate retries would be dropped on resume.
+ *
+ * The defensive shape is on purpose: the data source can drift into
+ * anomalous states under interruption, but the reader must never throw
+ * or feed garbage back into the dealer. A real in-scope URL that was
+ * truly interrupted mid-crawl will always have at least one anchor
+ * referrer (otherwise the dealer would not have queued it), so the
+ * strict filter loses no legitimate pending work.
+ *
+ * Seeds passed directly to `Crawler.start()` are NOT in the strict
+ * pending set when they were never picked by the dealer — they have no
+ * DB row at all in that case (`linkList.add` is purely in-memory until
+ * `setPage` runs). A Ctrl-C between dealer pick and `setPage` likewise
+ * leaves no row to recover. Recovery of un-picked seeds is the
+ * responsibility of the caller (e.g. re-running `--inventory ./list.txt`
+ * with the same URL list).
+ *
+ * The query uses an explicit `p` alias on the `pages` table so the
+ * correlated `EXISTS` subquery can join via `whereRaw('anchors.hrefId =
+ * p.id')`. A future refactor that renames the alias must update both
+ * sites — the raw string in the subquery cannot be grep-resolved
+ * automatically. Read-only / stub viewer connections never call this
+ * method (they do not need to know about pending state), so the EXISTS
+ * shape is safe to use without the `migrate*` guards that other writer
+ * methods carry.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns An object with `scraped` (completed URLs) and `pending` (the
+ *   strict set of in-scope, anchor-referenced, unfinished URLs).
+ */
+export async function getCrawlingState(
+	knex: Knex,
+): Promise<{ scraped: string[]; pending: string[] }> {
+	const ex = (r: { url: string }) => r.url;
+	const $scraped = await knex.select('url').from<DB_Page>('pages').where('scraped', 1);
+	const scraped = $scraped.map(ex);
+	const $pending = await knex
+		.select('p.url')
+		.from<DB_Page>({ p: 'pages' })
+		.where('p.scraped', 0)
+		.where('p.isExternal', 0)
+		.where((qb) => {
+			// "Anchored OR explicitly labelled". Either side is evidence
+			// that the row was deliberately enqueued for processing —
+			// only the predicted-discard leak (DEFAULT 'crawled' + no
+			// anchor) fails both halves. The `whereExists` callback
+			// uses `select('*')` since the column list is irrelevant
+			// inside an EXISTS check; calling through `client.raw(...)`
+			// would reach a private builder field.
+			qb.whereExists(function () {
+				this.select('*').from('anchors').whereRaw('anchors.hrefId = p.id');
+			}).orWhereNot('p.source', 'crawled');
+		});
+	const pending = $pending.map(ex);
+	return {
+		scraped,
+		pending,
+	};
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-existing-page-urls.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-existing-page-urls.ts
@@ -1,0 +1,34 @@
+import type { DB_Page } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { eachSplitted } from '../../../../utils/array/each-splitted.js';
+
+/**
+ * Return the subset of `urls` that already exist in the `pages` table.
+ * Chunked into batches so SQLite's `IN (?, ?, …)` parameter limit
+ * (`SQLITE_MAX_VARIABLE_NUMBER`, default 999) cannot be hit even when the
+ * inventory list contains tens of thousands of URLs.
+ *
+ * Read-only — no transaction, no lock contention with the crawler write
+ * pipeline (callers run this BEFORE the `<archive>.bak` is taken and the
+ * crawl is started).
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param urls - URL strings to probe (already in `withoutHashAndAuth` form).
+ * @returns URLs found in `pages`. Order is not preserved.
+ */
+export async function getExistingPageUrls(
+	knex: Knex,
+	urls: readonly string[],
+): Promise<string[]> {
+	if (urls.length === 0) {
+		return [];
+	}
+	const found: string[] = [];
+	await eachSplitted([...urls], 500, async (chunk) => {
+		const rows = await knex.select('url').from<DB_Page>('pages').whereIn('url', chunk);
+		for (const row of rows) {
+			found.push(row.url);
+		}
+	});
+	return found;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-page-count.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-page-count.ts
@@ -1,0 +1,21 @@
+import type { DB_Page } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { dbLog } from '../../../debug.js';
+
+/**
+ * Counts the total number of pages in the database.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns The total page count.
+ * @throws {Error} If the count query fails.
+ */
+export async function getPageCount(knex: Knex): Promise<number> {
+	const selected = await knex.count('id').from<DB_Page>('pages');
+	if (!selected[0]) {
+		throw new Error('No count');
+	}
+	// @ts-expect-error
+	const count: number = selected[0]['count(`id`)'];
+	dbLog('Number of pages: %d', count);
+	return count;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-page-source-by-url.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-page-source-by-url.ts
@@ -1,0 +1,31 @@
+import type { DB_Page, PageSource } from '../../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Look up the `source` column of a single page by its URL key. Used by
+ * the orchestrator's `PageSourceLookup` injection so the Crawler can
+ * resolve a parent page's lineage on `--resume` / `--retry-failed`
+ * sessions, where the in-memory `inventoryMode` is no longer
+ * available but the DB still remembers what label was last persisted.
+ *
+ * Returns `undefined` when the URL has no `pages` row (e.g. a brand-new
+ * URL that has not been seen yet) so the caller can fall through to
+ * its default behaviour without distinguishing "row absent" from "row
+ * present with NULL source" — the schema's `NOT NULL DEFAULT 'crawled'`
+ * makes a NULL value impossible in practice.
+ *
+ * Read-only — no transaction, single PK-equivalent lookup on
+ * `pages.url` (a UNIQUE column), so the cost is constant per call. The
+ * Crawler calls this at most once per page render, NOT per
+ * sub-resource, so the N+1 risk does not apply.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param url - URL key in `url.withoutHashAndAuth` form.
+ * @returns The recorded `source`, or `undefined` when no row exists.
+ */
+export async function getPageSourceByUrl(
+	knex: Knex,
+	url: string,
+): Promise<PageSource | undefined> {
+	const [row] = await knex.select('source').from<DB_Page>('pages').where('url', url);
+	return row?.source;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-pages-with-rels.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-pages-with-rels.ts
@@ -1,0 +1,128 @@
+import type { DB_Anchor, DB_Page, DB_Redirect, DB_Referrer } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { dbLog } from '../../../debug.js';
+import { limitedPageIds } from '../../../limited-page-ids.js';
+import { redirectTable } from '../../../redirect-table.js';
+import { addOrderField } from '../order/add-order-field.js';
+import { setUrlOrder } from '../order/set-url-order.js';
+
+/**
+ * Retrieves pages along with their related redirect, anchor, and referrer
+ * data. Results are ordered by the natural URL sort order (materialised
+ * through {@link addOrderField} + {@link setUrlOrder} before the join
+ * queries run). Only non-redirected pages are returned in the top-level
+ * `pages` array; redirect sources are surfaced only through the
+ * `redirects` array so downstream reports (Sheets export) can attribute
+ * every source without double-counting the destination.
+ *
+ * **Cross-domain call.** This is the only op that reaches from
+ * `pages/read/` into `pages/order/` — `addOrderField` and `setUrlOrder`
+ * are pre-flight side effects required to make `orderByRaw('order ASC
+ * NULLS LAST')` produce the natural sort. Keep the two calls in
+ * lock-step; skipping either yields un-sorted or partially-sorted
+ * output.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param offset - The number of rows to skip.
+ * @param limit - The maximum number of pages to return.
+ * @returns An object containing `pages`, `redirects`, `anchors`, and
+ *   `referrers` arrays.
+ */
+export async function getPagesWithRels(
+	knex: Knex,
+	offset: number,
+	limit: number,
+): Promise<{
+	pages: DB_Page[];
+	redirects: DB_Redirect[];
+	anchors: DB_Anchor[];
+	referrers: DB_Referrer[];
+}> {
+	await addOrderField(knex);
+	await setUrlOrder(knex);
+	dbLog('Get Pages');
+	const pages = await knex
+		.select('*')
+		.from<DB_Page>('pages')
+		.orderByRaw('`order` ASC NULLS LAST')
+		.whereNull('redirectDestId')
+		.limit(limit)
+		.offset(offset);
+
+	// When empty
+	if (pages.length === 0) {
+		return {
+			pages: [],
+			redirects: [],
+			referrers: [],
+			anchors: [],
+		};
+	}
+
+	dbLog('Get Pages: Redirects');
+	const redirects: DB_Redirect[] = await knex
+		.with('limitedPages', limitedPageIds(limit, offset))
+		.with('redirect', redirectTable(false))
+		.select('id as pageId', 'from', 'fromId')
+		.from('redirect')
+		// Filter
+		.join('limitedPages', 'redirect.toId', '=', 'limitedPages.id')
+		// Sort
+		.orderBy('id', 'asc');
+
+	dbLog('Get Pages: Anchors');
+	const anchors: DB_Anchor[] = await knex
+		.with('limitedPages', limitedPageIds(limit, offset))
+		.with('redirect', redirectTable())
+		.select(
+			'limitedPages.id as pageId',
+			'href.url',
+			'redirect.from as href',
+			'href.isExternal',
+			'href.title',
+			'href.status',
+			'href.statusText',
+			'href.contentType',
+			'anchors.hash',
+			'anchors.textContent',
+		)
+		.from('anchors')
+		// Filters
+		.join('limitedPages', 'anchors.pageId', '=', 'limitedPages.id')
+		// Resolves redirect
+		.join('redirect', 'anchors.hrefId', '=', 'redirect.fromId')
+		// Target
+		.join('pages as href', 'redirect.toId', '=', 'href.id')
+		// Sort
+		.orderBy('anchors.id', 'asc');
+
+	dbLog('Get Pages: Referrers');
+	const referrers: DB_Referrer[] = await knex
+		.with('limitedPages', limitedPageIds(limit, offset))
+		.with('redirect', redirectTable())
+		.select(
+			'redirect.toId as pageId',
+			'referrer.url',
+			'redirect.from as through',
+			'redirect.fromId as throughId',
+			'anchors.hash',
+			'anchors.textContent',
+		)
+		.from('anchors')
+		// Resolves redirect
+		.join('redirect', 'anchors.hrefId', '=', 'redirect.fromId')
+		// Referrer
+		.join('pages as referrer', 'anchors.pageId', '=', 'referrer.id')
+		// Filters
+		.join('limitedPages', 'redirect.toId', '=', 'limitedPages.id')
+		// Sort
+		.orderBy('anchors.id', 'asc');
+
+	dbLog('Get Pages: Done');
+	return {
+		pages,
+		redirects,
+		anchors,
+		referrers,
+	};
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-pages.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-pages.ts
@@ -1,0 +1,92 @@
+import type { DB_Page, PageFilter } from '../../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves pages from the database with optional filtering, pagination via offset and limit.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param filter - An optional {@link PageFilter} to narrow results by content type and origin.
+ * @param offset - The number of rows to skip. Defaults to `0`.
+ * @param limit - The maximum number of rows to return. Defaults to `100000`.
+ * @returns An array of raw {@link DB_Page} rows.
+ */
+export async function getPages(
+	knex: Knex,
+	filter?: PageFilter,
+	offset = 0,
+	limit = 100_000,
+): Promise<DB_Page[]> {
+	const q = knex.select('*').from<DB_Page>('pages');
+	switch (filter) {
+		case 'page': {
+			return q
+				.where({
+					contentType: 'text/html',
+					isTarget: 1,
+				})
+				.limit(limit)
+				.offset(offset);
+		}
+		case 'page-included-no-target': {
+			return q
+				.where({
+					contentType: 'text/html',
+				})
+				.limit(limit)
+				.offset(offset);
+		}
+		case 'external-page': {
+			return q
+				.where({
+					contentType: 'text/html',
+					isExternal: 1,
+				})
+				.limit(limit)
+				.offset(offset);
+		}
+		case 'internal-page': {
+			return q
+				.where({
+					contentType: 'text/html',
+					isExternal: 0,
+				})
+				.limit(limit)
+				.offset(offset);
+		}
+		case 'no-page': {
+			return q
+				.whereNull('contentType')
+				.orWhereNot({
+					contentType: 'text/html',
+				})
+				.limit(limit)
+				.offset(offset);
+		}
+		case 'external-no-page': {
+			return q
+				.where((qb) => {
+					qb.whereNull('contentType').orWhereNot({
+						contentType: 'text/html',
+					});
+				})
+				.andWhere({
+					isExternal: 1,
+				})
+				.limit(limit)
+				.offset(offset);
+		}
+		case 'internal-no-page': {
+			return q
+				.where((qb) => {
+					qb.whereNull('contentType').orWhereNot({
+						contentType: 'text/html',
+					});
+				})
+				.andWhere({
+					isExternal: 0,
+				})
+				.limit(limit)
+				.offset(offset);
+		}
+	}
+	return q.limit(limit).offset(offset);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-scraped-html-page-count.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/read/get-scraped-html-page-count.ts
@@ -1,0 +1,28 @@
+import type { DB_Page } from '../../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Counts pages that were scraped as crawl targets (full HTML render).
+ *
+ * Used by the crawler to seed its `pagesScraped` counter on resume so the
+ * progress display reflects all browser-rendered HTML pages across sessions,
+ * not just the current one.
+ *
+ * "HTML page" is guaranteed by `contentType = 'text/html'`, NOT by `isTarget`
+ * alone: `isTarget` means "in-scope crawl target" and is set for in-scope
+ * non-HTML resources too (e.g. a PDF reached via the HEAD pre-flight is
+ * `isTarget = 1`). Counting those would over-report the HTML page total, so
+ * page-ness is asserted at the read layer here rather than by trusting
+ * `isTarget`.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns The number of `text/html` rows with `isTarget = 1` and `scraped = 1`.
+ */
+export async function getScrapedHtmlPageCount(knex: Knex): Promise<number> {
+	const [row] = await knex
+		.from<DB_Page>('pages')
+		.where('isTarget', 1)
+		.andWhere('scraped', 1)
+		.andWhere('contentType', 'text/html')
+		.count<{ count: number }[]>('* as count');
+	return row ? Number(row.count) : 0;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/make-meta-reset-payload.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/make-meta-reset-payload.ts
@@ -1,0 +1,13 @@
+import { META_NULLABLE_COLUMNS } from './meta-nullable-columns.js';
+
+/**
+ * Builds the reset payload for {@link ./meta-nullable-columns.ts} as a plain object
+ * suitable for `knex.update(...)`. All listed columns are mapped to `null`.
+ */
+export function makeMetaResetPayload(): Record<string, null> {
+	const payload: Record<string, null> = {};
+	for (const col of META_NULLABLE_COLUMNS) {
+		payload[col] = null;
+	}
+	return payload;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/meta-nullable-columns.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/meta-nullable-columns.ts
@@ -1,0 +1,74 @@
+/**
+ * Columns of the `pages` table that should be reset to `null` whenever a
+ * previously-scraped row is demoted back to "pending" (i.e. by
+ * `resetFailedPages` and `repromoteExternalPages`).
+ *
+ * Includes all flat meta columns, the denormalised aggregates, and the
+ * `meta_extras` JSON catch-all. **Excludes** `firstCrawledAt` / `lastCrawledAt`
+ * by design — failure reset must not erase the last-success timestamp, which
+ * is the within-archive observation axis for #11 / #17 / #19 use cases.
+ *
+ * Centralised in one constant so schema growth and reset logic stay in lock-
+ * step: adding a flat meta column without updating this list would leave
+ * stale data after a reset.
+ */
+export const META_NULLABLE_COLUMNS: readonly string[] = [
+	// Document basics
+	'lang',
+	'dir',
+	'charset',
+	'baseHref',
+	'viewport_raw',
+	'themeColor',
+	'applicationName',
+	'author',
+	'generator',
+	'publisher',
+	// Title / description / keywords
+	'title',
+	'description',
+	'keywords',
+	// Robots
+	'robots_raw',
+	'robots_noindex',
+	'robots_nofollow',
+	'robots_noarchive',
+	'robots_noimageindex',
+	'googlebot',
+	// Link (1:1)
+	'canonical',
+	'amphtml',
+	'manifest',
+	'icon_href',
+	'appleTouchIcon_href',
+	// Open Graph
+	'og_type',
+	'og_title',
+	'og_url',
+	'og_site_name',
+	'og_description',
+	'og_image',
+	'og_image_alt',
+	'og_image_width',
+	'og_image_height',
+	'og_locale',
+	'og_article_published_time',
+	'og_article_modified_time',
+	// Twitter
+	'twitter_card',
+	'twitter_site',
+	'twitter_creator',
+	'twitter_title',
+	'twitter_description',
+	'twitter_image',
+	// One-offs
+	'fb_app_id',
+	'verification_google',
+	'formatDetection_telephone',
+	// Denormalised aggregates
+	'tag_count',
+	'jsonld_count',
+	'tags_providers_csv',
+	// Catch-all
+	'meta_extras',
+];

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/repromote-external-pages.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/repromote-external-pages.ts
@@ -1,0 +1,106 @@
+import type { DB_Page } from '../../../types.js';
+import type { ExURL, ParseURLOptions } from '@d-zero/shared/parse-url';
+import type { Knex } from 'knex';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+
+import { findScopeEntry } from '../../../../crawler/find-scope-entry.js';
+import { dbLog } from '../../../debug.js';
+
+import { makeMetaResetPayload } from './make-meta-reset-payload.js';
+
+/**
+ * Promote previously-external pages whose URL falls under any of the new scope
+ * entries back to a "needs scraping" state so that the next crawl picks them up
+ * as full internal pages.
+ *
+ * For each matching page:
+ * - clears the scrape metadata (status, headers, snapshot path, etc.),
+ * - flips `isExternal` to `0` and `scraped` to `0`,
+ * - removes stale `anchors`, `images`, and `resources-referrers` rows so that
+ *   the re-scrape can re-insert fresh ones without duplicates.
+ *
+ * The page row itself is kept (id is preserved) so existing referrers via
+ * `anchors.hrefId` remain valid. SELECT and UPDATE/DELETE statements are
+ * chunked to stay below SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER`.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param scopes - The hostname-indexed scope map after the new roots are merged.
+ * @param options - URL parsing options forwarded to {@link findScopeEntry}.
+ * @returns The URLs of the pages that were promoted.
+ */
+export async function repromoteExternalPages(
+	knex: Knex,
+	scopes: ReadonlyMap<string, readonly ExURL[]>,
+	options?: ParseURLOptions,
+): Promise<string[]> {
+	if (scopes.size === 0) {
+		return [];
+	}
+	const candidates = await knex
+		.select('id', 'url')
+		.from<DB_Page>('pages')
+		.where('isExternal', 1);
+
+	const promotedIds: number[] = [];
+	const promotedUrls: string[] = [];
+	for (const row of candidates) {
+		const parsed = parseUrl(row.url, options);
+		if (!parsed) {
+			continue;
+		}
+		if (findScopeEntry(parsed, scopes, options) === null) {
+			continue;
+		}
+		promotedIds.push(row.id);
+		promotedUrls.push(row.url);
+	}
+	if (promotedIds.length === 0) {
+		return [];
+	}
+
+	const chunkSize = 500;
+	const metaReset = makeMetaResetPayload();
+	for (let i = 0; i < promotedIds.length; i += chunkSize) {
+		const chunk = promotedIds.slice(i, i + chunkSize);
+		await knex<DB_Page>('pages')
+			.whereIn('id', chunk)
+			.update({
+				scraped: 0,
+				isExternal: 0,
+				isSkipped: 0,
+				skipReason: null,
+				status: null,
+				statusText: null,
+				contentType: null,
+				contentLength: null,
+				responseHeaders: '{}',
+				redirectDestId: null,
+				// Null every flat meta column + denormalised aggregates +
+				// meta_extras. `firstCrawledAt` / `lastCrawledAt` are
+				// deliberately omitted from META_NULLABLE_COLUMNS — the
+				// last-success timestamp survives the demotion.
+				...metaReset,
+			});
+		// Clear the prior crawl's data for the repromoted pages. `updatePage`
+		// also replaces anchors/images/tags/jsonld when it re-scrapes them, but
+		// only when the new scrape is non-empty — so this pre-clear is still
+		// load-bearing for pages that get repromoted but then re-scrape to
+		// nothing (or are never reached again), and it is the only place
+		// `resources-referrers` is cleared. The HTML body ref is also cleared
+		// so a repromoted page whose re-scrape ends up degraded does not keep
+		// its old external-render snapshot. `page_tags` / `page_jsonld` are
+		// cleared explicitly even though both tables also carry ON DELETE
+		// CASCADE — we keep the existing pattern of explicit chunked DELETEs
+		// rather than relying on CASCADE indirectly (and would not cascade
+		// anyway: the parent `pages` row is updated, not deleted). Orphan
+		// blobs in `page_html_blobs` are left behind; #23 will add GC.
+		await knex('anchors').whereIn('pageId', chunk).delete();
+		await knex('images').whereIn('pageId', chunk).delete();
+		await knex('resources-referrers').whereIn('pageId', chunk).delete();
+		await knex('page_html_ref').whereIn('page_id', chunk).delete();
+		await knex('page_tags').whereIn('pageId', chunk).delete();
+		await knex('page_jsonld').whereIn('pageId', chunk).delete();
+	}
+	dbLog('Repromoted %d external pages back to pending', promotedUrls.length);
+	return promotedUrls;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/reset-failed-pages.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/reset/reset-failed-pages.ts
@@ -1,0 +1,137 @@
+import type { DB_Page } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { classifyErrorKind } from '../../../../classify-error-kind.js';
+import { PERMANENT_ERROR_KINDS } from '../../../../permanent-error-kinds.js';
+import { dbLog } from '../../../debug.js';
+import { getFailedPageMessages } from '../../../get-failed-page-messages.js';
+
+import { makeMetaResetPayload } from './make-meta-reset-payload.js';
+
+/**
+ * Reset previously-attempted pages that ended in a recoverable failure so a
+ * follow-up crawl can re-fetch them from scratch.
+ *
+ * A page qualifies as a recoverable failure when it was already scraped
+ * (`scraped = 1`), is not a redirect source (`redirectDestId IS NULL`), was
+ * not intentionally skipped (`isSkipped` is not `1`), and one of the
+ * following holds:
+ *
+ * - `status = -1` — the sentinel a hard scrape failure (network error,
+ *   timeout, browser crash) is recorded with (see `handle-scrape-error.ts`);
+ * - `status IS NULL` — no status was ever stored for the row;
+ * - `contentType IS NULL` — the content type could not be determined;
+ * - `status` is in the `5xx` range — a (frequently transient) server error.
+ *
+ * Definitive `4xx` responses are intentionally excluded: re-fetching a 404
+ * almost always yields the same answer.
+ *
+ * A second exclusion runs in JS after the SQL candidate scan: any page whose
+ * latest recorded `page_errors` / `crawl_errors` message classifies into a
+ * permanent {@link PERMANENT_ERROR_KINDS} kind (dns / tls / client-blocked /
+ * parse-error / connection-refused) is left as-is rather than reset to
+ * pending. Without this filter, `--retry-failed` never converges: NXDOMAIN
+ * hosts, expired-cert hosts, and `ERR_BLOCKED_BY_CLIENT` ad pixels would be
+ * reset every iteration, re-attempted, fail identically, and rejoin the
+ * candidate pool for the next iteration. The exclusion keeps the retry
+ * target shrinking across `--retry-failed` passes by leaving deterministic
+ * dead-ends alone.
+ *
+ * Matching rows — internal and external alike — are demoted back to pending
+ * (`scraped = 0`) and have their stale scrape metadata cleared. The page row
+ * itself is kept (id preserved) so existing `anchors.hrefId` referrers stay
+ * valid, and `isExternal` is left untouched so the next pass re-classifies
+ * each page from the crawl scope. Related `anchors`, `images`,
+ * `resources-referrers`, and `page_errors` rows are deleted so the re-scrape
+ * can re-insert fresh data without duplicates.
+ *
+ * SELECT and UPDATE/DELETE statements are chunked to stay below SQLite's
+ * `SQLITE_LIMIT_VARIABLE_NUMBER`.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns The URLs of the pages that were reset to pending.
+ */
+export async function resetFailedPages(knex: Knex): Promise<string[]> {
+	const candidates = await knex
+		.select('id', 'url')
+		.from<DB_Page>('pages')
+		.where('scraped', 1)
+		.whereNull('redirectDestId')
+		.where((qb) => {
+			qb.where('isSkipped', 0).orWhereNull('isSkipped');
+		})
+		.where((qb) => {
+			qb.whereNull('status')
+				.orWhere('status', -1)
+				.orWhereNull('contentType')
+				.orWhereBetween('status', [500, 599]);
+		});
+
+	if (candidates.length === 0) {
+		return [];
+	}
+
+	const candidateIds = candidates.map((row) => row.id);
+	const candidateUrls = candidates.map((row) => row.url);
+	const messages = await getFailedPageMessages(knex, candidateIds, candidateUrls);
+	// Drop candidates whose latest recorded message classifies as permanent.
+	// An empty/absent message stays in the retry pool — we keep retrying when
+	// we don't know it's permanent, erring on the side of investigation.
+	const retryable = candidates.filter((row) => {
+		const message = messages.get(row.id) ?? '';
+		if (message === '') {
+			return true;
+		}
+		return !PERMANENT_ERROR_KINDS.has(classifyErrorKind(message));
+	});
+	const excludedCount = candidates.length - retryable.length;
+	if (excludedCount > 0) {
+		dbLog(
+			'Excluded %d page(s) from retry — permanent failure kinds (dns/tls/client-blocked/parse-error/connection-refused)',
+			excludedCount,
+		);
+	}
+	if (retryable.length === 0) {
+		return [];
+	}
+
+	const ids = retryable.map((row) => row.id);
+	const urls = retryable.map((row) => row.url);
+
+	const chunkSize = 500;
+	const metaReset = makeMetaResetPayload();
+	for (let i = 0; i < ids.length; i += chunkSize) {
+		const chunk = ids.slice(i, i + chunkSize);
+		await knex<DB_Page>('pages')
+			.whereIn('id', chunk)
+			.update({
+				scraped: 0,
+				status: null,
+				statusText: null,
+				contentType: null,
+				contentLength: null,
+				responseHeaders: '{}',
+				// Null every flat meta column + denormalised aggregates +
+				// meta_extras. `firstCrawledAt` / `lastCrawledAt` are
+				// deliberately omitted from META_NULLABLE_COLUMNS so the
+				// last-success timestamp records survive the demotion (the
+				// within-archive observation axis for #11/#17/#19).
+				...metaReset,
+			});
+		// Clear the prior crawl's per-page data so the re-scrape starts clean.
+		// `updatePage` only replaces anchors/images/tags/jsonld when the new
+		// scrape is non-empty, so this pre-clear is load-bearing for pages that
+		// reset but then fail again (or are never reached), and it is the only
+		// place `resources-referrers` and `page_errors` are cleared. The HTML
+		// body ref is also cleared so a previously-rendered page that now fails
+		// to re-scrape does not keep its old snapshot.
+		await knex('anchors').whereIn('pageId', chunk).delete();
+		await knex('images').whereIn('pageId', chunk).delete();
+		await knex('resources-referrers').whereIn('pageId', chunk).delete();
+		await knex('page_errors').whereIn('pageId', chunk).delete();
+		await knex('page_html_ref').whereIn('page_id', chunk).delete();
+		await knex('page_tags').whereIn('pageId', chunk).delete();
+		await knex('page_jsonld').whereIn('pageId', chunk).delete();
+	}
+	dbLog('Reset %d failed pages back to pending', urls.length);
+	return urls;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-inventory-seeds.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-inventory-seeds.ts
@@ -1,0 +1,59 @@
+import type { DB_Page, PageSource } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { eachSplitted } from '../../../../utils/array/each-splitted.js';
+
+/**
+ * Pre-insert inventory HTML seeds into `pages` as `scraped = 0`,
+ * `source = 'inventory-seed'` placeholders so the URL's existence in the
+ * archive is **durable before the scrape phase starts**.
+ *
+ * Why this is the linchpin of `--inventory` Ctrl+C tolerance: without
+ * pre-insertion, HTML seeds live only in the Crawler's in-memory
+ * `LinkList` until the dealer eventually calls `setPage`. A Ctrl+C /
+ * crash before that point loses the seed without trace, and `--resume`
+ * cannot recover it
+ * because `getCrawlingState`'s strict pending set requires a `pages` row.
+ * Pre-inserting fills exactly that gap: the strict pending set picks
+ * these rows up via its `OR p.source != 'crawled'` clause, so
+ * `--resume` after an interrupted inventory pass picks every seed back
+ * up. See `getCrawlingState` for the strict-set rationale.
+ *
+ * Idempotent: `onConflict('url').ignore()` keeps existing rows intact.
+ * The `getIdByUrl` crawled-wins downgrade still fires later when a
+ * crawled-lineage anchor reaches one of these seeds — that's the right
+ * behaviour (a seed that turned out to be reachable is not an orphan
+ * and should not retain the inventory label).
+ *
+ * Chunked into 500-URL batches so SQLite's bound-parameter limit
+ * (`SQLITE_MAX_VARIABLE_NUMBER`, default 999) cannot be hit even on a
+ * tens-of-thousands inventory list.
+ *
+ * Called by `CrawlerOrchestrator.inventory` during the
+ * `.bak`-protected ingestion phase, so any failure here aborts the run
+ * and restores from backup — the operator reruns from scratch.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param urls - URL strings already in `withoutHashAndAuth` form.
+ */
+export async function insertInventorySeeds(
+	knex: Knex,
+	urls: readonly string[],
+): Promise<void> {
+	if (urls.length === 0) {
+		return;
+	}
+	await eachSplitted([...urls], 500, async (chunk) => {
+		await knex<DB_Page>('pages')
+			.insert(
+				chunk.map((url) => ({
+					url,
+					scraped: 0 as const,
+					isExternal: 0 as const,
+					isTarget: 0 as const,
+					source: 'inventory-seed' as PageSource,
+				})),
+			)
+			.onConflict('url')
+			.ignore();
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-jsonld.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-jsonld.ts
@@ -1,0 +1,63 @@
+import type { PageData } from '../../../../utils/types/types.js';
+import type { Knex } from 'knex';
+
+import { eachSplitted } from '../../../../utils/array/each-splitted.js';
+import { classifyJsonLdType } from '../../../meta/classify-jsonld-type.js';
+
+/**
+ * Replaces the page's JSON-LD / SpeculationRules rows with the freshly
+ * captured set. Called inside `updatePage`'s transaction.
+ *
+ * `writeHtml = false` branches (`setExternalPage`, metadata-only) skip
+ * this entirely — JSON-LD lives inside the HTML body, so external pages
+ * that are not rendered have no entries to write. An empty array on a
+ * normally-rendered page is treated as a degraded re-scrape: prior rows
+ * are kept (same `delete-only-when-replacing` invariant as `anchors` /
+ * `images`).
+ * @param pageId
+ * @param meta
+ * @param trx
+ */
+export async function insertJsonLd(
+	pageId: number,
+	meta: PageData['meta'],
+	trx: Knex.Transaction,
+): Promise<void> {
+	// `??` guards tolerate the legacy "minimal meta" shape from older test
+	// fixtures. Real beholder 3.0.0 always populates these required fields.
+	const jsonLd = meta.jsonLd ?? [];
+	const speculationRules = meta.speculationRules ?? [];
+	const rows: Array<{
+		pageId: number;
+		kind: 'ld+json' | 'speculationrules';
+		type: string | null;
+		raw: string;
+		parsed: string | null;
+		parseError: string | null;
+	}> = [];
+	for (const entry of jsonLd) {
+		rows.push({
+			pageId,
+			kind: 'ld+json',
+			type: classifyJsonLdType(entry),
+			raw: entry.raw,
+			parsed: entry.parsed === undefined ? null : JSON.stringify(entry.parsed),
+			parseError: entry.parseError ?? null,
+		});
+	}
+	for (const entry of speculationRules) {
+		rows.push({
+			pageId,
+			kind: 'speculationrules',
+			type: classifyJsonLdType(entry),
+			raw: entry.raw,
+			parsed: entry.parsed === undefined ? null : JSON.stringify(entry.parsed),
+			parseError: entry.parseError ?? null,
+		});
+	}
+	if (rows.length === 0) return;
+	await trx('page_jsonld').where('pageId', pageId).delete();
+	await eachSplitted(rows, 100, async (chunk) => {
+		await trx('page_jsonld').insert(chunk);
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-page.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-page.ts
@@ -1,0 +1,112 @@
+import type { PageData } from '../../../../utils/types/types.js';
+import type { PageSource } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { normalizeContentType } from '../../../../crawler/normalize-content-type.js';
+import { computePageDenormalized } from '../../../meta/compute-page-denormalized.js';
+import { deriveFlatFromMeta } from '../../../meta/derive-flat-from-meta.js';
+import { deriveMetaExtras } from '../../../meta/derive-meta-extras.js';
+import { getIdByUrl } from '../../_shared/get-id-by-url.js';
+
+/**
+ * Upserts page data into the `pages` table (inserts if new, updates if existing).
+ *
+ * `source` is intentionally NOT in the UPDATE clause — provenance is set
+ * once at INSERT time inside `getIdByUrl`, and existing rows keep
+ * whatever label they were first inserted with.
+ * @param knex - Knex query builder connected to the archive DB. Used as the
+ *   fallback when `trx` is not provided.
+ * @param page
+ * @param isTarget
+ * @param trx
+ * @param source - Inventory provenance for the INSERT path. Ignored on UPDATE.
+ */
+export async function insertPage(
+	knex: Knex,
+	page: PageData,
+	isTarget: boolean,
+	trx?: Knex.Transaction,
+	source?: PageSource,
+): Promise<number> {
+	const qb = trx ?? knex;
+	const pageId = await getIdByUrl(qb, page.url.withoutHashAndAuth, undefined, source);
+	const flat = deriveFlatFromMeta(page.meta, page.url.href);
+	const denorm = computePageDenormalized(page.meta);
+	const extras = deriveMetaExtras(page.meta);
+	const now = Date.now();
+	// Source priority on UPDATE: 'crawled' > 'inventory-seed' >
+	// 'inventory-discovered'. The inventory feature exists to surface
+	// orphans (= URLs NOT reachable from the original crawl roots).
+	// Anything reachable via the crawled chain is therefore NOT an
+	// orphan and must be labelled `'crawled'`, even if previously
+	// labelled `'inventory-*'`. Within the inventory variants, the
+	// explicit user-listed `'inventory-seed'` wins over the transitive
+	// `'inventory-discovered'`.
+	//
+	// Note: in current callers, `source` only arrives as
+	// `'inventory-seed'` / `'inventory-discovered'` / `undefined`
+	// (`derivePageSource` never emits `'crawled'`, and outside inventory
+	// mode `source` is `undefined` so this CASE never runs). The
+	// `? = 'crawled'` branch is therefore reachable only via a future
+	// call site that wants to explicitly assert a crawled lineage —
+	// today the actual crawled-wins downgrade fires in `getIdByUrl`'s
+	// SELECT path when an anchor lineage `'crawled'` lands on an
+	// existing `'inventory-*'` row. The branch is kept so the CASE
+	// completely describes the priority lattice in one place.
+	const sourceUpdate =
+		source === undefined
+			? {}
+			: {
+					source: qb.raw(
+						`CASE
+								WHEN source = 'crawled' OR ? = 'crawled' THEN 'crawled'
+								WHEN source = 'inventory-seed' OR ? = 'inventory-seed' THEN 'inventory-seed'
+								WHEN source = 'inventory-discovered' OR ? = 'inventory-discovered' THEN 'inventory-discovered'
+								ELSE source
+							END`,
+						[source, source, source],
+					),
+				};
+	await qb('pages')
+		.where('id', pageId)
+		.update({
+			scraped: true,
+			isTarget,
+			isExternal: page.isExternal,
+			status: page.status,
+			statusText: page.statusText,
+			// Canonicalize so the stored value matches the exact-string page-ness
+			// predicate (`WHERE contentType = 'text/html'`) used by the read layer
+			// and the case-insensitive `isHtmlContentType` used in code. Responses
+			// are recorded verbatim upstream, so `Text/HTML` / `text/html ` can
+			// otherwise be stored and silently misclassified.
+			contentType: normalizeContentType(page.contentType),
+			contentLength: page.contentLength,
+			responseHeaders: JSON.stringify(page.responseHeaders),
+			// Flat meta columns derived from beholder 3.0.0 nested Meta.
+			// URL-shaped columns (canonical / og_url / og_image / amphtml / manifest /
+			// icon_href / appleTouchIcon_href / twitter_image) are already absolutised
+			// by `deriveFlatFromMeta` against the page URL — `find-mismatches` compares
+			// `canonical != url` directly, so storing the raw `getAttribute('href')`
+			// would generate false positives for sites using relative canonicals.
+			...flat,
+			// Denormalised aggregates: written once at scrape time so list reads
+			// (Sheets, page-detail summary) can answer "how many JSON-LD entries?"
+			// and "which Wappalyzer providers?" by selecting a single pages column
+			// rather than running a GROUP BY join on every read.
+			tag_count: denorm.tag_count,
+			jsonld_count: denorm.jsonld_count,
+			tags_providers_csv: denorm.tags_providers_csv,
+			// JSON catch-all for nested Meta sub-objects not flattened above.
+			meta_extras: JSON.stringify(extras),
+			// Timestamps: `firstCrawledAt` is set only on first INSERT — `COALESCE`
+			// preserves the existing value so a re-scrape (`--append`, `--retry-failed`)
+			// does not erase the discovery time. `lastCrawledAt` is updated every
+			// successful scrape.
+			firstCrawledAt: qb.raw('COALESCE(firstCrawledAt, ?)', [now]),
+			lastCrawledAt: now,
+			isSkipped: page.isSkipped,
+			...sourceUpdate,
+		});
+	return pageId;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-tags.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/insert-tags.ts
@@ -1,0 +1,41 @@
+import type { PageData } from '../../../../utils/types/types.js';
+import type { Knex } from 'knex';
+
+import { eachSplitted } from '../../../../utils/array/each-splitted.js';
+import { extractTagsForArchive } from '../../../meta/extract-tags-for-archive.js';
+
+/**
+ * Replaces the page's Wappalyzer tag rows with the freshly captured set.
+ * Called inside `updatePage`'s transaction unconditionally — tag
+ * detection draws on `<script src>` / `<iframe src>` / window globals /
+ * response headers, not the HTML body, so external pages that skip
+ * rendering still contribute tags.
+ *
+ * Same empty-guard as `insertJsonLd`: an empty array does not wipe
+ * prior rows on a degraded re-scrape.
+ * @param pageId
+ * @param meta
+ * @param trx
+ */
+export async function insertTags(
+	pageId: number,
+	meta: PageData['meta'],
+	trx: Knex.Transaction,
+): Promise<void> {
+	const partial = extractTagsForArchive(meta.tags);
+	if (partial.length === 0) return;
+	const rows = partial.map((p) => ({
+		pageId,
+		provider: p.provider,
+		category: p.category,
+		externalId: p.externalId,
+		version: p.version,
+		confidence: p.confidence,
+		categories: JSON.stringify(p.categories),
+		sources: JSON.stringify(p.sources),
+	}));
+	await trx('page_tags').where('pageId', pageId).delete();
+	await eachSplitted(rows, 100, async (chunk) => {
+		await trx('page_tags').insert(chunk);
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/link-redirect-sources.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/link-redirect-sources.ts
@@ -1,0 +1,107 @@
+import type { DB_Page, PageSource } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { dbLog } from '../../../debug.js';
+import { getIdByUrl } from '../../_shared/get-id-by-url.js';
+
+/**
+ * Points each redirect-source URL at the destination page, marking it scraped
+ * and clearing any content it owned in a former life.
+ *
+ * Shared by `updatePage` (which also renders and stores the destination)
+ * and `recordRedirect` (which only records the edge for a destination
+ * rendered elsewhere). Self-redirects (source equal to the destination) are
+ * skipped so a page is never marked as redirecting to itself — that would
+ * exclude it from reports via the `whereNull('redirectDestId')` filter.
+ * @param trx - The active transaction. All SQL below is executed exclusively
+ *   through this transaction; there is no separate `knex` fallback because
+ *   the callers (`updatePage` / `recordRedirect`) always invoke this helper
+ *   from within a transaction.
+ * @param sources - Redirect-source URLs (normalised): the original URL plus
+ *   any intermediate hops. Empty when the page was not redirected.
+ * @param destId - Database id of the redirect destination page.
+ * @param destUrlNormalized - Normalised destination URL, used to detect and
+ *   skip self-redirects.
+ * @param isExternal - Whether the sources are external to the crawl scope.
+ * @param chainLineageSource - Lineage label propagated to each intermediate
+ *   hop's row (passed through to {@link getIdByUrl}). Derived by the caller
+ *   from the **originating** page's source (`page.url`), not from the
+ *   destination — intermediates are reached transitively from the
+ *   originating render, so they inherit its lineage. Pass `'inventory-discovered'`
+ *   for chains rooted at inventory-seed/discovered pages so new intermediates
+ *   stay in the inventory chain; pass `'crawled'` for crawled chains so the
+ *   crawled-wins downgrade inside `getIdByUrl` fires on existing
+ *   `'inventory-*'` intermediates a crawled chain reaches. Pass `undefined`
+ *   to fall back to the DB DEFAULT (`'crawled'`) on INSERT without
+ *   triggering the downgrade on existing rows.
+ */
+export async function linkRedirectSources(
+	trx: Knex.Transaction,
+	sources: readonly string[],
+	destId: number,
+	destUrlNormalized: string,
+	isExternal: boolean,
+	chainLineageSource?: PageSource,
+): Promise<void> {
+	for (const redirect of sources) {
+		if (redirect === destUrlNormalized) {
+			dbLog('Skip self-redirect: %s', redirect);
+			continue;
+		}
+		dbLog('Set redirected url: %s -> id:%d', redirect, destId);
+		// Pass `chainLineageSource` through so a brand-new
+		// intermediate hop INSERTed here inherits the originating
+		// page's lineage label (inventory-discovered when the
+		// originating chain is in the inventory chain, undefined
+		// otherwise). The crawled-wins downgrade inside
+		// `getIdByUrl` still fires when this argument is `'crawled'`,
+		// matching the anchor-lineage propagation contract — an
+		// existing inventory-* intermediate that is later traversed
+		// by a `'crawled'` chain gets downgraded.
+		const redirectId = await getIdByUrl(trx, redirect, undefined, chainLineageSource);
+		await trx<DB_Page>('pages')
+			.where('id', redirectId)
+			.update({
+				scraped: 1,
+				redirectDestId: destId,
+				isExternal: isExternal ? 1 : 0,
+			});
+		// Conditional `301 Moved Permanently` stamp — applied ONLY
+		// when the row carries no definitive status yet (NULL or
+		// the `-1` hard-failure sentinel). HEAD pre-flight does not
+		// retain each hop's individual status code (`redirectPaths`
+		// is a URL[] without statuses), so the only honest answer
+		// for an unknown-status hop is "some 3xx" — 301 is the
+		// canonical representative.
+		//
+		// We deliberately do NOT overwrite an existing definitive
+		// status (200 / 302 / 307 / etc.): a row that already
+		// captured a concrete status from a prior direct scrape
+		// would lose accuracy. The stamp only flips two cases:
+		// - NULL: a placeholder row created by `getIdByUrl`
+		//   because the URL was reached only as a redirect
+		//   target / source, never directly scraped. Without the
+		//   stamp the row is invisible on the Errors view's status
+		//   distribution.
+		// - -1: a row that recorded a hard scrape failure (e.g. a
+		//   puppeteer goto returned null on a HTTPS→HTTP downgrade
+		//   redirect) BEFORE the chain was understood. That `-1`
+		//   then conflated "real failure" with "actually a redirect
+		//   source we now know about", polluting the `-1` bucket
+		//   AND inflating the `--retry-failed` target (via the
+		//   `whereNull('redirectDestId')` filter — the redirectDestId
+		//   update above already excludes the row from retry; this
+		//   stamp restores the visible identity).
+		await trx<DB_Page>('pages')
+			.where('id', redirectId)
+			.where((qb) => qb.whereNull('status').orWhere('status', -1))
+			.update({ status: 301, statusText: 'Moved Permanently' });
+		// A page that used to be scraped as content can later turn into a
+		// redirect source. It owns no content anymore, so drop any anchors /
+		// images it captured in its former life — otherwise they linger and
+		// leak into referrer / incoming-link reads (which do not filter out
+		// redirect sources).
+		await trx('anchors').where('pageId', redirectId).delete();
+		await trx('images').where('pageId', redirectId).delete();
+	}
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/record-redirect.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/record-redirect.ts
@@ -1,0 +1,113 @@
+import type { PageData } from '../../../../utils/types/types.js';
+import type { DB_Page, PageSource } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+
+import { dbLog } from '../../../debug.js';
+import { deriveLineageFromParent } from '../../../derive-lineage-from-parent.js';
+import { resolveRedirectChain } from '../../../resolve-redirect-chain.js';
+import { getIdByUrl } from '../../_shared/get-id-by-url.js';
+
+import { linkRedirectSources } from './link-redirect-sources.js';
+
+/**
+ * Records a redirect edge (source → destination) **without** re-storing the
+ * destination's content.
+ *
+ * The crawler renders a many-to-one redirect destination exactly once. For
+ * every subsequent source URL that redirects to that already-rendered
+ * destination, it calls this instead of {@link updatePage} (#73). Routing a
+ * content-less HEAD result through `updatePage` would funnel it into
+ * `insertPage` and overwrite the destination's good title / meta with empty
+ * values, so the dedicated edge-only path is required.
+ *
+ * The destination row is resolved (created on demand if a concurrent in-flight
+ * render has not committed it yet) so the edge always points at a valid id;
+ * the single render fills in the destination's content under that same id.
+ * The destination's existing anchors / images are never touched here.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param page - HEAD-resolved page data carrying the redirect chain. Its
+ *   `anchorList` / `imageList` are ignored (a redirect source owns no content).
+ * @param source - Inventory provenance forwarded by the orchestrator
+ *   (`Archive.setRedirect` → here) for the redirect-edge fast path. Used
+ *   as the fallback when the originating URL's row does NOT yet exist in
+ *   the archive (`#73` convergence on first sight, js-redirect rescue
+ *   before any prior write). When the originating row already exists
+ *   (e.g. anchor-lineage INSERT from a prior pass), its stored `source`
+ *   takes precedence so transitive lineage is preserved across resume /
+ *   retry-failed sessions. `undefined` keeps the DB DEFAULT `'crawled'`
+ *   on a brand-new destination row.
+ */
+export async function recordRedirect(
+	knex: Knex,
+	page: PageData,
+	source?: PageSource,
+): Promise<void> {
+	const { destUrl, sources } = resolveRedirectChain(
+		page.url.withoutHashAndAuth,
+		page.redirectPaths,
+	);
+
+	// No redirect chain (the URL is itself the already-rendered destination,
+	// reached both directly and via a redirect) → there is no edge to write.
+	// Returning here avoids opening a transaction and, crucially, avoids
+	// `getIdByUrl` inserting a content-less placeholder row for a destination
+	// that may not have been written yet.
+	if (sources.length === 0) {
+		return;
+	}
+
+	const destUrlObject = parseUrl(destUrl);
+
+	if (!destUrlObject) {
+		// A malformed redirect target should not abort the whole crawl (this
+		// runs inside the WriteQueue, whose rejection aborts the run). Recording
+		// a single redirect edge is best-effort, so skip it and move on. Unlike
+		// `updatePage`, there is no page content at stake here.
+		dbLog('recordRedirect: skip malformed destination URL: %s', destUrl);
+		return;
+	}
+
+	await knex.transaction(async (trx) => {
+		// Pass the caller-supplied `source` straight through so a
+		// brand-new destination row INSERTed here picks up the
+		// inventory lineage (instead of the DB DEFAULT `'crawled'`)
+		// when the caller is in the inventory chain — without the
+		// pass-through, inventory lineage would be laundered to
+		// `'crawled'` for js-redirect rescue / #73 convergence
+		// destinations that have not yet been rendered.
+		const destId = await getIdByUrl(
+			trx,
+			destUrlObject.withoutHashAndAuth,
+			undefined,
+			source,
+		);
+		// Chain lineage propagates FROM the originating URL
+		// (`page.url`), NOT from the destination. The originating
+		// URL is what initiated the redirect chain, so its lineage
+		// is what every intermediate hop transitively inherits.
+		// Reading from the destination would mis-propagate in
+		// "inventory-seed → ... → existing crawled dest" chains:
+		// the intermediates are reached only via the inventory
+		// chain, so they belong to the inventory chain even though
+		// the chain happens to land on a crawled URL. The
+		// `'crawled'` fallback arms the crawled-wins downgrade for
+		// existing `'inventory-*'` intermediates that a crawled
+		// chain reaches.
+		const [originatingRow] = await trx
+			.select('source')
+			.from<DB_Page>('pages')
+			.where('url', page.url.withoutHashAndAuth);
+		const originatingSource = originatingRow?.source ?? source;
+		const chainLineageSource = deriveLineageFromParent(originatingSource, 'crawled');
+		await linkRedirectSources(
+			trx,
+			sources,
+			destId,
+			destUrlObject.withoutHashAndAuth,
+			page.isExternal,
+			chainLineageSource,
+		);
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/set-skipped-page.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/set-skipped-page.ts
@@ -1,0 +1,29 @@
+import type { DB_Page } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { getIdByUrl } from '../../_shared/get-id-by-url.js';
+
+/**
+ * Marks a page as skipped in the database with the given reason.
+ * Creates the page row if it does not already exist.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param url - The URL of the skipped page.
+ * @param reason - The reason the page was skipped.
+ * @param isExternal - Whether the page is on an external domain. Defaults to `false`.
+ */
+export async function setSkippedPage(
+	knex: Knex,
+	url: string,
+	reason: string,
+	isExternal = false,
+): Promise<void> {
+	const pageId = await getIdByUrl(knex, url, isExternal ? 1 : 0);
+	await knex<DB_Page>('pages')
+		.where('id', pageId)
+		.update({
+			scraped: 1,
+			isExternal: isExternal ? 1 : 0,
+			isSkipped: 1,
+			skipReason: reason,
+		});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/update-page.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/update-page.ts
@@ -1,0 +1,223 @@
+import type { PageData } from '../../../../utils/types/types.js';
+import type { DB_Page, PageSource } from '../../../types.js';
+import type { Knex } from 'knex';
+
+import { tryParseUrl as parseUrl } from '@d-zero/shared/parse-url';
+
+import { isHtmlContentType } from '../../../../crawler/is-html-content-type.js';
+import { eachSplitted } from '../../../../utils/array/each-splitted.js';
+import { dbLog } from '../../../debug.js';
+import { deriveLineageFromParent } from '../../../derive-lineage-from-parent.js';
+import { resolveRedirectChain } from '../../../resolve-redirect-chain.js';
+import { getIdByUrl } from '../../_shared/get-id-by-url.js';
+
+import { insertJsonLd } from './insert-jsonld.js';
+import { insertPage } from './insert-page.js';
+import { insertTags } from './insert-tags.js';
+import { linkRedirectSources } from './link-redirect-sources.js';
+import { writePageHtmlBlob } from './write-page-html-blob.js';
+
+/**
+ * Inserts or updates a crawled page in the database, including its redirect chain,
+ * anchors, images, and (when `writeHtml`) its compressed HTML snapshot BLOB.
+ *
+ * Self-redirects (where the source URL equals the destination URL after normalization)
+ * are skipped to avoid marking a page as redirected to itself — a situation caused by
+ * authentication challenges (e.g. Basic Auth 302) that would otherwise exclude the page
+ * from reports via the `whereNull('redirectDestId')` filter.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param page - The page data to store.
+ * @param writeHtml - When `true`, this call is allowed to insert (or clear)
+ *   the page's HTML blob. `setExternalPage` passes `false` because external
+ *   metadata-only scrapes never carry HTML and must not perturb an already
+ *   stored body.
+ * @param isTarget - Whether this page is a crawl target.
+ * @param source - Provenance label written ONLY when the row is freshly
+ *   inserted. Existing rows keep their original `source` (this is why a
+ *   second `crawl --inventory` does not "demote" an `'inventory-seed'` row
+ *   that was discovered earlier).
+ * @returns The database `pageId` of the inserted/updated row.
+ */
+export async function updatePage(
+	knex: Knex,
+	page: PageData,
+	writeHtml: boolean,
+	isTarget: boolean,
+	source?: PageSource,
+): Promise<number> {
+	const { destUrl, sources } = resolveRedirectChain(
+		page.url.withoutHashAndAuth,
+		page.redirectPaths,
+	);
+
+	const destUrlObject = parseUrl(destUrl);
+
+	if (!destUrlObject) {
+		throw new Error(`Failed to parse URL: ${destUrl}`);
+	}
+
+	return await knex.transaction(async (trx) => {
+		const pageId = await insertPage(
+			knex,
+			{
+				...page,
+				url: destUrlObject,
+			},
+			isTarget,
+			trx,
+			source,
+		);
+
+		// Wappalyzer tag detection is HTML-body independent (relies on
+		// `<script src>` / `<iframe src>` / window globals / response
+		// headers) so it runs for every page including external /
+		// metadata-only. JSON-LD on the other hand lives inside the
+		// rendered HTML body, so we only write it when there is HTML to
+		// scrape — see the same `writeHtml` gate as `writePageHtmlBlob`
+		// below.
+		await insertTags(pageId, page.meta, trx);
+		if (writeHtml) {
+			await insertJsonLd(pageId, page.meta, trx);
+		}
+
+		// Chain lineage propagates FROM the originating URL
+		// (`page.url`), NOT from the destination. See the matching
+		// rationale in `recordRedirect` above: intermediates are
+		// reached transitively from the originating URL's render,
+		// so they inherit its lineage. The `source` argument is the
+		// authoritative origin label when inventoryMode is live;
+		// fall through to a DB lookup of `page.url` for the resume
+		// / retry-failed path where the call-site has no source.
+		let originatingSource: PageSource | undefined = source;
+		if (originatingSource === undefined) {
+			const [originatingRow] = await trx
+				.select('source')
+				.from<DB_Page>('pages')
+				.where('url', page.url.withoutHashAndAuth);
+			originatingSource = originatingRow?.source;
+		}
+		const chainLineageSource = deriveLineageFromParent(originatingSource, 'crawled');
+		await linkRedirectSources(
+			trx,
+			sources,
+			pageId,
+			destUrlObject.withoutHashAndAuth,
+			page.isExternal,
+			chainLineageSource,
+		);
+		// Only insert a snapshot blob when there is actual HTML to write.
+		// `page.html.length > 0` is the precise signal: the scraper returns
+		// `html: ''` for everything that is not a rendered `text/html` document
+		// (non-HTML responses, metadata-only, external, degraded renders), so a
+		// non-empty `html` is exactly "a rendered HTML body exists". Gating on
+		// `isTarget` alone would store an empty body for every internal non-HTML
+		// resource — PDF / zip / images are isTarget=1 (#72).
+		//
+		// `isTarget` is intentionally NOT part of this condition: it is implied by
+		// `html.length > 0` (only in-scope target pages are browser-rendered into a
+		// non-empty body; metadata-only and external pages carry `html: ''`), so the
+		// content check alone expresses the intent without a redundant term.
+		if (writeHtml && page.html.length > 0) {
+			await writePageHtmlBlob(pageId, page.html, trx);
+		} else if (
+			writeHtml &&
+			page.contentType !== null &&
+			!isHtmlContentType(page.contentType)
+		) {
+			// The page is now a *known* non-HTML type. If a previous scrape stored
+			// an HTML body for this URL (e.g. it served HTML then was replaced by
+			// a PDF across `crawl --resume` / `--append`), drop the stale ref so
+			// `page_html_ref` never contradicts `contentType`. A degraded HTML
+			// re-scrape (text/html or unknown content type with empty html) is NOT
+			// cleared — the last good snapshot is preserved, mirroring the
+			// anchors / images empty-guard below. Gated on `writeHtml` because a
+			// stale ref can only have been written by a snapshot-capable call
+			// (`setPage`); `setExternalPage` passes `writeHtml = false` and never
+			// sets `html`, so it has nothing to clear.
+			await trx('page_html_ref').where('page_id', pageId).delete();
+		}
+		// Re-scrape semantics: the same URL can be scraped more than once
+		// (e.g. `crawl --resume`, re-visits, `--append` re-promotion). The
+		// `anchors` / `images` tables have no uniqueness constraint, so
+		// re-inserting without clearing would accumulate a full duplicate set
+		// on every re-scrape (#70). So we delete-then-insert
+		// to *replace* the previous rows.
+		//
+		// The delete is paired with — and guarded by — a non-empty new list:
+		// a degraded re-scrape (navigation timeout / partial render) can return
+		// an empty `anchorList` for a page that previously had links, and
+		// wiping the prior good data in that case would be destructive. We
+		// cannot tell a transient empty result apart from a page that has
+		// legitimately lost all its links, so we err on the side of keeping
+		// what we already had. The accepted trade-off is that a page which
+		// genuinely dropped to zero links keeps its stale rows until the next
+		// non-empty re-scrape replaces them.
+		//
+		// (A DB-level unique constraint + `onConflict` would also prevent
+		// duplication, but multiple distinct anchors can share the same
+		// hrefId/hash/textContent legitimately, so there is no natural unique
+		// key to enforce — replace-on-write is the correct mechanism here.)
+		// Lineage propagation: read the current page's merged source
+		// (post-UPDATE by `insertPage`) so anchor placeholder rows
+		// inherit a label that reflects the parent's chain. A
+		// `'crawled'`-lineage parent passes `'crawled'` explicitly so the
+		// crawled-wins downgrade in `getIdByUrl` fires when an anchor
+		// hits an existing `'inventory-*'` row. An inventory-lineage
+		// parent passes `'inventory-discovered'` to label transitively-
+		// reached URLs correctly without the orchestrator needing to
+		// rehydrate `inventoryMode` from disk.
+		//
+		// Cost: one extra SELECT on `pages` per scraped page (the
+		// `id` is a PK index lookup so it is sub-millisecond even at
+		// 1M-row scale). The alternative — passing `mergedSource`
+		// through from the UPDATE result — would require RETURNING
+		// support that knex's SQLite dialect handles inconsistently;
+		// the small per-page round-trip is the cheaper trade.
+		const [parentRow] = await trx
+			.select('source')
+			.from<DB_Page>('pages')
+			.where('id', pageId);
+		// `deriveLineageFromParent` collapses the three call sites
+		// (anchor / redirect intermediate × updatePage / recordRedirect)
+		// onto the same rule. `'crawled'` fallback (vs `undefined`)
+		// arms the crawled-wins downgrade in `getIdByUrl` for
+		// existing `'inventory-*'` rows reached from a crawled
+		// parent — see `isInventorySource` for the membership rule.
+		const anchorLineageSource = deriveLineageFromParent(parentRow?.source, 'crawled');
+		const anchors = await Promise.all(
+			page.anchorList.map(async (anchor) => {
+				const hrefId = await getIdByUrl(
+					trx,
+					anchor.href.withoutHashAndAuth,
+					anchor.isExternal ? 1 : 0,
+					anchorLineageSource,
+				);
+				return {
+					pageId,
+					hrefId,
+					hash: anchor.href.hash,
+					textContent: anchor.textContent,
+				};
+			}),
+		);
+		dbLog('Insert anchors.length: %d', anchors.length);
+		if (anchors.length > 0) {
+			await trx('anchors').where('pageId', pageId).delete();
+			await eachSplitted(anchors, 100, async (_anchors) => {
+				await trx('anchors').insert(_anchors);
+			});
+		}
+		const images = page.imageList.map((image) => ({
+			pageId,
+			...image,
+		}));
+		dbLog('Insert images.length: %d', images.length);
+		if (images.length > 0) {
+			await trx('images').where('pageId', pageId).delete();
+			await eachSplitted(images, 100, async (_images) => {
+				await trx('images').insert(_images);
+			});
+		}
+		return pageId;
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/write-page-html-blob.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/pages/write/write-page-html-blob.ts
@@ -1,0 +1,48 @@
+import type { Knex } from 'knex';
+
+import { createHash } from 'node:crypto';
+import { zstdCompressSync } from 'node:zlib';
+
+/**
+ * Encodes, dedups, and persists a page's HTML snapshot.
+ *
+ * Computes SHA-256 over the raw UTF-8 bytes, compresses them with zstd,
+ * inserts into `page_html_blobs` only if the hash is new (so identical
+ * bodies — 404 templates, error pages, redirect destinations — share a
+ * single row), and then upserts `page_html_ref(page_id → hash)` so the
+ * latest scrape always points at the right body.
+ *
+ * Runs entirely inside the caller's transaction; a failure here rolls
+ * back the rest of `updatePage`, which is the desired semantics (an
+ * archive that lost its HTML for a page would otherwise serve stale
+ * meta against a missing body).
+ * @param pageId - The database id of the page.
+ * @param html - The raw HTML string (UTF-8).
+ * @param trx - The active transaction.
+ */
+export async function writePageHtmlBlob(
+	pageId: number,
+	html: string,
+	trx: Knex.Transaction,
+): Promise<void> {
+	const rawBytes = Buffer.from(html, 'utf8');
+	const hash = createHash('sha256').update(rawBytes).digest();
+	const compressed = zstdCompressSync(rawBytes);
+	await trx('page_html_blobs')
+		.insert({
+			hash,
+			body: compressed,
+			codec: 'zstd',
+			size_raw: rawBytes.byteLength,
+			size_stored: compressed.byteLength,
+		})
+		.onConflict('hash')
+		.ignore();
+	// Upsert so a re-scrape's body cleanly supersedes the prior pointer.
+	// The old blob row is intentionally left in place — a future #23 GC
+	// pass will sweep unreachable hashes.
+	await trx('page_html_ref')
+		.insert({ page_id: pageId, hash })
+		.onConflict('page_id')
+		.merge(['hash']);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/referrers/get-redirects-for-pages.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/referrers/get-redirects-for-pages.ts
@@ -1,0 +1,19 @@
+import type { DB_Redirect } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves redirect sources for the given page IDs in bulk.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param pageIds - The database IDs of the destination pages.
+ * @returns An array of {@link DB_Redirect} records mapping destination pages to their redirect sources.
+ */
+export async function getRedirectsForPages(
+	knex: Knex,
+	pageIds: number[],
+): Promise<DB_Redirect[]> {
+	if (pageIds.length === 0) return [];
+	return knex
+		.select('redirectDestId as pageId', 'url as from', 'id as fromId')
+		.from('pages')
+		.whereIn('redirectDestId', pageIds);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/referrers/get-referrers-of-page.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/referrers/get-referrers-of-page.ts
@@ -1,0 +1,35 @@
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves pages that link to a specific page (incoming links / referrers).
+ *
+ * Incoming links are resolved **through redirects**: an anchor pointing at a
+ * redirect source (e.g. `http://x` that 301s to `https://x`) counts as a
+ * referrer of the redirect's final destination, not of the source. This keeps
+ * backlinks merged on the canonical page instead of splitting them across the
+ * `http`/`https` (or any redirect source/dest) pair. The resolution mirrors
+ * `redirectTable()` — `redirectDestId` is pre-flattened to the final
+ * destination, so `COALESCE(target.redirectDestId, target.id)` is a single hop.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param pageId - The database ID of the target page.
+ * @returns An array of referrer records with URL, hash, and text content.
+ */
+export async function getReferrersOfPage(knex: Knex, pageId: number) {
+	const res = await knex
+		.select(
+			'referrer.url',
+			// `through` / `throughId` = the URL the anchor actually pointed at (the
+			// redirect source, e.g. `http://x`), mirroring `getPagesWithRels`'
+			// `redirect.from` / `redirect.fromId`. Lets report code print the
+			// "[REDIRECTED FROM]" note even on this (non-preloaded) referrer path.
+			'target.url as through',
+			'target.id as throughId',
+			'anchors.hash',
+			'anchors.textContent',
+		)
+		.from('anchors')
+		.join('pages as referrer', 'anchors.pageId', '=', 'referrer.id')
+		.join('pages as target', 'anchors.hrefId', '=', 'target.id')
+		.whereRaw('coalesce("target"."redirectDestId", "target"."id") = ?', [pageId]);
+	return res;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/referrers/get-referrers-of-resource.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/referrers/get-referrers-of-resource.ts
@@ -1,0 +1,17 @@
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves the page URLs that reference a specific resource.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param id - The database ID of the resource.
+ * @returns An array of page URL strings that reference the resource.
+ */
+export async function getReferrersOfResource(knex: Knex, id: number): Promise<string[]> {
+	const res = await knex
+		.select('pages.url')
+		.from('resources-referrers')
+		.join('resources', 'resources.id', '=', 'resources-referrers.resourceId')
+		.join('pages', 'pages.id', '=', 'resources-referrers.pageId')
+		.where('resources.id', id);
+	return res.map((r) => r.url);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-existing-resource-urls.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-existing-resource-urls.ts
@@ -1,0 +1,31 @@
+import type { DB_Resource } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { eachSplitted } from '../../../utils/array/each-splitted.js';
+
+/**
+ * Return the subset of `urls` that already exist in the `resources` table.
+ * See `getExistingPageUrls` — same chunking strategy.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param urls - URL strings to probe.
+ * @returns URLs found in `resources`.
+ */
+export async function getExistingResourceUrls(
+	knex: Knex,
+	urls: readonly string[],
+): Promise<string[]> {
+	if (urls.length === 0) {
+		return [];
+	}
+	const found: string[] = [];
+	await eachSplitted([...urls], 500, async (chunk) => {
+		const rows = await knex
+			.select('url')
+			.from<DB_Resource>('resources')
+			.whereIn('url', chunk);
+		for (const row of rows) {
+			found.push(row.url);
+		}
+	});
+	return found;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-resource-by-url.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-resource-by-url.ts
@@ -1,0 +1,24 @@
+import type { DB_Resource } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves a single sub-resource from the `resources` table by its URL.
+ *
+ * Accepts multiple URL candidates because the stored key is the resource's
+ * `href` while callers may only know the hash-stripped form; the first match
+ * wins.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param urls - URL candidates to match against the `url` column.
+ * @returns The raw {@link DB_Resource} row, or `null` if none match.
+ */
+export async function getResourceByUrl(
+	knex: Knex,
+	urls: readonly string[],
+): Promise<DB_Resource | null> {
+	const res = await knex
+		.select('*')
+		.from<DB_Resource>('resources')
+		.whereIn('url', [...urls])
+		.first();
+	return res ?? null;
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-resource-url-list.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-resource-url-list.ts
@@ -1,0 +1,12 @@
+import type { DB_Resource } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves a flat list of all resource URLs from the `resources` table.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns An array of resource URL strings.
+ */
+export async function getResourceUrlList(knex: Knex): Promise<string[]> {
+	const res = await knex.select('url').from<DB_Resource>('resources');
+	return res.map((r) => r.url);
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-resources.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/resources/get-resources.ts
@@ -1,0 +1,11 @@
+import type { DB_Resource } from '../../types.js';
+import type { Knex } from 'knex';
+
+/**
+ * Retrieves all sub-resources from the `resources` table.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @returns An array of raw {@link DB_Resource} rows.
+ */
+export async function getResources(knex: Knex): Promise<DB_Resource[]> {
+	return knex.select('*').from<DB_Resource>('resources');
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/resources/insert-inventory-resources.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/resources/insert-inventory-resources.ts
@@ -1,0 +1,53 @@
+import type { DB_Resource, PageSource } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { eachSplitted } from '../../../utils/array/each-splitted.js';
+
+/**
+ * Pre-insert inventory non-HTML URLs into `resources` as placeholder rows
+ * with `source = 'inventory-seed'` and all metadata columns NULL — the
+ * non-HTML counterpart of `insertInventorySeeds`. Used by
+ * `CrawlerOrchestrator.inventory` so the ingestion phase commits all of
+ * its non-HTML URLs in one chunked round-trip per 500 instead of N
+ * sequential `insertResource` awaits — a per-URL loop would spend
+ * minutes inside the `.bak`-protected window on a 50k-URL inventory
+ * list, where the bulk path finishes in seconds.
+ *
+ * Idempotent: `onConflict('url').ignore()` leaves existing rows untouched
+ * (the orchestrator's `getExistingResourceUrls` filter is what keeps a
+ * crawled-lineage `resources` row from being downgraded to the
+ * inventory label here).
+ *
+ * Chunked at 500 to stay well under SQLite's `SQLITE_MAX_VARIABLE_NUMBER`
+ * (default 999) — every row binds the URL plus the `responseHeaders`
+ * JSON null, so the per-chunk bound budget is well within limits.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param urls - URL strings (already in `withoutHashAndAuth` form).
+ */
+export async function insertInventoryResources(
+	knex: Knex,
+	urls: readonly string[],
+): Promise<void> {
+	if (urls.length === 0) {
+		return;
+	}
+	await eachSplitted([...urls], 500, async (chunk) => {
+		await knex<DB_Resource>('resources')
+			.insert(
+				chunk.map((url) => ({
+					url,
+					isExternal: 0 as const,
+					status: null,
+					statusText: null,
+					contentType: null,
+					contentLength: null,
+					compress: 0 as const,
+					cdn: 0 as const,
+					responseHeaders: null,
+					source: 'inventory-seed' as PageSource,
+				})),
+			)
+			.onConflict('url')
+			.ignore();
+	});
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/resources/insert-resource-referrers.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/resources/insert-resource-referrers.ts
@@ -1,0 +1,35 @@
+import type { DB_Resource } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { getIdByUrl } from '../_shared/get-id-by-url.js';
+
+/**
+ * Inserts a referrer relationship between a resource and a page into the
+ * `resources-referrers` table. Silently skips if the resource is not found.
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param src - The URL of the resource.
+ * @param pageUrl - The URL of the page that references the resource.
+ */
+export async function insertResourceReferrers(
+	knex: Knex,
+	src: string,
+	pageUrl: string,
+): Promise<void> {
+	const selected = await knex
+		.select('id')
+		.from<DB_Resource>('resources')
+		.where('url', src);
+	if (!selected[0]) {
+		// Ignore when the resource is not found
+		return;
+	}
+	const [{ id: resourceId }] = selected;
+	const pageId = await getIdByUrl(knex, pageUrl);
+	await knex('resources-referrers')
+		.insert({
+			resourceId,
+			pageId,
+		})
+		.onConflict(['resourceId', 'pageId'])
+		.ignore();
+}

--- a/packages/@nitpicker/crawler/src/archive/db-ops/resources/insert-resource.ts
+++ b/packages/@nitpicker/crawler/src/archive/db-ops/resources/insert-resource.ts
@@ -1,0 +1,41 @@
+import type { Resource } from '../../../utils/types/types.js';
+import type { DB_Resource, PageSource } from '../../types.js';
+import type { Knex } from 'knex';
+
+import { normalizeContentType } from '../../../crawler/normalize-content-type.js';
+
+/**
+ * Inserts a sub-resource into the `resources` table.
+ * Ignores duplicate URLs (uses `ON CONFLICT IGNORE`).
+ *
+ * The `source` provenance label is written ONLY on insert; an
+ * `ON CONFLICT IGNORE` collision leaves an existing row's source untouched
+ * (this is what makes a second `crawl --inventory` non-destructive).
+ * @param knex - Knex query builder connected to the archive DB.
+ * @param resource - The resource data to insert.
+ * @param source - Provenance label for new rows. `undefined` leaves the DB DEFAULT (`'crawled'`).
+ */
+export async function insertResource(
+	knex: Knex,
+	resource: Resource,
+	source?: PageSource,
+): Promise<void> {
+	await knex
+		.from<DB_Resource>('resources')
+		.insert({
+			url: resource.url.href,
+			isExternal: resource.isExternal ? 1 : 0,
+			status: resource.status,
+			statusText: resource.statusText,
+			// Canonicalize like `pages.contentType` (see #insertPage) so resource
+			// content-type filters / dedupe keys are case- and whitespace-stable.
+			contentType: normalizeContentType(resource.contentType),
+			contentLength: resource.contentLength,
+			compress: resource.compress || 0,
+			cdn: resource.cdn || 0,
+			responseHeaders: JSON.stringify(resource.headers),
+			...(source === undefined ? {} : { source }),
+		})
+		.onConflict('url')
+		.ignore();
+}


### PR DESCRIPTION
Part of #103 (Phase 6 write-model refactor). Closes #210.

## Why

`packages/@nitpicker/crawler/src/archive/database.ts` was **2810 lines / 50 methods** on a single `Database` class. The upcoming Phase 6-G writer switch (#196) will rewrite `setPage` / `updatePage` / `#insertPage` / `#getIdByUrl` / `#linkRedirectSources` / `insertResource` / `insertResourceReferrers` / `recordRedirect` / `resetFailedPages` / `insertInventorySeeds` / `insertInventoryResources` / `setSkippedPage` / `repromoteExternalPages` and their private helpers to target the new 0.13 tables. Doing that against a monolithic file produces a **1500+ line diff** that cannot be reviewed meaningfully.

This PR extracts every `Database` method into its own file under `db-ops/`, following the repo's "1 file, 1 export" rule. `Database` becomes a thin dispatcher class that wraps each op with `emitErrorAndRetry` / `emitError` / `retryCall` using the existing label convention.

## Scope — pure mechanical extraction

**No logic changes. No SQL changes. No public API changes.**

- Every op body is a verbatim copy of the corresponding class-method body with `this.#instance` → `knex` substitution
- `emitErrorAndRetry` label strings (`'Database.methodName'`) stay in `database.ts` next to each dispatcher — the "Label sync caveat" documented on the class stays intact
- Wrap-pattern heterogeneity preserved verbatim (`emitError` for `getExistingPageUrls` / `getExistingResourceUrls` / `getPageSourceByUrl`; `retryCall` with custom label for `getResourceByUrl`; no wrap for `checkpoint` / `destroy` / `getKnex` / `addOrderField` / `setUrlOrder`)
- Every existing JSDoc block (with its invariant / edge-case explanations) is replicated on the corresponding op file; class dispatchers keep a one-line `@link` pointer
- `getIdByUrl` signature slightly changed: the caller now resolves `trx ?? knex` before calling, keeping the extracted function pure of its arguments. Documented in `_shared/get-id-by-url.ts` JSDoc.

## Verification

`database.spec.ts` (2500+ lines) and **all 3217 tests pass unchanged** — that is the primary evidence of behaviour invariance. Callers (`archive.ts` / `crawler-orchestrator.ts` / `@nitpicker/query` / `viewer` / `mcp-server` / `cli` / spec files) were not modified.

- `yarn build` — green (all 14 packages)
- `yarn lint` + `yarn lint:check` — green
- `yarn test` — 3217 passed, 5 skipped, 448 files
- Rebased onto the current `feature/impl-new-db` tip (`765e45e`); upstream JSDoc improvements from `5008214` and `073e525` were ported into the corresponding op files during conflict resolution.

## Metrics

| Metric | Before | After |
| --- | ---: | ---: |
| `database.ts` LOC | 2810 | 726 |
| New files under `db-ops/` | — | 56 (54 op files + 2 shared) |
| Public API changes | — | 0 |
| Test file changes | — | 0 |

## Directory layout

```
packages/@nitpicker/crawler/src/archive/
├── database.ts              (Database class shell, 726 lines)
└── db-ops/
    ├── _shared/             (retry-setting, safe-parse-json, get-id-by-url)
    ├── config/              (get/set/update-config, base-url, name, info-column-allowlist, info-json-columns)
    ├── lifecycle/           (init, checkpoint, destroy)
    ├── pages/read/          (get-pages / get-page-count / get-crawling-state / get-pages-with-rels / ...)
    ├── pages/write/         (update-page / insert-page / record-redirect / link-redirect-sources / ...)
    ├── pages/reset/         (reset-failed-pages / repromote-external-pages / meta-nullable-columns / make-meta-reset-payload)
    ├── pages/order/         (add-order-field / set-url-order)
    ├── html/                (get-html-of-page-by-id)
    ├── meta/                (get-jsonld-of-page / get-tags-of-page)
    ├── anchors/             (get-anchors-on-page)
    ├── referrers/           (get-referrers-of-page / -resource / get-redirects-for-pages)
    ├── resources/           (insert-resource / get-* / insert-resource-referrers)
    ├── errors/              (insert-page-error / insert-crawl-error / list-dns-burned-host-candidates)
    ├── analysis/            (replace-analysis-violations)
    └── inventory/           (record-inventory-run)
```

## Unit specs for the new op files

Deferred to #196. The op function bodies will be entirely rewritten there to target the new 0.13 tables, so adding per-op `.spec.ts` on top of this mechanical extraction (which is already transitively covered by `database.spec.ts`) would create tests that go stale the moment #196 lands. The receiving-side plan is to add per-op specs alongside the writer rewrite in #196.

## Test plan

- [ ] `yarn build` green on CI
- [ ] `yarn lint` / `yarn lint:check` green on CI
- [ ] `yarn test` green on CI (3217 tests unchanged)
- [ ] E2E tests green on CI

## Follow-up

- #196 (Phase 6-G) — crawler write path → new 0.13 tables. Now diff-reviewable per op file.
