### PR TITLE
chore(repo): standardize renovate, yarn settings and add the npm-publish skill

### DIFF
--- a/.claude/skills/npm-publish/SKILL.md
+++ b/.claude/skills/npm-publish/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: npm-publish
+description: npm パッケージのリリース（dev→main マージ、バージョニング、tag push、publish workflow 監視、publish 結果検証、dev への同期）
+when_to_use: ユーザーが「リリースして」「publish して」「バージョン上げて」「/npm-publish」と指示した場合
+disable-model-invocation: true
+---
+
+# 前提
+
+- リリースは `main` ブランチから行う。`dev` の変更を `main` にマージしてから実行する
+- `v*` タグ push で `publish.yml` が発火し、npm へ自動 publish される（OIDC Trusted Publishing）
+- **publish は取り消せない**。各ステップでユーザーの確認を取る
+- **`yarn release` / `git push` 系はユーザーが実行する**。エージェントは実行せず（`.claude/settings.json` で deny されている）`!` プレフィックス付きのコマンドを提示し、完了報告を待つ
+
+# 対象パッケージ
+
+Lerna **fixed モード**のため、全パッケージが同一バージョンで上がる。
+
+| npm パッケージ名                  |
+| --------------------------------- |
+| `@nitpicker/analyze-axe`          |
+| `@nitpicker/analyze-lighthouse`   |
+| `@nitpicker/analyze-markuplint`   |
+| `@nitpicker/analyze-search`       |
+| `@nitpicker/analyze-textlint`     |
+| `@nitpicker/cli`                  |
+| `@nitpicker/core`                 |
+| `@nitpicker/crawler`              |
+| `@nitpicker/mcp-server`           |
+| `@nitpicker/query`                |
+| `@nitpicker/report-google-sheets` |
+| `@nitpicker/types`                |
+| `@nitpicker/viewer`               |
+
+`packages/test-server` は `private: true` なので publish されない。バージョンは上がるが npm には出ない。
+
+# 手順
+
+## 1. ワーキングツリーの状態確認
+
+`git status` で未コミットの変更・未追跡ファイルがないか確認する。
+
+- クリーンなら次へ
+- 変更があればユーザーに報告し、`git stash` / コミット / 中断のいずれかを尋ねる。指示に従ってから次へ
+
+`.nitpicker` アーカイブや `._*` の作業ファイルは gitignore 済みなので無視してよい。汚れたまま先に進むとマージ・バージョニングが意図しない差分を巻き込むため、追跡対象の変更は必ず処理する。
+
+## 2. main と dev の最新化
+
+```bash
+git fetch origin
+git checkout main
+git pull origin main
+git checkout dev
+git pull origin dev
+git checkout main
+```
+
+両ブランチをローカルで最新にしてから `main` に戻る。`dev` を最新にしておくのは、手順 11 の `main` → `dev` 同期でそのまま使うため。
+
+いずれかの `pull` が失敗したらユーザーに報告して指示を仰ぐ。
+
+## 3. 未マージ PR の確認
+
+リリースに含めるべき PR が残っていないか確認し、あればユーザーに提示して続行可否を尋ねる。
+
+```bash
+gh pr list --base dev --state open
+```
+
+## 4. dev → main マージ
+
+`dev` が `main` より進んでいる場合、差分コミットをユーザーに提示してからマージする。
+
+```bash
+git log --oneline main..dev
+git merge dev --no-edit
+```
+
+コンフリクトが発生したらユーザーに報告して指示を仰ぐ。
+
+## 5. lockfile の同期確認
+
+```bash
+yarn install
+git diff yarn.lock
+```
+
+差分が出たらユーザーに報告し、コミットしてから次へ。CI の `yarn install --immutable` が失敗するのを防ぐため必須。
+
+## 6. 事前チェック
+
+```bash
+yarn lint
+yarn build
+yarn test
+```
+
+すべてパスすること。E2E も確認する場合は `yarn vitest run --config vitest.e2e.config.ts` を別途実行する。`main` の CI が green かも併せて確認する。
+
+```bash
+gh run list --branch main --limit 5
+```
+
+## 7. リリース内容の提示
+
+現在のバージョンと前回タグからの差分をユーザーに提示し、リリース種別（graduate / alpha / beta / rc）の判断材料にする。
+
+```bash
+git describe --tags --abbrev=0
+git log --oneline $(git describe --tags --abbrev=0)..HEAD
+```
+
+fixed モードなので `lerna.json` の `version` が現行バージョンの正。
+
+## 8. バージョニングと push（ユーザー実行）
+
+`lerna version` はインタラクティブなため Claude からは実行できない。リリース種別を確認したうえで、`!` プレフィックス付きでユーザーに実行を依頼し、**完了報告を待つ**。
+
+```
+! yarn release          # graduate（正式リリース）
+! yarn release:alpha    # alpha プレリリース
+! yarn release:beta     # beta プレリリース
+! yarn release:rc       # RC プレリリース
+```
+
+リリーススクリプトは `--no-push` なので、**コミットとタグの push が別途必要**。
+
+```
+! git push origin main --follow-tags
+```
+
+ユーザーから完了報告を受けたら、実際にタグが push されたことを確認してから次へ進む。
+
+```bash
+git ls-remote --tags origin
+```
+
+## 9. publish workflow の監視
+
+`v*` タグ push で `publish.yml` が発火する。バックグラウンド実行で完了を待つ。
+
+```bash
+gh run watch --exit-status
+```
+
+失敗したらログ URL をユーザーに提示し、「12. 失敗時の対処」へ。
+
+## 10. publish 結果の検証
+
+workflow が success でも publish が意図通りとは限らない。**全パッケージについて**実際の npm 上の状態を確認する。
+
+```bash
+npm view @nitpicker/core version
+npm view @nitpicker/core dist-tags
+```
+
+確認項目:
+
+- バージョンが手順 8 で上げた値と一致しているか
+- **dist-tag が意図通りか**。正式リリースは `latest`、プレリリースは `alpha` / `beta` / `rc` / `next`。`publish.yml` は `lerna.json` の `version` 文字列から判定する（`-alpha` → `alpha`、`-` を含む → `next`、それ以外 → `latest`）
+- provenance が付与されているか（`npm view <package> --json` の `dist.attestations`）
+
+fixed モードでも**一部のパッケージだけ publish される（部分 publish）**ことがある。上表の13パッケージを個別に確認し、漏れがあればユーザーに報告する。
+
+**ここが success の判定点**。npm 上の状態を確認するまでリリース完了と判断してはいけない。
+
+## 11. main → dev の同期
+
+publish の成功を確認した後、バージョン更新コミットを `dev` に取り込む。
+
+```bash
+git checkout dev
+git merge main --no-edit
+```
+
+コンフリクトが発生したらユーザーに報告して指示を仰ぐ。マージできたら push をユーザーに依頼する。
+
+```
+! git push origin dev
+```
+
+`dev` はブランチ保護がかかっており、`maintain` ロールでは直接 push できない場合がある。push が拒否されたら PR 経由に切り替える（`git checkout -b chore/sync-main` してから `/pr` の手順へ）。
+
+## 12. 失敗時の対処
+
+- **sigstore の transient 409**: `gh run rerun` で再実行する。`from-package` は未 publish のバージョンのみを対象にするため、成功済みパッケージは二重 publish されない
+- **部分 publish**: 成功したパッケージは publish 済みで巻き戻せない。`workflow_dispatch` で publish workflow を再実行すれば、未 publish のパッケージのみが対象になる
+- **誤ったバージョンを publish した**: unpublish は原則不可。`npm deprecate <package>@<version> "<理由>"` で非推奨化し、修正版を新バージョンとして publish する。この判断は必ずユーザーに確認を取る
+- **publish が失敗したまま中断する場合**: 手順 11 の `dev` 同期は行わない。`main` にバージョン更新コミットだけが残るため、次回リリース時にそこから再開する
+
+# 注意
+
+- **`v*` タグの作成・削除は CODEOWNERS のみ**（GitHub Rulesets で保護）。権限がない場合は手順 8 で失敗するため、実行者がタグ権限者か事前に確認する
+- **publish は取り消せない**。手順 5・6 の事前チェックを省略しない
+- **`.yarnrc.yml` の `npmMinimalAgeGate` を一時的に外していないか確認する**。自社パッケージの取り込みのためにコメントアウトしたまま publish すると、保護が外れた状態がリリースに固定される

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,17 +1,52 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"],
+	"configMigration": true,
+	"extends": [
+		"config:recommended",
+		"docker:pinDigests",
+		"helpers:pinGitHubActionDigests",
+		":pinDevDependencies",
+		":semanticCommitTypeAll(chore)"
+	],
+	"timezone": "Asia/Tokyo",
+	"schedule": ["* 22-23,0-4 * * 1-5"],
 	"rangeStrategy": "pin",
 	"minimumReleaseAge": "7 days",
