### PR TITLE
fix(cli,viewer): unify nitpicker command hints to npx @nitpicker/cli

### DIFF
--- a/packages/@nitpicker/cli/src/commands/analyze.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/analyze.spec.ts
@@ -118,7 +118,7 @@ describe('analyze command', () => {
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: No .nitpicker file specified.');
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Usage: nitpicker analyze <file> [options]',
+			'Usage: npx @nitpicker/cli analyze <file> [options]',
 		);
 		expect(exitSpy).toHaveBeenCalledWith(1);
 	});

--- a/packages/@nitpicker/cli/src/commands/analyze.ts
+++ b/packages/@nitpicker/cli/src/commands/analyze.ts
@@ -91,7 +91,7 @@ export async function analyze(args: string[], flags: AnalyzeFlags) {
 		// eslint-disable-next-line no-console
 		console.error('Error: No .nitpicker file specified.');
 		// eslint-disable-next-line no-console
-		console.error('Usage: nitpicker analyze <file> [options]');
+		console.error('Usage: npx @nitpicker/cli analyze <file> [options]');
 		process.exit(1);
 	}
 

--- a/packages/@nitpicker/cli/src/commands/cache.ts
+++ b/packages/@nitpicker/cli/src/commands/cache.ts
@@ -70,7 +70,7 @@ export async function cache(args: string[], flags: CacheFlags): Promise<void> {
 		);
 		// eslint-disable-next-line no-console
 		console.error(
-			`Usage: nitpicker cache <${VALID_SUB_COMMANDS.join('|')}> [archive] [--json]`,
+			`Usage: npx @nitpicker/cli cache <${VALID_SUB_COMMANDS.join('|')}> [archive] [--json]`,
 		);
 		process.exit(ExitCode.Fatal);
 	}
@@ -162,7 +162,7 @@ async function runClear(
 				? `Removed cache entry for ${absArchivePath}: ${cacheDir}`
 				: `No cache entry matches the current content of ${absArchivePath} (nothing to clear here). ` +
 						`Note: stale entries from a previous version of this file are not found by ` +
-						`content-addressed lookup — use 'nitpicker cache list' + 'nitpicker cache clear' ` +
+						`content-addressed lookup — use 'npx @nitpicker/cli cache list' + 'npx @nitpicker/cli cache clear' ` +
 						`(no argument) to remove them.`,
 		);
 	} catch (error) {

--- a/packages/@nitpicker/cli/src/commands/pipeline.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/pipeline.spec.ts
@@ -96,7 +96,7 @@ describe('pipeline command', () => {
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: No URL specified.');
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Usage: nitpicker pipeline <URL> [options]',
+			'Usage: npx @nitpicker/cli pipeline <URL> [options]',
 		);
 		expect(exitSpy).toHaveBeenCalledWith(ExitCode.Fatal);
 	});

--- a/packages/@nitpicker/cli/src/commands/pipeline.ts
+++ b/packages/@nitpicker/cli/src/commands/pipeline.ts
@@ -209,7 +209,7 @@ export async function pipeline(args: string[], flags: PipelineFlags) {
 		// eslint-disable-next-line no-console
 		console.error('Error: No URL specified.');
 		// eslint-disable-next-line no-console
-		console.error('Usage: nitpicker pipeline <URL> [options]');
+		console.error('Usage: npx @nitpicker/cli pipeline <URL> [options]');
 		process.exit(ExitCode.Fatal);
 	}
 

--- a/packages/@nitpicker/cli/src/commands/query.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/query.spec.ts
@@ -63,7 +63,7 @@ describe('query command', () => {
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: No .nitpicker file specified.');
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Usage: nitpicker query <file> <sub-command> [options]',
+			'Usage: npx @nitpicker/cli query <file> <sub-command> [options]',
 		);
 		expect(exitSpy).toHaveBeenCalledWith(1);
 	});

