### PR TITLE
feat(repo): make migrate-to-0.13 resumable across process kills

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,7 +157,7 @@
 3. 読み取り経路: `db-ops/pages/read/build-page-query.ts` + `reconstruct-page-rows.ts`（flat 形状の再構築）と `db-ops/_shared/load-response-headers-by-set-ids.ts` / `decode-json-ref.ts`（ヘッダ / json_refs の復元 primitive、query パッケージも共用）
 4. `crawler/src/archive/meta/assert-compatible-version.ts`（互換ガード）と `meta/derive-flat-from-meta.ts`（Meta 展開列）
 5. 読み取り影響: `query/src/`（`get-summary.ts` / `list-pages.ts` / `content-type-rules.ts`）
-6. 既存アーカイブ適用スクリプト: リポジトリルート `scripts/`（`migrate-to-0.13.mjs` は legacy テーブルからの populate → adjunct FK retarget（`retarget-legacy-fk-tables.ts`）→ legacy drop（`drop-legacy-tables.ts`）→ `foreign_key_check`（`verify-migration/check-foreign-key-integrity.ts`）の一括実行。schema catch-up 用の `migrate-ref-tables.ts` / `migrate-entity-tables.ts` はこのスクリプト専用で、archive open 時には走らない。テスト用の pre-0.13 fixture は `scripts/generate-pre-0.13-fixture.mjs`（`archive/test-utils/setup-legacy-fk-db.ts` 経由）が単一の生成元）
+6. 既存アーカイブ適用スクリプト: リポジトリルート `scripts/`（`migrate-to-0.13.mjs` は legacy テーブルからの populate → adjunct FK retarget（`retarget-legacy-fk-tables.ts`）→ legacy drop（`drop-legacy-tables.ts`）→ `foreign_key_check`（`verify-migration/check-foreign-key-integrity.ts`）の一括実行。SIGKILL 耐性あり — work dir を決定的パスで管理し、途中終了しても次回実行で完了済みフェーズをスキップして再開する（詳細はスクリプト冒頭の RESUMING AFTER A KILL 節）。schema catch-up 用の `migrate-ref-tables.ts` / `migrate-entity-tables.ts` はこのスクリプト専用で、archive open 時には走らない。テスト用の pre-0.13 fixture は `scripts/generate-pre-0.13-fixture.mjs`（`archive/test-utils/setup-legacy-fk-db.ts` 経由）が単一の生成元）
 
 ### Content-Type カテゴリ追加（3 箇所は CI が強制・2 箇所は手動）
 

--- a/cspell.json
+++ b/cspell.json
@@ -24,6 +24,8 @@
 		// Filesystems / OS storage primitives (tar cache documentation)
 		"APFS",
 		"tmpfs",
+		"statfs",
+		"bavail",
 
 		// English compounds used in technical commentary
 		"unsuffixed",

--- a/packages/@nitpicker/crawler/src/archive/migrate-to-0.13-script.spec.ts
+++ b/packages/@nitpicker/crawler/src/archive/migrate-to-0.13-script.spec.ts
@@ -1,15 +1,39 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 
 import knex from 'knex';
 import * as tar from 'tar';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { acquireArchiveLock } from './archive-lock.js';
+import { createAdjunctTables } from './create-adjunct-tables.js';
 import { peekTarTopDir } from './filesystem/peek-tar-top-dir.js';
 import { LibsqlDialect } from './libsql-dialect.js';
+import { migrateEntityTables } from './migrate-entity-tables.js';
+import { migrateRefTables } from './migrate-ref-tables.js';
+import { populateEntityTables } from './populate-entity-tables/populate-entities.js';
+import { populateContentTypeRefs } from './populate-ref-tables/populate-content-type-refs.js';
+import { populateRefTables } from './populate-ref-tables/populate-refs.js';
+import { populateUrlRefs } from './populate-ref-tables/populate-url-refs.js';
+import { retargetLegacyFkTables } from './retarget-legacy-fk-tables.js';
 import { fkParentTables } from './test-utils/fk-parent-tables.js';
+import { verifyMigration } from './verify-migration/verify-migration.js';
+
+/**
+ * No-op stub for `populateEntityTables`'s DOM-path resolver: test fixtures
+ * carry no real HTML snapshots, so every image falls back to the
+ * synthetic "unknown" marker regardless of what the resolver returns.
+ */
+const noopDomPathResolver = () => Promise.resolve(new Map());
 
 const __filename = new URL(import.meta.url).pathname;
 const __dirname = path.dirname(__filename);
@@ -93,6 +117,58 @@ async function mutateFixture(
 	} finally {
 		rmSync(stageDir, { recursive: true, force: true });
 	}
