### PR TITLE
feat: fail fast when Chrome is missing before crawl

### DIFF
--- a/packages/@nitpicker/cli/docs/crawl.md
+++ b/packages/@nitpicker/cli/docs/crawl.md
@@ -12,6 +12,19 @@ npx @nitpicker/cli crawl --resume <stub-dir>
 
 複数URLを渡すと、それぞれがクロール起点かつスコープエントリになります。スコープは `(hostname, port, path)` で判定されます。
 
+## 前提条件: Puppeteer用Chrome
+
+`crawl`（`--diff` を除く全モード）はPuppeteer経由でヘッドレスChromeを起動します。環境（npmのinstall-scriptブロック方針、`unzip` 等の展開ツール不在、ネットワーク制限など）によってはpostinstallでのChrome自動ダウンロードが行われないことがあります。
+
+Chromeが見つからない場合、クロールが実際にページを取得し始める前に以下のようなエラーで即座に停止します。
+
+```
+Error: Chrome executable not found at: <解決されたパス>
+Run `npx puppeteer@<pinned-version> browsers install chrome` to install the Chrome build Puppeteer expects, then retry.
+```
+
+案内された通り、表示された `npx puppeteer@<version> browsers install chrome` コマンドをそのまま実行すればインストールできます。
+
 ## 通常クロール
 
 ```sh

--- a/packages/@nitpicker/cli/docs/pipeline.md
+++ b/packages/@nitpicker/cli/docs/pipeline.md
@@ -17,6 +17,8 @@ npx @nitpicker/cli pipeline https://example.com --sheet <Google Sheets URL> --al
 
 `--sheet` を指定した場合だけ `report` ステップを実行します。指定しない場合は `crawl` と `analyze` までを実行します。
 
+crawlステップの前提条件（Puppeteer用Chromeが必要）は [crawl の前提条件](./crawl.md#前提条件-puppeteer用chrome) を参照してください。
+
 ## オプション一覧
 
 ### crawl系

--- a/packages/@nitpicker/cli/src/commands/crawl.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/crawl.spec.ts
@@ -15,6 +15,7 @@ const mockAppend = vi.fn();
 const mockRetryFailed = vi.fn();
 const mockInventory = vi.fn();
 const mockComputeFileSha256 = vi.fn(() => 'd'.repeat(64));
+const mockAssertChromeIsInstalled = vi.fn().mockResolvedValue();
 
 vi.mock('@nitpicker/crawler', () => ({
 	CrawlerOrchestrator: {
@@ -25,6 +26,7 @@ vi.mock('@nitpicker/crawler', () => ({
 		inventory: mockInventory,
 	},
 	computeFileSha256: mockComputeFileSha256,
+	assertChromeIsInstalled: mockAssertChromeIsInstalled,
 }));
 
 const mockEventAssignments = vi.fn().mockResolvedValue();
@@ -1033,6 +1035,47 @@ describe('crawl', () => {
 				createFlags({ inventory: '/tmp/urls.txt', single: true }),
 			),
 		).rejects.toThrow('--inventory cannot be combined with --single');
+	});
+
+	it('クロール開始前に assertChromeIsInstalled を呼び出す', async () => {
+		const { crawl } = await import('./crawl.js');
+		await crawl(['https://example.com'], createFlags());
+
+		expect(mockAssertChromeIsInstalled).toHaveBeenCalled();
+		expect(mockAssertChromeIsInstalled.mock.invocationCallOrder[0]).toBeLessThan(
+			mockCrawling.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	it('assertChromeIsInstalled が失敗した場合、クロールを開始せずエラーを伝播する', async () => {
+		mockAssertChromeIsInstalled.mockRejectedValueOnce(
+			new Error('Chrome executable not found at: /fake/chrome'),
+		);
+		const { crawl } = await import('./crawl.js');
+
+		await expect(crawl(['https://example.com'], createFlags())).rejects.toThrow(
+			'Chrome executable not found at: /fake/chrome',
+		);
+		expect(mockCrawling).not.toHaveBeenCalled();
+	});
+
+	it('--diff モードでは assertChromeIsInstalled を呼ばない', async () => {
+		const { crawl } = await import('./crawl.js');
+		await crawl(['a.nitpicker', 'b.nitpicker'], createFlags({ diff: true }));
+
+		expect(mockAssertChromeIsInstalled).not.toHaveBeenCalled();
+	});
+
+	it('--resume モードでも assertChromeIsInstalled が失敗すればクロールを開始しない', async () => {
+		mockAssertChromeIsInstalled.mockRejectedValueOnce(
+			new Error('Chrome executable not found at: /fake/chrome'),
+		);
+		const { crawl } = await import('./crawl.js');
+
+		await expect(crawl([], createFlags({ resume: '/tmp/stub' }))).rejects.toThrow(
+			'Chrome executable not found at: /fake/chrome',
+		);
+		expect(mockResume).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/@nitpicker/cli/src/commands/crawl.ts
+++ b/packages/@nitpicker/cli/src/commands/crawl.ts
@@ -5,7 +5,11 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { readList, toListWithPosition } from '@d-zero/readtext/list';
-import { computeFileSha256, CrawlerOrchestrator } from '@nitpicker/crawler';
+import {
+	assertChromeIsInstalled,
+	computeFileSha256,
+	CrawlerOrchestrator,
+} from '@nitpicker/crawler';
 
 import { classifyInventoryListItems } from '../crawl/classify-inventory-list-items.js';
 import { log, verbosely } from '../crawl/debug.js';
@@ -514,6 +518,10 @@ function validateUrls(urls: readonly string[]) {
  * 5. `--retry-failed` mode: Re-fetches failed pages in an existing archive
  * 6. `--list-file` / `--list` mode: Crawls a pre-defined URL list (non-recursive)
  * 7. Default mode: Crawls from one or more root URLs
+ *
+ * Every mode except `--diff` launches a browser, so
+ * {@link assertChromeIsInstalled} runs once up front and fails fast if
+ * Chrome is missing, rather than letting it surface per-page.
  * @param args - Positional arguments (typically one or two URLs/file paths)
  * @param flags - Parsed CLI flags from the `crawl` command
  * @returns A promise that resolves when the dispatched mode completes.
@@ -557,6 +565,12 @@ export async function crawl(args: string[], flags: CrawlFlags) {
 	}
 
 	try {
+		// Every mode below launches a browser per URL; failing this once,
+		// up front, turns a missing Chrome into an immediate fatal error
+		// instead of a per-page scrape error buried in a "completed with
+		// N error(s)" summary (see `assertChromeIsInstalled`'s JSDoc).
+		await assertChromeIsInstalled();
+
 		if (flags.resume) {
 			if (flags.output) {
 				throw new Error(

--- a/packages/@nitpicker/cli/src/commands/pipeline.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/pipeline.spec.ts
@@ -1,5 +1,6 @@
 import type { CrawlerError } from '@nitpicker/crawler';
 
+import { assertChromeIsInstalled } from '@nitpicker/crawler';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 
 import { ExitCode } from '../exit-code.js';
@@ -15,6 +16,10 @@ vi.mock('./crawl.js', () => {
 		startCrawl: vi.fn(),
 	};
 });
+
+vi.mock('@nitpicker/crawler', () => ({
+	assertChromeIsInstalled: vi.fn(),
+}));
 
 vi.mock('./analyze.js', () => ({
 	analyze: vi.fn(),
@@ -390,5 +395,29 @@ describe('pipeline command', () => {
 			['https://example.com'],
 			expect.objectContaining({ strict: true }),
 		);
+	});
+
+	it('crawl 開始前に assertChromeIsInstalled を呼び出す', async () => {
+		vi.mocked(startCrawlFn).mockResolvedValue('/tmp/site.nitpicker');
+		vi.mocked(analyzeFn).mockResolvedValue();
+
+		await pipeline(['https://example.com'], defaultFlags);
+
+		expect(assertChromeIsInstalled).toHaveBeenCalled();
+		expect(vi.mocked(assertChromeIsInstalled).mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(startCrawlFn).mock.invocationCallOrder[0]!,
+		);
+	});
+
+	it('assertChromeIsInstalled が失敗した場合、crawl を開始せずエラーを伝播する', async () => {
+		vi.mocked(assertChromeIsInstalled).mockRejectedValueOnce(
+			new Error('Chrome executable not found at: /fake/chrome'),
+		);
+
+		await expect(pipeline(['https://example.com'], defaultFlags)).rejects.toThrow(
+			'Chrome executable not found at: /fake/chrome',
+		);
+		expect(startCrawlFn).not.toHaveBeenCalled();
+		expect(analyzeFn).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@nitpicker/cli/src/commands/pipeline.ts
+++ b/packages/@nitpicker/cli/src/commands/pipeline.ts
@@ -1,5 +1,7 @@
 import type { CommandDef, InferFlags } from '@d-zero/roar';
 
+import { assertChromeIsInstalled } from '@nitpicker/crawler';
+
 import { ExitCode } from '../exit-code.js';
 import { formatCliError } from '../format-cli-error.js';
 
@@ -214,6 +216,10 @@ export async function pipeline(args: string[], flags: PipelineFlags) {
 
 	let archivePath: string;
 	try {
+		// Fails fast if Chrome is missing, before the crawl step does any
+		// archive I/O — see `assertChromeIsInstalled`'s JSDoc.
+		await assertChromeIsInstalled();
+
 		archivePath = await startCrawl([siteUrl], {
 			interval: flags.interval,
 			image: flags.image,

--- a/packages/@nitpicker/crawler/src/crawler.ts
+++ b/packages/@nitpicker/crawler/src/crawler.ts
@@ -65,6 +65,7 @@ export type { NetworkProbe } from './crawler/probe-network.js';
 export { probeNetwork } from './crawler/probe-network.js';
 export { computeOutageClampTimestamp } from './archive/db-ops/outages/compute-outage-clamp-timestamp.js';
 export { chooseProbeHost } from './crawler/choose-probe-host.js';
+export { assertChromeIsInstalled } from './crawler/assert-chrome-installed.js';
 export { computeFileSha256 } from './utils/compute-file-sha256.js';
 
 // 0.13 ref-table population (issue #191, epic #103). Exposed as the

--- a/packages/@nitpicker/crawler/src/crawler/assert-chrome-installed.spec.ts
+++ b/packages/@nitpicker/crawler/src/crawler/assert-chrome-installed.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import pkg from '../../package.json' with { type: 'json' };
+
+const mockExistsSync = vi.fn();
+const mockExecutablePath = vi.fn();
+
+vi.mock('node:fs', () => ({
+	existsSync: (...args: unknown[]) => mockExistsSync(...args),
+}));
+
+vi.mock('puppeteer', () => ({
+	executablePath: (...args: unknown[]) => mockExecutablePath(...args),
+}));
+
+describe('assertChromeIsInstalled', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('明示的な executablePath が存在すれば解決される（puppeteer は呼ばれない）', async () => {
+		const { assertChromeIsInstalled } = await import('./assert-chrome-installed.js');
+		mockExistsSync.mockReturnValue(true);
+
+		await expect(assertChromeIsInstalled('/opt/chrome/chrome')).resolves.toBeUndefined();
+		expect(mockExecutablePath).not.toHaveBeenCalled();
+	});
+
+	it('明示的な executablePath が存在しなければ、そのパスを含むエラーを投げる', async () => {
+		const { assertChromeIsInstalled } = await import('./assert-chrome-installed.js');
+		mockExistsSync.mockReturnValue(false);
+
+		await expect(assertChromeIsInstalled('/opt/chrome/missing')).rejects.toThrow(
+			'Executable path does not exist: /opt/chrome/missing',
+		);
+	});
+
+	it('executablePath 未指定時、puppeteer が解決したパスが存在すれば解決される', async () => {
+		const { assertChromeIsInstalled } = await import('./assert-chrome-installed.js');
+		mockExecutablePath.mockReturnValue(
+			'/home/user/.cache/puppeteer/chrome/linux-1.2.3/chrome',
+		);
+		mockExistsSync.mockReturnValue(true);
+
+		await expect(assertChromeIsInstalled()).resolves.toBeUndefined();
+	});
+
+	it('executablePath が null の場合も puppeteer のデフォルト解決にフォールバックする', async () => {
+		const { assertChromeIsInstalled } = await import('./assert-chrome-installed.js');
+		mockExecutablePath.mockReturnValue(
+			'/home/user/.cache/puppeteer/chrome/linux-1.2.3/chrome',
+		);
+		mockExistsSync.mockReturnValue(true);
+
+		await expect(assertChromeIsInstalled(null)).resolves.toBeUndefined();
+	});
+
+	it('puppeteer が解決したパスが存在しなければ、インストールコマンドを含むエラーを投げる', async () => {
+		const { assertChromeIsInstalled } = await import('./assert-chrome-installed.js');
+		mockExecutablePath.mockReturnValue(
+			'/home/user/.cache/puppeteer/chrome/linux-1.2.3/chrome',
+		);
+		mockExistsSync.mockReturnValue(false);
+
+		const error = await assertChromeIsInstalled().catch(
+			(error_: unknown) => error_ as Error,
+		);
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(
+			'Chrome executable not found at: /home/user/.cache/puppeteer/chrome/linux-1.2.3/chrome',
+		);
+		expect((error as Error).message).toContain(
+			`npx puppeteer@${pkg.dependencies.puppeteer} browsers install chrome`,
+		);
+	});
+});

--- a/packages/@nitpicker/crawler/src/crawler/assert-chrome-installed.ts
+++ b/packages/@nitpicker/crawler/src/crawler/assert-chrome-installed.ts
@@ -1,0 +1,53 @@
+import type { CrawlerOptions } from './types.js';
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import pkg from '../../package.json' with { type: 'json' };
+
+/**
+ * Verifies that Puppeteer can resolve an installed Chrome/Chromium executable
+ * before a crawl starts.
+ *
+ * A crawl otherwise only discovers a missing browser deep inside the
+ * per-URL scrape loop (`Crawler#_launchBrowserAndScrape`), where it surfaces
+ * as one more scrape error among many — the CLI still prints "Crawl
+ * completed" and writes an archive, so a missing Chrome (a fatal
+ * precondition, not a per-page failure) is easy to miss. Calling this once,
+ * before any archive I/O begins, turns it into an immediate, actionable
+ * failure instead.
+ * @param executablePath - Explicit override, matching
+ *   {@link CrawlerOptions.executablePath}. Pass `null` (or omit) to check
+ *   Puppeteer's own pinned Chrome resolution instead.
+ * @throws {Error} When the resolved executable path does not exist on disk.
+ * @example
+ * ```ts
+ * import { assertChromeIsInstalled } from '@nitpicker/crawler';
+ *
+ * // Throws with install instructions before any crawl work starts.
+ * await assertChromeIsInstalled();
+ * ```
+ */
+export async function assertChromeIsInstalled(
+	executablePath?: string | null,
+): Promise<void> {
+	if (executablePath) {
+		const execPath = path.resolve(executablePath);
+		if (existsSync(execPath)) {
+			return;
+		}
+		throw new Error(`Executable path does not exist: ${execPath}`);
+	}
+
+	const puppeteer = await import('puppeteer');
+	const resolvedPath = await puppeteer.executablePath();
+	if (existsSync(resolvedPath)) {
+		return;
+	}
+
+	const puppeteerVersion = pkg.dependencies.puppeteer;
+	throw new Error(
+		`Chrome executable not found at: ${resolvedPath}\n` +
+			`Run \`npx puppeteer@${puppeteerVersion} browsers install chrome\` to install the Chrome build Puppeteer expects, then retry.`,
+	);
+}