--- a/packages/@nitpicker/cli/src/commands/query.ts
+++ b/packages/@nitpicker/cli/src/commands/query.ts
@@ -185,7 +185,7 @@ export async function query(args: string[], flags: QueryFlags) {
 		// eslint-disable-next-line no-console
 		console.error('Error: No .nitpicker file specified.');
 		// eslint-disable-next-line no-console
-		console.error('Usage: nitpicker query <file> <sub-command> [options]');
+		console.error('Usage: npx @nitpicker/cli query <file> <sub-command> [options]');
 		process.exit(1);
 	}
 

--- a/packages/@nitpicker/cli/src/commands/report.spec.ts
+++ b/packages/@nitpicker/cli/src/commands/report.spec.ts
@@ -183,7 +183,7 @@ describe('report command', () => {
 
 		expect(consoleErrorSpy).toHaveBeenCalledWith('Error: No .nitpicker file specified.');
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			'Usage: nitpicker report <file> [options]',
+			'Usage: npx @nitpicker/cli report <file> [options]',
 		);
 		expect(exitSpy).toHaveBeenCalledWith(1);
 		expect(runReport).not.toHaveBeenCalled();

--- a/packages/@nitpicker/cli/src/commands/report.ts
+++ b/packages/@nitpicker/cli/src/commands/report.ts
@@ -84,7 +84,7 @@ export async function report(args: string[], flags: ReportFlags) {
 		// eslint-disable-next-line no-console
 		console.error('Error: No .nitpicker file specified.');
 		// eslint-disable-next-line no-console
-		console.error('Usage: nitpicker report <file> [options]');
+		console.error('Usage: npx @nitpicker/cli report <file> [options]');
 		process.exit(1);
 	}
 

--- a/packages/@nitpicker/cli/src/commands/viewer-build.ts
+++ b/packages/@nitpicker/cli/src/commands/viewer-build.ts
@@ -95,7 +95,7 @@ export async function viewerBuild(
 		// eslint-disable-next-line no-console
 		console.error('Error: No .nitpicker file specified.');
 		// eslint-disable-next-line no-console
-		console.error('Usage: nitpicker viewer-build <archive> [--force]');
+		console.error('Usage: npx @nitpicker/cli viewer-build <archive> [--force]');
 		process.exit(ExitCode.Fatal);
 	}
 

--- a/packages/@nitpicker/cli/src/commands/viewer.ts
+++ b/packages/@nitpicker/cli/src/commands/viewer.ts
@@ -54,7 +54,7 @@ export async function viewer(args: string[], flags: ViewerFlags) {
 			'Error: No source specified. Pass a .nitpicker file or a crawl stub directory.',
 		);
 		// eslint-disable-next-line no-console
-		console.error('Usage: nitpicker viewer <file-or-stub-dir> [options]');
+		console.error('Usage: npx @nitpicker/cli viewer <file-or-stub-dir> [options]');
 		process.exit(ExitCode.Fatal);
 	}
 

--- a/packages/@nitpicker/viewer/e2e/template-clusters-classified.spec.ts
+++ b/packages/@nitpicker/viewer/e2e/template-clusters-classified.spec.ts
@@ -120,7 +120,7 @@ test.describe('Nitpicker Viewer template clusters (classified fixture)', () => {
 			'No cluster-selection evidence was captured for this cluster.',
 		);
 		await expect(sectionsCluster).toContainText(
-			'nitpicker analyze <archive> --templates',
+			'npx @nitpicker/cli analyze <archive> --templates',
 		);
 	});
 });

--- a/packages/@nitpicker/viewer/e2e/template-clusters.spec.ts
+++ b/packages/@nitpicker/viewer/e2e/template-clusters.spec.ts
@@ -17,7 +17,7 @@ test.describe('Nitpicker Viewer template clusters (unclassified fixture)', () =>
 			page.getByRole('heading', { name: 'Template Clusters', level: 1 }),
 		).toBeVisible();
 		await expect(page.locator('.state code')).toHaveText(
-			'nitpicker analyze <archive> --templates',
+			'npx @nitpicker/cli analyze <archive> --templates',
 		);
 		await expect(page.locator('details')).toHaveCount(0);
 	});

