### PR TITLE
chore: streamline npm-publish and pr skills

### DIFF
--- a/.claude/skills/npm-publish/SKILL.md
+++ b/.claude/skills/npm-publish/SKILL.md
@@ -104,33 +104,42 @@ gh run list --branch main --limit 5
 
 ## 7. リリース内容の提示
 
-現在のバージョンと前回タグからの差分をユーザーに提示し、リリース種別（graduate / alpha / beta / rc）の判断材料にする。
+現在のバージョンと前回タグからの差分をユーザーに提示する。
 
 ```bash
 git describe --tags --abbrev=0
 git log --oneline $(git describe --tags --abbrev=0)..HEAD
 ```
 
-fixed モードなので `lerna.json` の `version` が現行バージョンの正。
+fixed モードなので `lerna.json` の `version` が現行バージョンの正。`yarn release` は conventional commits からバージョンを自動決定するため、**リリース種別（graduate / alpha / beta / rc）をユーザーに確認する必要はない**。差分は「何が入るか」の確認材料として提示するだけでよい。
 
 ## 8. バージョニングと push（ユーザー実行）
 
-`lerna version` はインタラクティブなため Claude からは実行できない。リリース種別を確認したうえで、`!` プレフィックス付きでユーザーに実行を依頼し、**完了報告を待つ**。
+`lerna version` は選択・確認のプロンプトを出すインタラクティブコマンドで、Claude Code の `!` 経由では対話できない（プロンプトが表示されても入力できず止まる）。ユーザーに次の手順を依頼する:
+
+1. Claude Code のセッションを終了する（`exit`）
+2. ターミナルで直接 `yarn release` を実行し、プロンプトに対話的に回答する
+3. 完了したら `claude --continue` で会話に戻る
 
 ```
-! yarn release          # graduate（正式リリース）
-! yarn release:alpha    # alpha プレリリース
-! yarn release:beta     # beta プレリリース
-! yarn release:rc       # RC プレリリース
+yarn release          # graduate（正式リリース。通常はこれだけで十分）
 ```
 
-リリーススクリプトは `--no-push` なので、**コミットとタグの push が別途必要**。
+alpha / beta / rc のプレリリースが必要な場合は、ユーザーが会話の中で明示的に指示したときだけ、上記と同じ exit → 実行 → `--continue` の手順で該当コマンドを案内する。
+
+```
+yarn release:alpha    # alpha プレリリース
+yarn release:beta     # beta プレリリース
+yarn release:rc       # RC プレリリース
+```
+
+リリーススクリプトは `--no-push` なので、**コミットとタグの push が別途必要**。ユーザーから完了報告を受けたら、次を提示する。
 
 ```
 ! git push origin main --follow-tags
 ```
 
-ユーザーから完了報告を受けたら、実際にタグが push されたことを確認してから次へ進む。
+実際にタグが push されたことを確認してから次へ進む。
 
 ```bash
 git ls-remote --tags origin

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -24,4 +24,5 @@ description: プルリクエストの作成とプッシュ
 8. **CI 監視:**
    - `gh pr checks --watch` を**バックグラウンド実行**（`run_in_background`）で起動して CI の完了を待機する（フォアグラウンド実行はターン内タイムアウトで出力が欠損する）。
    - テストが途中で失敗した場合は完了を待たずに修正作業に戻る。
-   - 全テストが通りマージ可能になったらユーザーに報告する。
+   - 全テストが通ったら、`gh pr view <number> --json mergeable,mergeStateStatus` で再度 `CONFLICTING` / `DIRTY` になっていないか確認する（CI 実行中に base が進んで新たにコンフリクトが発生している可能性があるため）。
+   - `CONFLICTING` ならステップ 7 の対処に戻る。問題なければ `gh pr view <number> --web` でブラウザを開き、マージ可能であることをユーザーに報告してマージを促す。


### PR DESCRIPTION
## 概要

`npm-publish` スキルと `pr` スキルに2つの改善を加える。

## npm-publish: リリース種別の確認を削除

`yarn release` は conventional commits からバージョンを自動決定するため、Claude が「graduate / alpha / beta / rc のどれにしますか」と確認する手順は無駄な質問になっていた。デフォルトで `yarn release` を案内するだけに変更し、プレリリースが必要な場合はユーザーが明示的に指示したときだけ案内する。

併せて、`lerna version` は選択・確認のプロンプトを出すインタラクティブコマンドで Claude Code の `!` 経由では対話できないため、「Claude Code を `exit` → ターミナルで直接実行 → `claude --continue` で戻る」という手順に改めた。

## pr: CI green 後の web オープン

CI が green になり、かつ `CONFLICTING` / `DIRTY` でないことを確認したら、`gh pr view --web` でブラウザを自動的に開き、マージを促すようにした。

## 確認事項

- ドキュメント（SKILL.md）のみの変更、動作影響なし