### PR DESCRIPTION
## Summary

- Add `assertChromeIsInstalled` to `@nitpicker/crawler`, which verifies Puppeteer can resolve an installed Chrome executable and throws an actionable error (including the exact `npx puppeteer@<pinned-version> browsers install chrome` command) when it cannot.
- Call it up front in both `crawl()` and `pipeline()`, before any archive I/O, so a missing Chrome stops the run immediately instead of surfacing as a per-page scrape error buried in a "completed with N error(s)" summary.
- Document the new precondition and error message in `docs/crawl.md`, with a cross-reference from `docs/pipeline.md`.

## Why

Under recent npm versions, dependency install scripts (including Puppeteer's own Chrome download) are blocked by default unless explicitly allow-listed. When that happens, `npx @nitpicker/cli crawl <URL>` currently proceeds into the crawl loop, fails per-URL with a generic Puppeteer stack trace, and still reports "Crawl completed with N error(s)" — easy to miss as the root cause of a fatal, environment-level precondition failure.

## Test plan

- [x] `yarn build` (with `NX_WORKSPACE_ROOT_PATH` set for this worktree)
- [x] `yarn test` — full suite green
- [x] `yarn lint:eslint:check` / `yarn lint:prettier:check` / `yarn lint:textlint:check` / `yarn lint:cspell` — clean
- [x] `/code-review medium`, `/qa-engineer`, `/product-manager` — findings addressed (pipeline.ts bypass fixed; --resume coverage test added; docs cross-reference added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