--- a/packages/@nitpicker/viewer/e2e/viewer-stub.spec.ts
+++ b/packages/@nitpicker/viewer/e2e/viewer-stub.spec.ts
@@ -78,7 +78,7 @@ test.describe('Nitpicker Viewer (stub mode)', () => {
 		).toBeVisible();
 		await expect(
 			page.getByText(
-				'No directory data available. Run `nitpicker viewer-build` to generate it.',
+				'No directory data available. Run `npx @nitpicker/cli viewer-build` to generate it.',
 			),
 		).toBeVisible();
 	});

--- a/packages/@nitpicker/viewer/src/routes/register-duplicates-route.ts
+++ b/packages/@nitpicker/viewer/src/routes/register-duplicates-route.ts
@@ -96,7 +96,7 @@ export function registerDuplicatesRoute(app: Hono, context: ArchiveContext): voi
 			return c.json(
 				{
 					error:
-						'Duplicate-group member pages require the viewer read model, which is not built or is stale for this archive. Rebuild it with `nitpicker viewer-build`.',
+						'Duplicate-group member pages require the viewer read model, which is not built or is stale for this archive. Rebuild it with `npx @nitpicker/cli viewer-build`.',
 				},
 				404,
 			);

--- a/packages/@nitpicker/viewer/src/start-viewer.ts
+++ b/packages/@nitpicker/viewer/src/start-viewer.ts
@@ -60,7 +60,7 @@ export async function startViewer(options: ViewerOptions): Promise<void> {
 				"\n  ⚠ This archive's viewer read model is missing or stale.\n" +
 					'    Pages/resources/links/images and similar list views will\n' +
 					'    respond with "read model required" until you rebuild it:\n\n' +
-					`      nitpicker viewer-build ${filePath}\n`,
+					`      npx @nitpicker/cli viewer-build ${filePath}\n`,
 			);
 		}
 	}

--- a/packages/@nitpicker/viewer/web/api/api-client.ts
+++ b/packages/@nitpicker/viewer/web/api/api-client.ts
@@ -60,8 +60,8 @@ export async function apiGet<T>(
 	) {
 		throw new Error(
 			"This view requires the archive's viewer read model, which is missing or stale. " +
-				'Run `nitpicker viewer-build <archive>` once, then restart the viewer. ' +
-				'このビューにはviewer read modelが必要です。`nitpicker viewer-build <archive>` を実行してからviewerを再起動してください。',
+				'Run `npx @nitpicker/cli viewer-build <archive>` once, then restart the viewer. ' +
+				'このビューにはviewer read modelが必要です。`npx @nitpicker/cli viewer-build <archive>` を実行してからviewerを再起動してください。',
 		);
 	}
 	return payload;

--- a/packages/@nitpicker/viewer/web/i18n/translations.ts
+++ b/packages/@nitpicker/viewer/web/i18n/translations.ts
@@ -17,7 +17,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				'A crawler process is currently writing this directory. The view is a snapshot taken when the viewer started; the underlying data is still moving.',
 			interruptedCrawlBadge: 'Interrupted crawl stub',
 			interruptedCrawlBadgeTitle:
-				'This is a stub directory left behind by a stopped crawl. Read-only — you can resume the crawl with `nitpicker crawl --resume`.',
+				'This is a stub directory left behind by a stopped crawl. Read-only — you can resume the crawl with `npx @nitpicker/cli crawl --resume`.',
 		},
 		nav: {
 			summary: 'Summary',
@@ -183,7 +183,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				expandNode: 'Expand {name}',
 				collapseNode: 'Collapse {name}',
 				noRoots:
-					'No directory data available. Run `nitpicker viewer-build` to generate it.',
+					'No directory data available. Run `npx @nitpicker/cli viewer-build` to generate it.',
 				collapseDepthInputLabel: 'Depth',
 				collapseToDepth: 'Collapse to depth',
 				sortOrderLabel: 'Sort order',
@@ -387,7 +387,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 					'Every DOM-structure template cluster found by `--templates`, with the top directories by page count and common stylesheet set computed from its member pages — the raw template key is an opaque blocking key and is not human-readable on its own.',
 				notClassified:
 					'This archive has no DOM-structure template classification yet. Run the following, then re-open the viewer:',
-				notClassifiedCommandHint: 'nitpicker analyze <archive> --templates',
+				notClassifiedCommandHint: 'npx @nitpicker/cli analyze <archive> --templates',
 				noClusters: 'No template clusters found.',
 				pageCount: '{count} pages',
 				commonDirectories: 'Top directories',
@@ -415,7 +415,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				siblingsCaveat:
 					'Clusters that split off from the same blocking group as this one.',
 				noReason: 'No cluster-selection evidence was captured for this cluster.',
-				noReasonCommandHint: 'nitpicker analyze <archive> --templates',
+				noReasonCommandHint: 'npx @nitpicker/cli analyze <archive> --templates',
 			},
 			consoleLogs: {
 				title: 'Console Logs',
@@ -456,7 +456,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				'クロールプロセスがこのディレクトリに書き込み中です。表示は viewer 起動時点のスナップショットで、実データは更新され続けています。',
 			interruptedCrawlBadge: '中断クロールのスタブ',
 			interruptedCrawlBadgeTitle:
-				'停止されたクロールのスタブディレクトリです。読み取り専用 — `nitpicker crawl --resume` で再開できます。',
+				'停止されたクロールのスタブディレクトリです。読み取り専用 — `npx @nitpicker/cli crawl --resume` で再開できます。',
 		},
 		nav: {
 			summary: 'サマリー',
@@ -622,7 +622,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				expandNode: '{name} を展開',
 				collapseNode: '{name} を折りたたむ',
 				noRoots:
-					'ディレクトリデータがありません。`nitpicker viewer-build` を実行して生成してください。',
+					'ディレクトリデータがありません。`npx @nitpicker/cli viewer-build` を実行して生成してください。',
 				collapseDepthInputLabel: '階層数',
 				collapseToDepth: '階層まで全て閉じる',
 				sortOrderLabel: '並び順',
@@ -826,7 +826,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 					'`--templates` で検出したDOM構造テンプレートクラスタの一覧。各クラスタの所属ページ数が多いディレクトリ上位と共通CSSファイルを算出して表示します — 生のテンプレートキーはブロッキング用の内部識別子で、それ自体は人間には読めません。',
 				notClassified:
 					'このアーカイブはまだテンプレート分類を実行していません。以下を実行してからビューアを再度開いてください:',
-				notClassifiedCommandHint: 'nitpicker analyze <archive> --templates',
+				notClassifiedCommandHint: 'npx @nitpicker/cli analyze <archive> --templates',
 				noClusters: 'テンプレートクラスタが見つかりません。',
 				pageCount: '{count} ページ',
 				commonDirectories: '主要ディレクトリ',
@@ -853,7 +853,7 @@ export const translations: Record<Locale, Record<string, unknown>> = {
 				siblings: '兄弟クラスタ',
 				siblingsCaveat: '同じブロッキンググループから分岐したクラスタ。',
 				noReason: 'このクラスタのクラスタ選定理由は保存されていません。',
-				noReasonCommandHint: 'nitpicker analyze <archive> --templates',
+				noReasonCommandHint: 'npx @nitpicker/cli analyze <archive> --templates',
 			},
 			consoleLogs: {
 				title: 'コンソールログ',


### PR DESCRIPTION
## Summary

- Unify the `nitpicker` command shown in CLI/viewer error and warning messages to `npx @nitpicker/cli`, since the bare binary name is not how the CLI is actually invoked
- Covers CLI `Usage:` errors (analyze/report/pipeline/query/viewer/viewer-build/cache), the cache-clear content-addressed lookup hint, viewer runtime warnings/errors (stale read-model banner, duplicate-group 404, read-model-required error), and viewer UI translation strings (EN/JA: crawl `--resume`, `viewer-build`, `analyze --templates` hints)
- Updated the specs/e2e tests asserting these exact strings to match

## Test plan

- [x] `yarn lint` — 0 errors (pre-existing unrelated warnings only)
- [x] `yarn build` (with `NX_WORKSPACE_ROOT_PATH` for the worktree)
- [x] `yarn test` — 601 test files passed