+}
+
+/**
+ * Mirrors `scripts/migrate-to-0.13.mjs`'s deterministic work-dir naming
+ * (output-path basename, no PID) so specs can construct or inspect the
+ * exact directory the script will use for a given output path without
+ * ever running the script first.
+ * @param outputPath - The output `.nitpicker` path the script would be
+ *   invoked with.
+ */
+function deriveWorkDir(outputPath: string): string {
+	return path.resolve(
+		path.dirname(outputPath),
+		`._migrate-to-0.13-${path.basename(outputPath, path.extname(outputPath))}`,
+	);
+}
+
+/**
+ * Builds a work dir that looks, from the script's point of view, exactly
+ * like a completed untar from a prior (possibly killed) run: extracted
+ * contents, the `.untar-complete` sentinel, and a `.source-fingerprint.json`
+ * matching `fingerprintSourcePath` — mirroring
+ * `scripts/migrate-to-0.13.mjs`'s own `writeSourceFingerprint`, since the
+ * script now refuses to resume a work dir whose fingerprint doesn't match
+ * the input path it was invoked with.
+ *
+ * `archiveToExtract` and `fingerprintSourcePath` are deliberately separate
+ * parameters: a test simulating "resumed past the legacy-table drop" seeds
+ * the work dir's contents from an already-migrated archive (to avoid
+ * re-running the whole pipeline just to reach that state), while the
+ * fingerprint must still match the original pre-migration input the
+ * script will actually be invoked with.
+ * @param options
+ * @param options.archiveToExtract - The `.nitpicker` to untar into the work dir.
+ * @param options.workDir - The work dir to populate (see {@link deriveWorkDir}).
+ * @param options.fingerprintSourcePath - The path the script will be invoked
+ *   with as its input argument.
+ */
+async function seedResumableWorkDir(options: {
+	archiveToExtract: string;
+	workDir: string;
+	fingerprintSourcePath: string;
+}): Promise<void> {
+	const { archiveToExtract, workDir, fingerprintSourcePath } = options;
+	mkdirSync(workDir, { recursive: true });
+	await tar.x({ file: archiveToExtract, cwd: workDir });
+	const stat = statSync(fingerprintSourcePath);
+	writeFileSync(
+		path.resolve(workDir, '.source-fingerprint.json'),
+		JSON.stringify({ size: stat.size, mtimeMs: stat.mtimeMs }),
+	);
+	writeFileSync(path.resolve(workDir, '.untar-complete'), '');
 }
 
 describe('scripts/migrate-to-0.13.mjs (integration)', () => {
@@ -194,6 +270,10 @@ describe('scripts/migrate-to-0.13.mjs (integration)', () => {
 				for (const row of infoRows) {
 					expect(row.version).toBe('0.13.0');
 				}
+
+				// The internal resume-checkpoint table must never ship in the
+				// output — it is dropped once every DB-level step is done.
+				expect(await db.schema.hasTable('_migrate_progress')).toBe(false);
 			} finally {
 				await db.destroy();
 			}
@@ -253,6 +333,11 @@ describe('scripts/migrate-to-0.13.mjs (integration)', () => {
 
 			// Input tar bytes unchanged — the effective ".bak restore" clause.
 			expect(sha256File(inputPath)).toBe(inputHashBefore);
+
+			// The work dir is preserved on failure (only removed on full
+			// success) so a resumed run can pick back up instead of
+			// re-extracting and re-populating from scratch.
+			expect(existsSync(deriveWorkDir(outputPath))).toBe(true);
 		},
 	);
 
@@ -339,6 +424,742 @@ describe('scripts/migrate-to-0.13.mjs (integration)', () => {
 			} finally {
 				await db.destroy();
 			}
+		},
+	);
+
+	it(
+		'resume: skips untar when a completed work dir already exists',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			// Build the work dir by hand exactly as a completed untar would
+			// leave it, so the script's resume path is exercised without
+			// ever having to actually kill a process.
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('resuming existing work dir (skip untar)');
+			// The fresh-extraction log line only appears on the non-resume path.
+			expect(stdout).not.toContain('[1/3] untar ');
+			expect(existsSync(outputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'resume: wipes and re-extracts an incomplete work dir (no untar-complete marker)',
+		{ timeout: 60_000 },
+		() => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			// Simulate a kill mid-extraction: a work dir with a garbage inner
+			// directory and an unusable `db.sqlite`, but no `.untar-complete`
+			// sentinel — that marker is only ever written right after a real
+			// `tar.x` call completes, so its absence must never be read as
+			// "safe to resume".
+			const workDir = deriveWorkDir(outputPath);
+			const garbageInner = path.resolve(workDir, 'garbage-inner');
+			mkdirSync(garbageInner, { recursive: true });
+			writeFileSync(path.resolve(garbageInner, 'db.sqlite'), 'not a real sqlite file');
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('[1/3] untar ');
+			expect(stdout).not.toContain('resuming existing work dir');
+			expect(existsSync(outputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'resume: skips ref-table populate steps already recorded in _migrate_progress',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+			const innerDirName = await peekTarTopDir(inputPath);
+			const dbPath = path.resolve(workDir, innerDirName, 'db.sqlite');
+
+			// Pre-complete the first two of the six ref-table steps exactly as
+			// the script itself would (same functions, same order), then
+			// record them in `_migrate_progress` — reproducing the state a
+			// kill partway through "populate ref tables" would leave behind.
+			const db = knex({
+				client: LibsqlDialect,
+				connection: { filename: dbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				await db.raw('PRAGMA foreign_keys = ON');
+				await migrateRefTables(db);
+				await populateContentTypeRefs(db);
+				await populateUrlRefs(db);
+				await db.schema.createTable('_migrate_progress', (t) => {
+					t.string('step').primary();
+					t.string('completed_at').notNullable();
+				});
+				await db('_migrate_progress').insert([
+					{ step: 'content_type_refs', completed_at: new Date().toISOString() },
+					{ step: 'url_refs', completed_at: new Date().toISOString() },
+				]);
+				await db.raw('PRAGMA wal_checkpoint(TRUNCATE)');
+			} finally {
+				await db.destroy();
+			}
+			for (const sidecar of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+				if (existsSync(sidecar)) rmSync(sidecar, { force: true });
+			}
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('populate content_type_refs: already done, skipping');
+			expect(stdout).toContain('populate url_refs: already done, skipping');
+			// The remaining four steps were NOT pre-completed and must still run.
+			expect(stdout).not.toContain('populate text_refs: already done, skipping');
+			expect(stdout).not.toContain('populate json_refs: already done, skipping');
+			expect(stdout).not.toContain('populate blob_refs: already done, skipping');
+			expect(stdout).not.toContain('populate header_tables: already done, skipping');
+			expect(stdout).toContain('verification passed');
+			expect(existsSync(outputPath)).toBe(true);
+
+			const inspectDir = path.resolve(workingDir, 'inspect-ref-resume');
+			mkdirSync(inspectDir, { recursive: true });
+			await tar.x({ file: outputPath, cwd: inspectDir });
+			const outInnerDirName = await peekTarTopDir(outputPath);
+			const outDbPath = path.resolve(inspectDir, outInnerDirName, 'db.sqlite');
+			const outDb = knex({
+				client: LibsqlDialect,
+				connection: { filename: outDbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				// Final data matches a clean single run (happy-path fixture: 2 pages).
+				const contentItemsCount = await outDb('content_items').count<{ n: number }[]>({
+					n: '*',
+				});
+				expect(Number(contentItemsCount[0]!.n)).toBe(2);
+			} finally {
+				await outDb.destroy();
+			}
+		},
+	);
+
+	it(
+		'resume: a work dir past the legacy-table drop resumes without crashing',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			// Run the script to completion normally — the output has the
+			// legacy tables already gone and `_migrate_progress` already
+			// dropped, same as any migrated archive.
+			const firstOutputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			execFileSync('node', [migrateScript, inputPath, firstOutputPath], {
+				cwd: repoRoot,
+			});
+
+			// Seed a second target's work dir directly from that already-
+			// migrated archive. From the script's point of view this is
+			// indistinguishable from "a run was killed right after the drop
+			// step committed": `pages` etc. are gone, `.untar-complete` is
+			// present, `_migrate_progress` does not exist. `ensureLegacySourceColumns`
+			// unconditionally runs `ALTER TABLE pages ...` unless every legacy
+			// table's presence is checked first — resuming into this exact
+			// shape without that guard fails with `no such table: pages`.
+			const resumeOutputPath = path.resolve(workingDir, 'input.resume.0.13.nitpicker');
+			const workDir = deriveWorkDir(resumeOutputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: firstOutputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, resumeOutputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('legacy tables already dropped');
+			expect(existsSync(resumeOutputPath)).toBe(true);
+
+			const inspectDir = path.resolve(workingDir, 'inspect-post-drop-resume');
+			mkdirSync(inspectDir, { recursive: true });
+			await tar.x({ file: resumeOutputPath, cwd: inspectDir });
+			const innerDirName = await peekTarTopDir(resumeOutputPath);
+			const dbPath = path.resolve(inspectDir, innerDirName, 'db.sqlite');
+			const db = knex({
+				client: LibsqlDialect,
+				connection: { filename: dbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				const contentItemsCount = await db('content_items').count<{ n: number }[]>({
+					n: '*',
+				});
+				expect(Number(contentItemsCount[0]!.n)).toBe(2);
+				const infoRows = await db('info').select('version');
+				expect(infoRows.length).toBeGreaterThan(0);
+				for (const row of infoRows) {
+					expect(row.version).toBe('0.13.0');
+				}
+			} finally {
+				await db.destroy();
+			}
+		},
+	);
+
+	it(
+		'resume: refuses to silently reuse a work dir extracted from a different input',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPathA = path.resolve(workingDir, 'input-a.nitpicker');
+			const inputPathB = path.resolve(workingDir, 'input-b.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPathA);
+			buildFixtureArchive(inputPathB);
+			// Make B distinguishable from A's otherwise-identical fixture
+			// data: one extra legacy page, so B's final `content_items`
+			// count (3) differs from A's (2).
+			await mutateFixture(inputPathB, async (db) => {
+				await db('pages').insert({
+					url: 'https://example.com/extra-page',
+					scraped: true,
+					isTarget: true,
+				});
+			});
+
+			// Seed the work dir as if a prior (killed) run had already
+			// extracted A — the work dir's deterministic name is derived
+			// only from `outputPath`, so it is identical regardless of
+			// which input produced it.
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPathA,
+				workDir,
+				fingerprintSourcePath: inputPathA,
+			});
+
+			// Invoke the script with B as the input, same output path. A
+			// naive "work dir + untar-complete marker exists, skip untar"
+			// resume check would silently migrate A's stale data and
+			// produce an output that claims to be B's migration but isn't.
+			// The fingerprint mismatch must force a fresh extraction from
+			// the actual input argument instead.
+			const stdout = execFileSync('node', [migrateScript, inputPathB, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('does not match');
+			expect(stdout).toContain('[1/3] untar ');
+
+			const inspectDir = path.resolve(workingDir, 'inspect-fingerprint-mismatch');
+			mkdirSync(inspectDir, { recursive: true });
+			await tar.x({ file: outputPath, cwd: inspectDir });
+			const innerDirName = await peekTarTopDir(outputPath);
+			const dbPath = path.resolve(inspectDir, innerDirName, 'db.sqlite');
+			const db = knex({
+				client: LibsqlDialect,
+				connection: { filename: dbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				const contentItemsCount = await db('content_items').count<{ n: number }[]>({
+					n: '*',
+				});
+				// 3, not 2 — proves the output was built from B (the actual
+				// input argument), not from A (the work dir's stale contents).
+				expect(Number(contentItemsCount[0]!.n)).toBe(3);
+			} finally {
+				await db.destroy();
+			}
+		},
+	);
+
+	it(
+		'resume: a live lock on the work dir rejects a concurrent invocation',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			// Hold the lock with this test process's own (necessarily live)
+			// PID instead of racing two real subprocesses — deterministic,
+			// no timing window to get wrong.
+			const workDir = deriveWorkDir(outputPath);
+			const releaseLock = await acquireArchiveLock(workDir);
+			try {
+				let thrown: Error | null = null;
+				try {
+					execFileSync('node', [migrateScript, inputPath, outputPath], {
+						cwd: repoRoot,
+						stdio: 'pipe',
+					});
+				} catch (error) {
+					thrown = error as Error;
+				}
+				expect(thrown).not.toBeNull();
+				const stderr = (
+					(thrown as unknown as { stderr?: Buffer }).stderr ?? Buffer.from('')
+				).toString();
+				expect(stderr).toMatch(/Archive is being used by another process/);
+				expect(existsSync(outputPath)).toBe(false);
+			} finally {
+				await releaseLock();
+			}
+		},
+	);
+
+	it(
+		'resume: skips the entity-populate + verify step already recorded in _migrate_progress',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+			const innerDirName = await peekTarTopDir(inputPath);
+			const dbPath = path.resolve(workDir, innerDirName, 'db.sqlite');
+
+			// Pre-complete ref-table populate, entity-table populate, and
+			// verification exactly as the script itself would, then record
+			// `entity_and_verify` as done — reproducing the state a kill
+			// right after that step committed would leave behind.
+			const db = knex({
+				client: LibsqlDialect,
+				connection: { filename: dbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				await db.raw('PRAGMA foreign_keys = ON');
+				await migrateRefTables(db);
+				await migrateEntityTables(db);
+				await populateRefTables(db);
+				await populateEntityTables(db, noopDomPathResolver);
+				await verifyMigration(db);
+				await db.schema.createTable('_migrate_progress', (t) => {
+					t.string('step').primary();
+					t.string('completed_at').notNullable();
+				});
+				const completedAt = new Date().toISOString();
+				await db('_migrate_progress').insert(
+					[
+						'content_type_refs',
+						'url_refs',
+						'text_refs',
+						'json_refs',
+						'blob_refs',
+						'header_tables',
+						'entity_and_verify',
+					].map((step) => ({ step, completed_at: completedAt })),
+				);
+				await db.raw('PRAGMA wal_checkpoint(TRUNCATE)');
+			} finally {
+				await db.destroy();
+			}
+			for (const sidecar of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+				if (existsSync(sidecar)) rmSync(sidecar, { force: true });
+			}
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain(
+				'populate entity tables + verify: already done and already verified, skipping',
+			);
+			// The entity-populate transaction was not re-entered, so its own
+			// "verify migration invariants" line must not appear again.
+			expect(stdout).not.toContain('verify migration invariants');
+			expect(existsSync(outputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'resume: skips the adjunct FK retarget step already recorded in _migrate_progress',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+			const innerDirName = await peekTarTopDir(inputPath);
+			const dbPath = path.resolve(workDir, innerDirName, 'db.sqlite');
+
+			// Pre-complete everything through retarget, exactly as the script
+			// itself would, then record `retarget` as done — reproducing the
+			// state a kill right after that step committed would leave behind.
+			const db = knex({
+				client: LibsqlDialect,
+				connection: { filename: dbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				await db.raw('PRAGMA foreign_keys = ON');
+				await migrateRefTables(db);
+				await migrateEntityTables(db);
+				await populateRefTables(db);
+				await populateEntityTables(db, noopDomPathResolver);
+				await verifyMigration(db);
+				await createAdjunctTables(db);
+				await retargetLegacyFkTables(db);
+				await db.schema.createTable('_migrate_progress', (t) => {
+					t.string('step').primary();
+					t.string('completed_at').notNullable();
+				});
+				const completedAt = new Date().toISOString();
+				await db('_migrate_progress').insert(
+					[
+						'content_type_refs',
+						'url_refs',
+						'text_refs',
+						'json_refs',
+						'blob_refs',
+						'header_tables',
+						'entity_and_verify',
+						'retarget',
+					].map((step) => ({ step, completed_at: completedAt })),
+				);
+				await db.raw('PRAGMA wal_checkpoint(TRUNCATE)');
+			} finally {
+				await db.destroy();
+			}
+			for (const sidecar of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+				if (existsSync(sidecar)) rmSync(sidecar, { force: true });
+			}
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain(
+				'retarget adjunct FKs → content_items(id): already done, skipping',
+			);
+			expect(existsSync(outputPath)).toBe(true);
+
+			const inspectDir = path.resolve(workingDir, 'inspect-retarget-resume');
+			mkdirSync(inspectDir, { recursive: true });
+			await tar.x({ file: outputPath, cwd: inspectDir });
+			const outInnerDirName = await peekTarTopDir(outputPath);
+			const outDbPath = path.resolve(inspectDir, outInnerDirName, 'db.sqlite');
+			const outDb = knex({
+				client: LibsqlDialect,
+				connection: { filename: outDbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				for (const table of [
+					'page_html_ref',
+					'page_tags',
+					'page_jsonld',
+					'page_errors',
+				]) {
+					const parents = await fkParentTables(outDb, table);
+					expect(parents.has('content_items'), `${table} → content_items`).toBe(true);
+				}
+			} finally {
+				await outDb.destroy();
+			}
+		},
+	);
+
+	it(
+		'resume: skips the viewer read model build when its completion marker already exists',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			const firstOutputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			execFileSync('node', [migrateScript, inputPath, firstOutputPath], {
+				cwd: repoRoot,
+			});
+
+			// `.viewer-build-complete` lives at the work dir root, a sibling
+			// of the tarred inner directory — never part of the output tar —
+			// so it must be recreated by hand here to simulate a kill right
+			// after the viewer build committed.
+			const resumeOutputPath = path.resolve(
+				workingDir,
+				'input.resume-viewer.0.13.nitpicker',
+			);
+			const workDir = deriveWorkDir(resumeOutputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: firstOutputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+			writeFileSync(path.resolve(workDir, '.viewer-build-complete'), '');
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, resumeOutputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('build viewer read model: already done, skipping');
+			expect(existsSync(resumeOutputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'resume: treats a partial (inconsistent) legacy-table state as gone rather than crashing',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+			const innerDirName = await peekTarTopDir(inputPath);
+			const dbPath = path.resolve(workDir, innerDirName, 'db.sqlite');
+
+			// A state `dropLegacyTables` cannot produce today (it drops all
+			// five legacy tables together) but the LEGACY_TABLE_NAMES guard
+			// must still handle safely: entity/ref populate already done
+			// (so retarget has real `content_items` rows to point at) and
+			// one legacy table gone, while `pages` — which
+			// `ensureLegacySourceColumns` reads unconditionally when legacy
+			// tables are considered present — is still intact.
+			const db = knex({
+				client: LibsqlDialect,
+				connection: { filename: dbPath },
+				useNullAsDefault: true,
+			});
+			try {
+				await db.raw('PRAGMA foreign_keys = ON');
+				await migrateRefTables(db);
+				await migrateEntityTables(db);
+				await populateRefTables(db);
+				await populateEntityTables(db, noopDomPathResolver);
+				await verifyMigration(db);
+				await db.raw('PRAGMA foreign_keys = OFF');
+				await db.schema.dropTableIfExists('resources-referrers');
+				await db.raw('PRAGMA wal_checkpoint(TRUNCATE)');
+			} finally {
+				await db.destroy();
+			}
+			for (const sidecar of [`${dbPath}-wal`, `${dbPath}-shm`]) {
+				if (existsSync(sidecar)) rmSync(sidecar, { force: true });
+			}
+
+			// Must not crash with "no such table: pages" — the guard treats
+			// any missing legacy table as "cannot safely touch legacy
+			// tables" and skips straight past the legacy-dependent steps.
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('legacy tables already dropped');
+			expect(existsSync(outputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'resume: a completed-but-not-yet-cleaned-up prior run is finalized on the next invocation',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			execFileSync('node', [migrateScript, inputPath, outputPath], { cwd: repoRoot });
+			// The script deletes its own work dir on success; recreate one
+			// here to simulate a kill between the output rename and that
+			// final cleanup.
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('A previous run already completed successfully');
+			expect(existsSync(workDir)).toBe(false);
+			expect(existsSync(outputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'errors when the output already exists and no work dir remains to explain it',
+		{ timeout: 60_000 },
+		() => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+			execFileSync('node', [migrateScript, inputPath, outputPath], { cwd: repoRoot });
+
+			// The script already deleted its own work dir on success — this
+			// reproduces re-running against an output that exists for a
+			// reason the script cannot explain from its own state.
+			let thrown: Error | null = null;
+			try {
+				execFileSync('node', [migrateScript, inputPath, outputPath], {
+					cwd: repoRoot,
+					stdio: 'pipe',
+				});
+			} catch (error) {
+				thrown = error as Error;
+			}
+			expect(thrown).not.toBeNull();
+			const stderr = (
+				(thrown as unknown as { stderr?: Buffer }).stderr ?? Buffer.from('')
+			).toString();
+			expect(stderr).toContain('remove it first');
+		},
+	);
+
+	it(
+		'errors instead of guessing when the output exists alongside a work dir that does not match it',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPathA = path.resolve(workingDir, 'input-a.nitpicker');
+			const inputPathB = path.resolve(workingDir, 'input-b.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPathA);
+			buildFixtureArchive(inputPathB);
+
+			execFileSync('node', [migrateScript, inputPathA, outputPath], { cwd: repoRoot });
+			// Recreate a work dir as if an unrelated attempt against a
+			// different input (B) was killed right after finishing its own
+			// rename — from the script's perspective at start-up this looks
+			// identical to "output exists, work dir also exists", but the
+			// work dir does not actually belong to A.
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPathB,
+				workDir,
+				fingerprintSourcePath: inputPathB,
+			});
+
+			let thrown: Error | null = null;
+			try {
+				execFileSync('node', [migrateScript, inputPathA, outputPath], {
+					cwd: repoRoot,
+					stdio: 'pipe',
+				});
+			} catch (error) {
+				thrown = error as Error;
+			}
+			expect(thrown).not.toBeNull();
+			const stderr = (
+				(thrown as unknown as { stderr?: Buffer }).stderr ?? Buffer.from('')
+			).toString();
+			expect(stderr).toContain('does not match');
+			// The pre-existing output from A must be left untouched, not
+			// silently overwritten or deleted based on an unrelated work dir.
+			expect(existsSync(outputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'resume: removes a leftover .tmp output from a re-tar killed mid-write before starting',
+		{ timeout: 60_000 },
+		() => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			// Simulate a kill mid-re-tar: a stray `.tmp` file at the output
+			// path, but no real output yet.
+			writeFileSync(`${outputPath}.tmp`, 'partial tar bytes');
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('verification passed');
+			expect(existsSync(outputPath)).toBe(true);
+			expect(existsSync(`${outputPath}.tmp`)).toBe(false);
+		},
+	);
+
+	it(
+		'--skip-disk-check bypasses the startup disk-space estimate without breaking argument parsing',
+		{ timeout: 60_000 },
+		() => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			const stdout = execFileSync(
+				'node',
+				[migrateScript, inputPath, outputPath, '--skip-disk-check'],
+				{ cwd: repoRoot },
+			).toString();
+
+			expect(stdout).toContain('verification passed');
+			expect(existsSync(outputPath)).toBe(true);
+		},
+	);
+
+	it(
+		'resume: treats an unparseable fingerprint file as a mismatch and re-extracts',
+		{ timeout: 60_000 },
+		async () => {
+			const inputPath = path.resolve(workingDir, 'input.nitpicker');
+			const outputPath = path.resolve(workingDir, 'input.0.13.nitpicker');
+			buildFixtureArchive(inputPath);
+
+			const workDir = deriveWorkDir(outputPath);
+			await seedResumableWorkDir({
+				archiveToExtract: inputPath,
+				workDir,
+				fingerprintSourcePath: inputPath,
+			});
+			// Corrupt the fingerprint after seeding — simulates a write that
+			// was itself interrupted mid-flush.
+			writeFileSync(path.resolve(workDir, '.source-fingerprint.json'), '{not valid json');
+
+			const stdout = execFileSync('node', [migrateScript, inputPath, outputPath], {
+				cwd: repoRoot,
+			}).toString();
+
+			expect(stdout).toContain('does not match');
+			expect(stdout).toContain('[1/3] untar ');
+			expect(existsSync(outputPath)).toBe(true);
 		},
 	);
 });

--- a/packages/@nitpicker/crawler/src/archive/populate-ref-tables/populate-refs.ts
+++ b/packages/@nitpicker/crawler/src/archive/populate-ref-tables/populate-refs.ts
@@ -31,15 +31,22 @@ import { populateUrlRefs } from './populate-url-refs.js';
  *
  * Every sub-populate is independently idempotent via `INSERT OR IGNORE`
  * on its natural key. Running this orchestrator twice on the same archive
- * produces the same rows — no phase marker table is used. The whole
- * invocation is expected to run inside one writer
- * transaction with `.bak` protection at the caller level; this function
- * does not open its own transaction so the caller controls the boundary.
+ * produces the same rows — no phase marker table is used. This function
+ * does not open its own transaction so the caller controls the boundary;
+ * the whole invocation is expected to run inside one writer transaction
+ * with `.bak` protection at the caller level.
+ *
+ * `scripts/migrate-to-0.13.mjs` does NOT call this orchestrator directly
+ * — it calls the same six sub-populates itself, each in its own
+ * transaction, so a killed multi-hour migration only re-does the one
+ * table in flight on resume rather than the whole six-table batch. Use
+ * this function directly when that per-table checkpointing is not
+ * needed and a single all-or-nothing transaction is preferred.
  * @param trx - Knex instance or transaction connected to the archive DB.
  * @param onProgress - Optional sink threaded to every sub-populate for
  *   periodic progress lines; see {@link ../create-progress-reporter.ts}.
  * @example
- * // Typical migration-script use: connect via Archive, wrap in a
+ * // Single-transaction use: connect via Archive, wrap in a
  * // transaction, run every sub-step, then rely on the caller's `.bak`
  * // safety net if any step throws.
  * const archive = await Archive.open(archivePath);

--- a/scripts/migrate-to-0.13.mjs
+++ b/scripts/migrate-to-0.13.mjs
@@ -11,10 +11,12 @@
  * USAGE
  * -----
  *
- *     node scripts/migrate-to-0.13.mjs <old.nitpicker> [<new.nitpicker>]
+ *     node scripts/migrate-to-0.13.mjs <old.nitpicker> [<new.nitpicker>] [--skip-disk-check]
  *
  * If <new.nitpicker> is omitted, writes to `<old>.0.13.nitpicker` next
- * to the input.
+ * to the input. `--skip-disk-check` bypasses the startup disk-space
+ * estimate (see RESUMING AFTER A KILL below) for operators who have
+ * already confirmed enough free space by other means.
  *
  * WHAT IT DOES
  * ------------
@@ -25,14 +27,20 @@
  *    ref tables). Idempotent via `CREATE TABLE IF NOT EXISTS`. Also
  *    adds `pages.source` / `resources.source` when the input predates
  *    the `--inventory` feature — the entity populate copies `source`
- *    verbatim, so the columns must exist before it runs.
+ *    verbatim, so the columns must exist before it runs. Skipped
+ *    entirely once the legacy tables are gone (see step 6).
  * 2. **Ref-table populate** — populates every ref table (`url_refs`,
  *    `text_refs`, `json_refs`, `blob_refs`, `content_type_refs`,
- *    `header_*`) from the still-present pre-0.13 tables.
+ *    `header_*`) from the still-present pre-0.13 tables. Each of the
+ *    six sub-populates commits in its own transaction and records a
+ *    `_migrate_progress` row, so a kill partway through this step only
+ *    costs the one table in flight on the next run, not the whole step.
  * 3. **Entity-table populate** — populates the six entity / edge
  *    tables. All six run inside a single knex transaction so a failure
  *    aborts the whole step; SQLite's WAL rollback returns the DB to
- *    the pre-migration state.
+ *    the pre-migration state. A `_migrate_progress` row recorded in
+ *    the same transaction lets a resumed run skip this (potentially
+ *    multi-hour) step entirely once it has committed once.
  * 4. **Verification** — runs invariant checks against the populated
  *    archive. The check functions live in
  *    `packages/@nitpicker/crawler/src/archive/verify-migration/` and
@@ -49,13 +57,19 @@
  *    point at `content_items(id)` instead of the legacy `pages(id)`
  *    (SQLite has no `ALTER TABLE … DROP CONSTRAINT`). Runs with
  *    `PRAGMA foreign_keys = ON` so the data copy validates row-level
- *    integrity as it goes.
+ *    integrity as it goes. Recorded in `_migrate_progress` so a
+ *    resumed run skips it once done.
  * 6. **Legacy-table drop** — `dropLegacyTables` removes `pages` /
  *    `anchors` / `images` / `resources` / `resources-referrers`.
  *    Enforcement is switched OFF for this step: `pages.redirectDestId`
  *    is a self-FK that can make an enforced `DROP TABLE` fail on
  *    implicit-DELETE row order, and skipping the implicit DELETE lets
  *    SQLite truncate whole b-trees instead of deleting row by row.
+ *    `dropLegacyTables` is itself `DROP TABLE IF EXISTS`-based and
+ *    safe to call unconditionally on every run. Once the legacy tables
+ *    are gone, steps 1–4 are skipped on any subsequent run (see
+ *    RESUMING AFTER A KILL) — running them against a dropped `pages`
+ *    would fail outright, not silently no-op.
  * 7. **FK integrity check** — `checkForeignKeyIntegrity` asserts
  *    `PRAGMA foreign_key_check` reports zero violations against the
  *    final schema.
@@ -63,15 +77,59 @@
  *    subsequent CLI open passes `assertCompatibleVersion`. This is
  *    the single mechanism the reader side uses to detect "archive
  *    predates the current format" — no separate per-migration assert.
+ *    `_migrate_progress` is dropped immediately after so it never
+ *    ships in the output archive.
  * 9. **Viewer read model build** — `buildViewerReadModel` runs against
  *    the migrated archive so it opens in the viewer's fast path
  *    immediately, matching what a live crawl gets for free at crawl
  *    completion, instead of requiring a separate `viewer-build` run
- *    an operator has to remember.
- * 10. **Re-tar** the work dir to the output path. The input file is
+ *    an operator has to remember. A `.viewer-build-complete` sentinel
+ *    file next to the extracted archive (not a DB row — the DB's
+ *    `_migrate_progress` is already gone by this point) lets a
+ *    resumed run skip a repeat build.
+ * 10. **Re-tar** the work dir to `<output>.tmp`, then rename it to the
+ *    final output path. The rename is the commit point: a kill during
+ *    the tar write leaves only a `.tmp` file behind, never a
+ *    half-written file at the real output path. The input file is
  *    never touched, so it doubles as the rollback artefact — keep it
  *    until the migrated output has been verified in real use
  *    (issue #197 recommends ≥ 30 days).
+ *
+ * RESUMING AFTER A KILL
+ * ---------------------
+ *
+ * A large archive's migration can run for hours; this script is built
+ * to survive a `SIGKILL` (OOM, operator `kill -9`, terminal closed)
+ * partway through and pick back up close to where it left off on the
+ * next invocation with the same arguments:
+ *
+ * - The work dir is named after the *output* path only (no PID), so a
+ *   re-invocation resolves to the same directory a killed run used.
+ * - The work dir is only removed on a fully successful run. A kill —
+ *   or any thrown error — leaves it in place for the next attempt.
+ * - Untar only runs once: completion is marked by a
+ *   `.untar-complete` sentinel file in the work dir (not the presence
+ *   of `db.sqlite`, which can exist in a truncated, unusable state if
+ *   the kill landed mid-extraction). Without the sentinel the work dir
+ *   is wiped and re-extracted from scratch.
+ * - An advisory lock (`acquireArchiveLock`, the same mechanism
+ *   `Archive.resume` uses) on the work dir stops two invocations
+ *   against the same output from clobbering each other; a lock left
+ *   by a killed process is reclaimed automatically once its PID is
+ *   confirmed dead.
+ * - Every phase from step 2 onward is checkpointed (`_migrate_progress`
+ *   table rows, committed in the same transaction as the phase itself,
+ *   or the `.viewer-build-complete` file for the one step that runs
+ *   after `_migrate_progress` is dropped) so a resumed run skips
+ *   whatever already committed instead of redoing it.
+ * - If the legacy tables (`pages` etc.) are already gone — the kill
+ *   landed after step 6 — steps 1–4 are skipped outright rather than
+ *   attempted against tables that no longer exist.
+ * - A startup disk-space check estimates the peak usage (roughly
+ *   input-size × 2 for a fresh run, × 1.2 for a resume where the work
+ *   dir already exists) against the output volume's free space and
+ *   refuses to start if it looks insufficient, rather than running for
+ *   hours and failing on `ENOSPC`. Pass `--skip-disk-check` to bypass.
  *
  * DOM-PATH DERIVATION
  * -------------------
@@ -110,21 +168,37 @@
 
 /* eslint-disable no-console, import-x/no-extraneous-dependencies */
 
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	statfsSync,
+	writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
 import knex from 'knex';
 import * as tar from 'tar';
 
+import { acquireArchiveLock } from '../packages/@nitpicker/crawler/lib/archive/archive-lock.js';
 import Archive from '../packages/@nitpicker/crawler/lib/archive/archive.js';
 import { createAdjunctTables } from '../packages/@nitpicker/crawler/lib/archive/create-adjunct-tables.js';
 import { dropLegacyTables } from '../packages/@nitpicker/crawler/lib/archive/drop-legacy-tables.js';
+import { rename } from '../packages/@nitpicker/crawler/lib/archive/filesystem/rename.js';
 import { LibsqlDialect } from '../packages/@nitpicker/crawler/lib/archive/libsql-dialect.js';
 import { migrateEntityTables } from '../packages/@nitpicker/crawler/lib/archive/migrate-entity-tables.js';
 import { migrateRefTables } from '../packages/@nitpicker/crawler/lib/archive/migrate-ref-tables.js';
 import { populateEntityTables } from '../packages/@nitpicker/crawler/lib/archive/populate-entity-tables/populate-entities.js';
-import { populateRefTables } from '../packages/@nitpicker/crawler/lib/archive/populate-ref-tables/populate-refs.js';
+import { populateBlobRefs } from '../packages/@nitpicker/crawler/lib/archive/populate-ref-tables/populate-blob-refs.js';
+import { populateContentTypeRefs } from '../packages/@nitpicker/crawler/lib/archive/populate-ref-tables/populate-content-type-refs.js';
+import { populateHeaderTables } from '../packages/@nitpicker/crawler/lib/archive/populate-ref-tables/populate-header-tables.js';
+import { populateJsonRefs } from '../packages/@nitpicker/crawler/lib/archive/populate-ref-tables/populate-json-refs.js';
+import { populateTextRefs } from '../packages/@nitpicker/crawler/lib/archive/populate-ref-tables/populate-text-refs.js';
+import { populateUrlRefs } from '../packages/@nitpicker/crawler/lib/archive/populate-ref-tables/populate-url-refs.js';
 import { retargetLegacyFkTables } from '../packages/@nitpicker/crawler/lib/archive/retarget-legacy-fk-tables.js';
 import { checkForeignKeyIntegrity } from '../packages/@nitpicker/crawler/lib/archive/verify-migration/check-foreign-key-integrity.js';
 import { verifyMigration } from '../packages/@nitpicker/crawler/lib/archive/verify-migration/verify-migration.js';
@@ -133,9 +207,25 @@ import { buildViewerReadModel } from '../packages/@nitpicker/query/lib/viewer-re
 import { createDomPathResolver } from './create-dom-path-resolver.mjs';
 
 const SQLITE_DB_FILE_NAME = 'db.sqlite';
+const UNTAR_COMPLETE_MARKER = '.untar-complete';
+const VIEWER_BUILD_COMPLETE_MARKER = '.viewer-build-complete';
+const SOURCE_FINGERPRINT_FILE = '.source-fingerprint.json';
+
+/** `_migrate_progress` step names, shared between the writer (`markStepComplete`) and the reader (`hasCompletedStep`) call sites so a typo in one can't silently drift out of sync with the other and leave a step re-running forever without ever surfacing as an error. */
+const STEP_ENTITY_AND_VERIFY = 'entity_and_verify';
+const STEP_RETARGET = 'retarget';
+
+/** The five legacy write-model tables `dropLegacyTables` removes together in one transaction — checking all five (not just `pages`) keeps the "are the legacy tables gone" guard correct even if a future change makes the drop itself resumable in separate steps. */
+const LEGACY_TABLE_NAMES = [
+	'pages',
+	'anchors',
+	'images',
+	'resources',
+	'resources-referrers',
+];
 
 /**
- * `onProgress` sink threaded into `populateRefTables` / `populateEntityTables`
+ * `onProgress` sink threaded into the ref-table sub-populates / `populateEntityTables`
  * (see `packages/@nitpicker/crawler/src/archive/create-progress-reporter.ts`).
  * Each sub-populate reports at most once per ~5% of its source table
  * scanned, so a multi-million-row table produces ~20 lines total instead
@@ -150,10 +240,12 @@ function logProgress(message) {
  * Entry point.
  */
 async function main() {
-	const [inputArg, outputArg] = process.argv.slice(2);
+	const positional = process.argv.slice(2).filter((arg) => !arg.startsWith('--'));
+	const skipDiskCheck = process.argv.includes('--skip-disk-check');
+	const [inputArg, outputArg] = positional;
 	if (!inputArg) {
 		console.error(
-			'Usage: node scripts/migrate-to-0.13.mjs <old.nitpicker> [<new.nitpicker>]',
+			'Usage: node scripts/migrate-to-0.13.mjs <old.nitpicker> [<new.nitpicker>] [--skip-disk-check]',
 		);
 		process.exit(1);
 	}
@@ -169,28 +261,82 @@ async function main() {
 		console.error(`Input not found: ${inputPath}`);
 		process.exit(1);
 	}
-	if (existsSync(outputPath)) {
+
+	const workDir = path.resolve(
+		path.dirname(outputPath),
+		`._migrate-to-0.13-${path.basename(outputPath, path.extname(outputPath))}`,
+	);
+	const tmpOutputPath = `${outputPath}.tmp`;
+
+	if (existsSync(outputPath) && !existsSync(workDir)) {
 		console.error(`Output already exists: ${outputPath} — remove it first`);
 		process.exit(1);
 	}
 
-	const workDir = path.resolve(
-		path.dirname(outputPath),
-		`._migrate-to-0.13-${process.pid}-${path.basename(inputPath, path.extname(inputPath))}`,
-	);
-	if (existsSync(workDir)) {
-		console.error(`Stale work dir present: ${workDir} — remove it first`);
-		process.exit(1);
-	}
-	mkdirSync(workDir, { recursive: true });
+	// Acquire the lock before inspecting workDir's contents (or deciding
+	// the run below is already complete) so two concurrent invocations
+	// against the same output can't both decide "not yet extracted" and
+	// race to untar into it, and so a still-running process's work dir
+	// can never be mistaken for leftover-after-success debris. A lock
+	// held by a killed process (stale PID) is reclaimed automatically;
+	// one held by a live process surfaces as an `ArchiveLockError` here.
+	const releaseLock = await acquireArchiveLock(workDir);
 
 	const startedAt = Date.now();
 	try {
-		console.log(`[1/3] untar ${inputPath} -> ${workDir}`);
-		await tar.x({ file: inputPath, cwd: workDir });
+		if (existsSync(outputPath)) {
+			// Now that the lock is ours, no other process is actively
+			// working on this pair. Confirm the work dir actually belongs to
+			// THIS input before trusting that — a prior run against a
+			// different input file at the same output path would otherwise
+			// look identical from here (see `sourceFingerprintMatches`).
+			if (!sourceFingerprintMatches(workDir, inputPath)) {
+				console.error(
+					`Output already exists: ${outputPath} — remove it first. ` +
+						`(A work dir also exists at ${workDir}, but it does not match ${inputPath} — ` +
+						`inspect both manually before proceeding.)`,
+				);
+				process.exit(1);
+			}
+			// A prior run must have finished the rename but been killed
+			// before its own cleanup. The migration itself already
+			// succeeded; clean up and exit successfully instead of erroring
+			// "remove it first" on a file that is, in fact, the correct
+			// finished output.
+			console.log(`Output already exists: ${outputPath}`);
+			console.log(
+				'A previous run already completed successfully — cleaning up and exiting.',
+			);
+			rmSync(workDir, { recursive: true, force: true });
+			return;
+		}
+		if (existsSync(tmpOutputPath)) {
+			// Leftover from a re-tar killed mid-write; never a valid output.
+			rmSync(tmpOutputPath, { force: true });
+		}
 
-		const innerDirName = findInnerDir(workDir);
-		const extractedDir = path.join(workDir, innerDirName);
+		let isResuming = existsSync(path.join(workDir, UNTAR_COMPLETE_MARKER));
+		if (isResuming && !sourceFingerprintMatches(workDir, inputPath)) {
+			console.log(
+				`  work dir exists but does not match ${inputPath} (different file, or the ` +
+					`original was renamed/replaced) — starting fresh instead of resuming`,
+			);
+			isResuming = false;
+		}
+		checkDiskSpace(path.dirname(outputPath), inputPath, isResuming, skipDiskCheck);
+
+		if (isResuming) {
+			console.log(`[1/3] resuming existing work dir (skip untar): ${workDir}`);
+		} else {
+			rmSync(workDir, { recursive: true, force: true });
+			mkdirSync(workDir, { recursive: true });
+			console.log(`[1/3] untar ${inputPath} -> ${workDir}`);
+			await tar.x({ file: inputPath, cwd: workDir });
+			writeSourceFingerprint(workDir, inputPath);
+			writeFileSync(path.join(workDir, UNTAR_COMPLETE_MARKER), '');
+		}
+		const extractedDir = path.join(workDir, findInnerDir(workDir));
+
 		const dbPath = path.join(extractedDir, SQLITE_DB_FILE_NAME);
 		if (!existsSync(dbPath)) {
 			throw new Error(`Missing ${SQLITE_DB_FILE_NAME} in input archive`);
@@ -199,8 +345,14 @@ async function main() {
 		console.log('[2/3] apply 0.13 migration migrations');
 		await applyMigrations(dbPath);
 
-		console.log('  build viewer read model');
-		await buildArchiveViewerReadModel(extractedDir);
+		const viewerBuildMarker = path.join(workDir, VIEWER_BUILD_COMPLETE_MARKER);
+		if (existsSync(viewerBuildMarker)) {
+			console.log('  build viewer read model: already done, skipping');
+		} else {
+			console.log('  build viewer read model');
+			await buildArchiveViewerReadModel(extractedDir);
+			writeFileSync(viewerBuildMarker, '');
+		}
 
 		// libsql leaves -wal / -shm sidecars after close — remove them so
 		// the re-tar contains a clean single-file db.sqlite.
@@ -209,17 +361,77 @@ async function main() {
 		}
 
 		console.log(`[3/3] tar -> ${outputPath}`);
-		await tar.c({ file: outputPath, cwd: workDir, portable: true }, [innerDirName]);
+		await tar.c({ file: tmpOutputPath, cwd: workDir, portable: true }, [
+			path.basename(extractedDir),
+		]);
+		await rename(tmpOutputPath, outputPath, false);
 
 		console.log(`Done. (${formatElapsed(Date.now() - startedAt)})`);
+		rmSync(workDir, { recursive: true, force: true });
 	} catch (error) {
-		if (existsSync(outputPath)) {
-			rmSync(outputPath, { force: true });
-		}
+		console.error(
+			`Migration failed. The work dir was preserved for a resumed attempt: ${workDir}\n` +
+				`  - Re-run the exact same command to resume.\n` +
+				`  - To discard the partial progress instead, run: rm -rf ${workDir}`,
+		);
 		throw error;
 	} finally {
-		rmSync(workDir, { recursive: true, force: true });
+		await releaseLock();
 	}
+}
+
+/**
+ * Estimates the peak disk usage this script needs on the output volume
+ * and aborts before any work starts if the volume looks too full. The
+ * estimate is deliberately generous rather than exact: a fresh run
+ * needs room for both the extracted work dir (roughly input-sized, plus
+ * growth from the new entity/ref tables and WAL churn during the
+ * entity-populate transaction) and the final output tar alongside it,
+ * so `input size × 2` approximates the worst case. A resumed run
+ * (`isResuming`) already has the work dir on disk — it only needs room
+ * for the output tar plus headroom for continued DB growth, hence the
+ * smaller `× 1.2` multiplier.
+ *
+ * This is a coarse guard, not a guarantee (actual growth depends on the
+ * archive's data shape) — `--skip-disk-check` lets an operator who has
+ * independently confirmed enough free space bypass it.
+ * @param {string} outputDir - Directory the output (and work dir) live in.
+ * @param {string} inputPath - Path to the input `.nitpicker` archive.
+ * @param {boolean} isResuming - Whether an already-extracted work dir is being reused.
+ * @param {boolean} skip - Whether to bypass the check entirely.
+ */
+function checkDiskSpace(outputDir, inputPath, isResuming, skip) {
+	if (skip) {
+		return;
+	}
+	const inputSize = statSync(inputPath).size;
+	const requiredBytes = Math.ceil(inputSize * (isResuming ? 1.2 : 2));
+	const stats = statfsSync(outputDir);
+	const availableBytes = stats.bavail * stats.bsize;
+	if (availableBytes < requiredBytes) {
+		// Thrown rather than `process.exit()`ed so the caller's `finally`
+		// still releases the work dir lock — nothing has been written yet
+		// at this point, so there is no partial state to preserve either.
+		throw new Error(
+			`Insufficient disk space in ${outputDir}: need ~${formatBytes(requiredBytes)}, ` +
+				`have ${formatBytes(availableBytes)} available. Free up space, or pass ` +
+				`--skip-disk-check if you have independently confirmed there is enough room.`,
+		);
+	}
+}
+
+/**
+ * Formats a byte count as a rough `<N> GB`/`MB` string for the disk-space
+ * error message — not meant for precision, just enough for an operator
+ * to judge the shortfall at a glance.
+ * @param {number} bytes
+ */
+function formatBytes(bytes) {
+	const gb = bytes / 1024 ** 3;
+	if (gb >= 1) {
+		return `${gb.toFixed(1)} GB`;
+	}
+	return `${(bytes / 1024 ** 2).toFixed(0)} MB`;
 }
 
 /**
@@ -253,13 +465,15 @@ function formatElapsed(ms) {
  * cross-script coupling for a 20-line predicate.
  *
  * Skips macOS AppleDouble (`._*`) sidecar files that BSD tar embeds and
- * Node's `tar` library surfaces verbatim.
+ * Node's `tar` library surfaces verbatim, and the sentinel files this
+ * script itself writes at the work dir root (`.untar-complete`,
+ * `.viewer-build-complete`).
  * @param {string} workDir
  * @returns {string} Inner directory basename.
  */
 function findInnerDir(workDir) {
 	const candidates = readdirSync(workDir).filter((name) => {
-		if (name.startsWith('._')) return false;
+		if (name.startsWith('.')) return false;
 		const stat = statSync(path.join(workDir, name));
 		return stat.isDirectory();
 	});
@@ -278,11 +492,143 @@ function findInnerDir(workDir) {
 }
 
 /**
+ * Records `inputPath`'s size and mtime in `workDir` right after a fresh
+ * untar. `workDir` is named only from the *output* path (see `main()`), so
+ * a resumed run's `.untar-complete` sentinel alone cannot tell "this work
+ * dir was extracted from the exact input given this time" from "this work
+ * dir happens to sit at the path this output would use, but was extracted
+ * from a different input archive entirely" — e.g. the same output path
+ * re-run against a different source file after a kill. Content hashing
+ * would be unambiguous but prohibitively slow to redo on every resumed
+ * invocation of a multi-gigabyte archive; size + mtime is cheap (a single
+ * `stat` call) and enough to catch "wrong file", while still matching
+ * across a plain rename (which preserves both) — renaming a `.nitpicker`
+ * after the fact is a normal, expected operation (see `peekTarTopDir`'s
+ * own doc comment).
+ * @param {string} workDir
+ * @param {string} inputPath
+ */
+function writeSourceFingerprint(workDir, inputPath) {
+	const stat = statSync(inputPath);
+	writeFileSync(
+		path.join(workDir, SOURCE_FINGERPRINT_FILE),
+		JSON.stringify({ size: stat.size, mtimeMs: stat.mtimeMs }),
+	);
+}
+
+/**
+ * Whether `workDir`'s recorded source fingerprint (see
+ * {@link writeSourceFingerprint}) matches `inputPath` as it stands now.
+ * Returns `false` — never throws — when the fingerprint file is missing
+ * (e.g. a work dir left by a version of this script that predates the
+ * fingerprint) so callers can treat a missing/mismatched fingerprint
+ * uniformly as "cannot trust this work dir belongs to this input".
+ * @param {string} workDir
+ * @param {string} inputPath
+ * @returns {boolean}
+ */
+function sourceFingerprintMatches(workDir, inputPath) {
+	const fingerprintPath = path.join(workDir, SOURCE_FINGERPRINT_FILE);
+	if (!existsSync(fingerprintPath)) {
+		return false;
+	}
+	/** @type {{ size: number, mtimeMs: number }} */
+	let recorded;
+	try {
+		recorded = JSON.parse(readFileSync(fingerprintPath, 'utf8'));
+	} catch {
+		return false;
+	}
+	const stat = statSync(inputPath);
+	return recorded.size === stat.size && recorded.mtimeMs === stat.mtimeMs;
+}
+
+/**
+ * Records that `step` has completed by inserting a row into
+ * `_migrate_progress`. Called from inside the same transaction as the
+ * step's own writes so the marker and the data it describes commit
+ * atomically — there is no window where one is visible without the
+ * other.
+ * @param {import('knex').Knex} trx
+ * @param {string} step
+ */
+async function markStepComplete(trx, step) {
+	await trx('_migrate_progress')
+		.insert({ step, completed_at: new Date().toISOString() })
+		.onConflict('step')
+		.ignore();
+}
+
+/**
+ * Whether `step` was already recorded as complete by {@link markStepComplete}
+ * in a prior (possibly killed) run. Every call site treats a `true` result
+ * as license to skip potentially expensive work (a multi-million-row
+ * re-scan, a multi-hour entity populate) — reads outside any transaction
+ * are safe here because callers only ever check this after their own
+ * schema-catch-up step has already run, by which point `_migrate_progress`
+ * reflects every transaction committed by a prior invocation.
+ * @param {import('knex').Knex} db
+ * @param {string} step
+ * @returns {Promise<boolean>}
+ */
+async function hasCompletedStep(db, step) {
+	const row = await db('_migrate_progress').where({ step }).first();
+	return row != null;
+}
+
+/**
+ * The six ref-table sub-populates in the fixed order
+ * `populateRefTables` (`packages/@nitpicker/crawler/src/archive/populate-ref-tables/populate-refs.ts`)
+ * documents: dictionary tables first, header tables last. Called
+ * directly (bypassing that shared orchestrator) so each sub-populate
+ * can commit — and checkpoint — independently; `populateRefTables`
+ * itself is left unchanged since its other callers rely on it running
+ * inside one caller-supplied transaction.
+ * @type {{ step: string, run: (trx: import('knex').Knex) => Promise<void> }[]}
+ */
+const REF_TABLE_STEPS = [
+	{ step: 'content_type_refs', run: (trx) => populateContentTypeRefs(trx) },
+	{ step: 'url_refs', run: (trx) => populateUrlRefs(trx, logProgress) },
+	{ step: 'text_refs', run: (trx) => populateTextRefs(trx, logProgress) },
+	{ step: 'json_refs', run: (trx) => populateJsonRefs(trx, logProgress) },
+	{ step: 'blob_refs', run: (trx) => populateBlobRefs(trx, logProgress) },
+	{ step: 'header_tables', run: (trx) => populateHeaderTables(trx, logProgress) },
+];
+
+/**
+ * Runs each ref-table sub-populate in its own transaction, skipping any
+ * step already recorded as complete in `_migrate_progress`. Every
+ * sub-populate is independently idempotent via `INSERT OR IGNORE` on
+ * its natural key, so re-running an already-complete step would also
+ * be safe — the marker exists purely to skip the (potentially
+ * multi-million-row) re-scan on a resumed run, not for correctness.
+ * @param {import('knex').Knex} db
+ */
+async function populateRefTableSteps(db) {
+	for (const { step, run } of REF_TABLE_STEPS) {
+		if (await hasCompletedStep(db, step)) {
+			console.log(`  populate ${step}: already done, skipping`);
+			continue;
+		}
+		await db.transaction(async (trx) => {
+			await run(trx);
+			await markStepComplete(trx, step);
+		});
+	}
+}
+
+/**
  * Opens the extracted `db.sqlite` and applies every 0.13 migration step:
  * schema catch-up, populate refs, populate entities, verify invariants,
- * and finally bump `info.version` to `0.13.0`. Populate + verify run
- * inside a single knex transaction so the whole batch either commits or
- * rolls back on failure.
+ * retarget + drop legacy tables, and finally bump `info.version` to
+ * `0.13.0`.
+ *
+ * If the legacy tables (`pages` / `resources` / `anchors` / `images`)
+ * are already gone — meaning a prior run already reached the drop step
+ * before being killed — the legacy-dependent steps (source-column
+ * backfill, ref populate, entity populate + verify) are skipped
+ * outright rather than attempted: they read from tables that no longer
+ * exist and would fail, not silently no-op.
  * @param {string} dbPath - Path to the extracted `db.sqlite`.
  */
 async function applyMigrations(dbPath) {
@@ -294,43 +640,75 @@ async function applyMigrations(dbPath) {
 	try {
 		await db.raw('PRAGMA journal_mode = WAL');
 		await db.raw('PRAGMA foreign_keys = ON');
+		await db.schema.createTableIfNotExists('_migrate_progress', (t) => {
+			t.string('step').primary();
+			t.string('completed_at').notNullable();
+		});
 
 		console.log('  ensure ref tables');
 		await migrateRefTables(db);
 		console.log('  ensure entity tables');
 		await migrateEntityTables(db);
-		await ensureLegacySourceColumns(db);
 
-		console.log('  populate ref tables');
-		await db.transaction(async (trx) => {
-			await populateRefTables(trx, logProgress);
-		});
-
-		console.log('  populate entity tables');
-		const domPathResolver = createDomPathResolver();
-		/** @type {import('../packages/@nitpicker/crawler/lib/archive/verify-migration/types.js').MigrationVerificationSummary} */
-		let summary;
-		await db.transaction(async (trx) => {
-			await populateEntityTables(trx, domPathResolver, logProgress);
-			console.log('  verify migration invariants');
-			summary = await verifyMigration(trx);
-		});
-		console.log(
-			`  verification passed — content_items=${summary.contentItems}, ` +
-				`page_meta=${summary.pageMeta}, anchor_edges=${summary.anchorEdges} ` +
-				`(sum count=${summary.anchorEdgesSum}), image_items=${summary.imageItems}, ` +
-				`resource_items=${summary.resourceItems}`,
+		// `.every` rather than a single `hasTable('pages')`: the legacy
+		// dependent steps below (`ensureLegacySourceColumns`, ref/entity
+		// populate) must only run when every legacy table they might touch
+		// is confirmed present. `dropLegacyTables` removes all five in one
+		// transaction today so partial-drop can't happen in practice, but
+		// checking all five (not just `pages`) keeps this guard correct even
+		// if a future change splits the drop into separate steps.
+		const legacyTablePresence = await Promise.all(
+			LEGACY_TABLE_NAMES.map((table) => db.schema.hasTable(table)),
 		);
+		const legacyTablesPresent = legacyTablePresence.every(Boolean);
+		/** @type {import('../packages/@nitpicker/crawler/lib/archive/verify-migration/types.js').MigrationVerificationSummary | undefined} */
+		let summary;
+		if (legacyTablesPresent) {
+			await ensureLegacySourceColumns(db);
+
+			console.log('  populate ref tables');
+			await populateRefTableSteps(db);
+
+			console.log('  populate entity tables');
+			if (await hasCompletedStep(db, STEP_ENTITY_AND_VERIFY)) {
+				console.log(
+					'  populate entity tables + verify: already done and already verified, skipping',
+				);
+			} else {
+				const domPathResolver = createDomPathResolver();
+				await db.transaction(async (trx) => {
+					await populateEntityTables(trx, domPathResolver, logProgress);
+					console.log('  verify migration invariants');
+					summary = await verifyMigration(trx);
+					await markStepComplete(trx, STEP_ENTITY_AND_VERIFY);
+				});
+				console.log(
+					`  verification passed — content_items=${summary.contentItems}, ` +
+						`page_meta=${summary.pageMeta}, anchor_edges=${summary.anchorEdges} ` +
+						`(sum count=${summary.anchorEdgesSum}), image_items=${summary.imageItems}, ` +
+						`resource_items=${summary.resourceItems}`,
+				);
+			}
+		} else {
+			console.log(
+				'  legacy tables already dropped (resumed past that point) — skipping source-column backfill and ref/entity populate',
+			);
+		}
 
 		console.log('  ensure adjunct tables');
 		await createAdjunctTables(db);
 
 		// Retarget under enforcement so the data copy validates every
 		// pageId / page_id against content_items row by row.
-		console.log('  retarget adjunct FKs → content_items(id)');
-		await db.transaction(async (trx) => {
-			await retargetLegacyFkTables(trx);
-		});
+		if (await hasCompletedStep(db, STEP_RETARGET)) {
+			console.log('  retarget adjunct FKs → content_items(id): already done, skipping');
+		} else {
+			console.log('  retarget adjunct FKs → content_items(id)');
+			await db.transaction(async (trx) => {
+				await retargetLegacyFkTables(trx);
+				await markStepComplete(trx, STEP_RETARGET);
+			});
+		}
 
 		// The drop runs with enforcement OFF: `pages.redirectDestId` is a
 		// self-FK that can fail an enforced DROP TABLE's implicit DELETE on
@@ -340,6 +718,9 @@ async function applyMigrations(dbPath) {
 		// this is a separate transaction from the retarget above — safe
 		// because the whole mutation happens in the extracted work dir and
 		// the output tar is only produced when every step has succeeded.
+		// `dropLegacyTables` is `DROP TABLE IF EXISTS`-based, so calling it
+		// unconditionally on every run (including ones where the legacy
+		// tables are already gone) is safe and cheap.
 		console.log(
 			'  drop legacy tables (pages/anchors/images/resources/resources-referrers)',
 		);
@@ -384,6 +765,14 @@ async function applyMigrations(dbPath) {
 			);
 		}
 		await db('info').update({ version: '0.13.0' });
+
+		// Drop the internal checkpoint table now that every DB-level step
+		// is done — it must never ship in the output archive. The
+		// remaining step (viewer read model build) checkpoints via a
+		// work-dir sentinel file instead (see VIEWER_BUILD_COMPLETE_MARKER
+		// in main()), not a DB row, precisely so it can still be resumed
+		// after this DROP.
+		await db.raw('DROP TABLE IF EXISTS _migrate_progress');
 
 		await db.raw('PRAGMA wal_checkpoint(TRUNCATE)');
 	} finally {


### PR DESCRIPTION
## Summary

- Makes `scripts/migrate-to-0.13.mjs` resumable across a process kill. A large archive's migration can run for hours; previously a `SIGKILL` (OOM, operator `kill -9`, terminal closed) discarded all progress because the work dir was named after the process PID (never reusable on restart) and unconditionally deleted in a `finally` block.
- Work dir is now named deterministically from the output path, with an `.untar-complete` sentinel marking a genuinely finished extraction (not just `db.sqlite`'s presence, which can exist truncated if the kill landed mid-extraction).
- A `.source-fingerprint.json` (size + mtime) prevents a resumed run from silently mixing in a *different* input archive at the same output path — found and fixed during review, this was a real data-correctness bug in the first draft.
- Ref-table populate is split into 6 independently-committed transactions with a `_migrate_progress` checkpoint table, so a kill partway through only re-does the one table in flight, not the whole multi-million-row batch. Entity-populate+verify and the adjunct FK retarget get the same per-phase checkpoint.
- A legacy-table-presence guard (checks all 5 tables, not just `pages`) skips legacy-dependent steps outright once those tables are confirmed dropped — otherwise a resume landing after the drop step crashes with `no such table: pages`.
- Re-tar now writes to `<output>.tmp` and renames into place (reusing the existing `rename` helper), so a killed re-tar never leaves a half-written file at the real output path.
- Reuses the existing `acquireArchiveLock` (the same mechanism `Archive.resume` uses) so two concurrent invocations against the same output can't clobber each other; a lock left by a killed process is reclaimed automatically.
- Adds a startup disk-space estimate (`statfsSync`, roughly input-size × 2 fresh / × 1.2 resumed) with a `--skip-disk-check` escape hatch, rather than running for hours and failing on `ENOSPC`.

## Test plan

- [x] `yarn build` / `yarn lint` (0 errors) / `yarn test` — 468 files / 3322 tests passed, 4 skipped
- [x] 16 new integration tests in `migrate-to-0.13-script.spec.ts` (4 → 20), all constructing resumed states directly (no real kills, no test-only env-var hooks) per this repo's testing conventions:
  - untar-skip resume, incomplete-untar cleanup, ref-table partial resume, entity-populate+verify skip, adjunct-retarget skip, viewer-build skip, drop-completed regression, partial/inconsistent legacy-table state, completed-but-uncleaned success path, output-exists-no-workdir error, output-exists-mismatched-workdir error, `.tmp` cleanup, `--skip-disk-check` smoke test, unparseable-fingerprint fallback, concurrent-lock rejection, plus a dedicated regression test for the different-input mix-up bug found during review
- [x] Existing happy-path/failure-path tests extended: `_migrate_progress` absent from final output, work dir preserved on failure
- [x] Code review (8 parallel finder angles) → 1 confirmed correctness bug (input-identity mix-up across resumed runs) fixed with a fingerprint check, plus 7 cleanup/consistency findings fixed
- [x] QA pass → found 7 untested branches in the resumability logic itself (the PR's core purpose); all now covered
- [x] Product-manager pass → ARCHITECTURE.md and JSDoc consistency confirmed, two low-priority doc polish items applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