+	"internalChecksFilter": "strict",
+	"osvVulnerabilityAlerts": true,
+	"vulnerabilityAlerts": {
+		"minimumReleaseAge": null
+	},
+	"autoApprove": true,
+	"labels": ["Dependencies", "Renovate"],
 	"lockFileMaintenance": {
 		"enabled": true,
 		"automerge": true,
-		"schedule": ["before 6am on monday"]
+		"schedule": ["* 0-5 * * 1"]
 	},
 	"packageRules": [
 		{
+			"matchDepTypes": ["optionalDependencies"],
+			"addLabels": ["Dependencies: Optional"]
+		},
+		{
+			"matchDepTypes": ["devDependencies"],
+			"addLabels": ["Dependencies: Development"]
+		},
+		{
+			"matchDepTypes": ["dependencies"],
+			"addLabels": ["Dependencies: Production"]
+		},
+		{
+			"description": "Automerge non-major updates, except for 0.x where minor is breaking",
 			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"matchCurrentVersion": "!/^0/",
 			"automerge": true
+		},
+		{
+			"description": "Keep yarn resolutions on auto range strategy",
+			"matchDepTypes": ["resolutions"],
+			"rangeStrategy": "auto"
 		},
 		{
 			"groupName": "puppeteer",

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,16 @@ nodeLinker: node-modules
 npmRegistryServer: 'https://registry.npmjs.org'
 enableGlobalCache: true
 
+# 依存パッケージの install / postinstall スクリプトを実行しない。
+# サプライチェーン攻撃の主要経路（悪意ある postinstall による任意コード実行）を
+# 塞ぐ。Yarn 4 では個別の allow-list ができないため全か無かの設定。
+enableScripts: false
+
+# `yarn add` でバージョンを固定する（`^` / `~` を付けない）。
+# Renovate 側の `rangeStrategy: pin` と対になる設定で、片方だけだと手動追加と
+# Renovate 更新でバージョン表記が混ざる。
+defaultSemverRangePrefix: ''
+
 # npm publish 後 7 日経過していないパッケージを依存解決から除外する
 # サプライチェーン保護。typosquatting や即時 takedown が走ったパッケージを
 # 取り込まないためのセーフティガード。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,21 @@ yarn lint                                          # lint + prettier + cspell
 - **パッケージディレクトリに cd しない**: 常にリポジトリルートから実行する
 - **コマンドの連続実行禁止**: `&&` / `;` / 改行連結をしない。1 回の実行で 1 コマンドのみ（permissions のパターンマッチを守るため）
 
+## 依存関係の追加
+
+- バージョンは固定で追加する（`yarn add foo@1.2.3`）。`^` / `~` を付けない（`.yarnrc.yml` の `defaultSemverRangePrefix: ''` で既定化されている）
+- **追加したら `.github/renovate.json` の `packageRules` を確認する**。そのパッケージが既存の `groupName` グループに入るべきか、新しいグループを作るべきかを判断する
+  - `config:recommended` は `group:monorepos` を含むため、**同一 monorepo から公開されるパッケージ群（`@puppeteer/*`、`@tanstack/*`、`@testing-library/*` など）は設定なしで自動的に束ねられる**。手で書く必要はない
+  - 手当てが必要なのは Renovate が推測できない**ベンダー横断の結合**:
+    - 本体と型定義のペア（`debug` + `@types/debug`）。DefinitelyTyped は別リポジトリで公開されるため自動グループ化されない
+    - peer dependency で結ばれた別ベンダーのパッケージ
+    - `resolutions` で固定しているパッケージとその利用側（現在は `google-auth-library`）
+    - 自前の `@d-zero/*` パッケージ群（configs と runtime で分ける）
+    - 併用が前提のツール群（`lighthouse` + `chrome-launcher`、`knex` + `libsql` など）
+  - 判断基準は「**片方だけバージョンが上がった状態でビルドと型チェックが通るか**」。通らないなら同じ `groupName` にまとめる
+- グループ化を怠ると、Renovate が個別に PR を作り、片方だけマージされた中間状態で CI が赤になる。結果として**両方の PR がマージできなくなる**
+- グルーピングの現状は `git branch -r --list 'origin/renovate/*'` で確認できる。`*-monorepo` サフィックスのブランチは `group:monorepos` による自動グループ
+
 ## ドキュメント原則
 
 情報は置き場で役割が決まる。**コードには How、テストコードには What、コミットログには Why、コードコメントには Why not**（Why が必要なときは Why も書く）。
@@ -81,14 +96,15 @@ yarn lint                                          # lint + prettier + cspell
 
 ## スキル
 
-| スキル          | パス                                      | 用途                                                     |
-| --------------- | ----------------------------------------- | -------------------------------------------------------- |
-| Product Manager | `.claude/skills/product-manager/SKILL.md` | リポジトリ分析、ドキュメント整合チェック、PR レビュー    |
-| QA Engineer     | `.claude/skills/qa-engineer/SKILL.md`     | コードレビュー、テスト品質チェック                       |
-| Impl            | `.claude/skills/impl/SKILL.md`            | 合意済み計画の実装・検証・PR 作成のオーケストレーション  |
-| Grill me        | `.claude/skills/grill-me/SKILL.md`        | 計画・設計の前提を掘り下げて合意形成する                 |
-| Git             | `.claude/skills/git/SKILL.md`             | コミット規約・コミット前コンテンツチェック               |
-| PR              | `.claude/skills/pr/SKILL.md`              | PR 作成フロー（base 追従・push はユーザー実行・CI 監視） |
+| スキル          | パス                                      | 用途                                                            |
+| --------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| Product Manager | `.claude/skills/product-manager/SKILL.md` | リポジトリ分析、ドキュメント整合チェック、PR レビュー           |
+| QA Engineer     | `.claude/skills/qa-engineer/SKILL.md`     | コードレビュー、テスト品質チェック                              |
+| Impl            | `.claude/skills/impl/SKILL.md`            | 合意済み計画の実装・検証・PR 作成のオーケストレーション         |
+| Grill me        | `.claude/skills/grill-me/SKILL.md`        | 計画・設計の前提を掘り下げて合意形成する                        |
+| Git             | `.claude/skills/git/SKILL.md`             | コミット規約・コミット前コンテンツチェック                      |
+| PR              | `.claude/skills/pr/SKILL.md`              | PR 作成フロー（base 追従・push はユーザー実行・CI 監視）        |
+| npm publish     | `.claude/skills/npm-publish/SKILL.md`     | リリース（dev→main マージ・バージョニング・publish 監視・検証） |
 
 ## AI 操作プロトコル
 


### PR DESCRIPTION
## 概要

Renovate 設定・Yarn 設定・Claude Code スキルを D-Zero 標準に揃えます。実装コードには触れていません（差分は設定とドキュメントのみ）。

BurgerEditor v4 で先行して適用した内容（[BurgerEditor#827](https://github.com/d-zero-dev/BurgerEditor/pull/827)）を、このリポジトリの実態に合わせて反映したものです。

## Renovate 設定を `.github/` へ移動し、共通ベースを適用

Renovate は `renovate.json` → `renovate.json5` → `.github/renovate.json` の順で探し、**最初に見つかった1ファイルしか読みません**。ルート配置でも動いてはいましたが、配置場所を `.github/renovate.json` に統一しておかないと、将来 `.github/` 側にファイルが増えたときに黙って無視される構成になります。

移動にあわせて共通ベースを適用しました。

| 追加した設定 | 意図 |
|---|---|
| `configMigration` | プリセットが deprecated になったとき Renovate が移行 PR を出す（`config:base` のような取り残しを防ぐ） |
| `docker:pinDigests` / `helpers:pinGitHubActionDigests` | イメージと Actions を digest 固定。可変タグの差し替え攻撃を防ぐ |
| `:pinDevDependencies` / `:semanticCommitTypeAll(chore)` | 依存更新のコミット種別を統一 |
| `timezone` + `schedule` | 平日夜間（JST）に PR 作成。日中の CI 枠を空ける |
| `lockFileMaintenance.schedule` | 月曜未明に lockfile 再生成 |
| `internalChecksFilter: strict` | `minimumReleaseAge` を満たさない更新が緩和されて混ざらないようにする |
| `osvVulnerabilityAlerts` | OSV の脆弱性情報を使う |
| `vulnerabilityAlerts.minimumReleaseAge: null` | **脆弱性修正だけは7日待たない** |
| `autoApprove` + ラベル | Renovate が review をバイパスできるブランチ保護設定と対で機能する |
| `resolutions` を pin 除外 | resolutions は範囲指定に意味があるため |

あわせて **0.x の automerge を止めました**（`matchCurrentVersion: "!/^0/"`）。semver は 0.x の minor に破壊的変更を許すため、major と同様に人の目を通します。

既存の `groupName` グループは変更していません。このリポジトリのどの依存が一緒に動くべきかという知識がそこに入っているためです。

## Yarn 設定

### `enableScripts: false`

依存の install / postinstall を実行しません。悪意ある postinstall による任意コード実行という、サプライチェーン攻撃の主要経路を塞ぎます。Yarn 4 は個別の allow-list ができないため全か無かの設定です。

build script を持つ依存は `nx` / `puppeteer` / `simple-wappalyzer` / `unrs-resolver` の4つです。**特に puppeteer の postinstall は Chrome のダウンロードなので、クローラーである本リポジトリでは影響を確認する必要がありました。**

結論として問題ありません。

- `e2e.yml` は既に `PUPPETEER_SKIP_DOWNLOAD: 'true'` を設定し、`PUPPETEER_EXECUTABLE_PATH` でランナー同梱の Chrome を指しています。「このランナーでは puppeteer のダウンロードが空フォルダを作るだけの no-op になる」とコメントにも明記されています
- ローカルにもブラウザキャッシュ（`~/.cache/puppeteer`）が存在せず、`PUPPETEER_*` 環境変数も未設定でした。つまり**この変更以前から postinstall は使えるブラウザを供給していません**

puppeteer のダウンロードに依存していた場合は、明示的にインストールするか CI と同様に `PUPPETEER_EXECUTABLE_PATH` でシステム Chrome を指してください。

### `defaultSemverRangePrefix: ''`

`yarn add` がバージョンを固定します。Renovate の `rangeStrategy: pin` と対になる設定で、片方だけだと手動追加と Renovate 更新でバージョン表記が混ざります。

## npm-publish スキルの追加

リリース手順はこれまでオーケストレーションディレクトリ側にあり、**このリポジトリの worktree で作業中には呼べませんでした**。リポジトリ内に移します。

本リポジトリの実態に合わせて記述しています。

- fixed モード、publish 対象13パッケージ（`packages/test-server` は `private: true` なので対象外）
- リリーススクリプトが `--no-push` なので、tag push が別ステップであることを明示
- 最後に npm 側の実状態（version / dist-tag / provenance）をパッケージごとに検証して完了とする。**workflow の success は publish プロセスが正常終了したことしか保証せず、dist-tag の誤りも部分 publish も green のまま起きる**ため

## CLAUDE.md に「依存関係の追加」節を追加

`groupName` の判断は `yarn add` のたびに発生するので、毎セッション読まれる場所に判断基準を置きました。

`config:recommended` が `group:monorepos` を含むため、同一 monorepo 由来（`@puppeteer/*`、`@tanstack/*` 等）は設定なしで自動的に束ねられます。手で書くべきなのは Renovate が推測できないベンダー横断の結合だけです。判断基準は「**片方だけバージョンが上がった状態でビルドと型チェックが通るか**」。

## 検証

| 検証 | 結果 |
|---|---|
| `yarn install` | 成功 |
| `yarn build` | 13パッケージ成功 |
| `yarn test` | **516ファイル / 3678テスト 全通過**（58秒） |
| `yarn lint` | 成功（cspell 1427ファイル、0 issue） |
| `yarn.lock` | 差分なし |

E2E（`vitest.e2e.config.ts`）は未実行です。CI での実行を待ちます。
